### PR TITLE
fix warnings about automatic conversion from size_t to uint32_t

### DIFF
--- a/include/vsg/io/BinaryOutput.h
+++ b/include/vsg/io/BinaryOutput.h
@@ -48,7 +48,7 @@ namespace vsg
 
         void _write(const std::string& str)
         {
-            uint32_t size = str.size();
+            uint32_t size = static_cast<uint32_t>(str.size());
             _output.write(reinterpret_cast<const char*>(&size), sizeof(uint32_t));
             _output.write(str.c_str(), size);
         }

--- a/include/vsg/vk/Descriptor.h
+++ b/include/vsg/vk/Descriptor.h
@@ -109,7 +109,7 @@ namespace vsg
         virtual void assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const
         {
             Descriptor::assignTo(wds, descriptorSet);
-            wds.descriptorCount = _imageInfos.size();
+            wds.descriptorCount = static_cast<uint32_t>(_imageInfos.size());
             wds.pImageInfo = _imageInfos.data();
         }
 
@@ -140,7 +140,7 @@ namespace vsg
         virtual void assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const
         {
             Descriptor::assignTo(wds, descriptorSet);
-            wds.descriptorCount = _bufferInfos.size();
+            wds.descriptorCount = static_cast<uint32_t>(_bufferInfos.size());
             wds.pBufferInfo = _bufferInfos.data();
         }
 
@@ -170,7 +170,7 @@ namespace vsg
             std::vector<VkBufferView> texelBufferViews(_texelBufferViewList.size());
 
             Descriptor::assignTo(wds, descriptorSet);
-            wds.descriptorCount = _texelBufferViews.size();
+            wds.descriptorCount = static_cast<uint32_t>(_texelBufferViews.size());
             wds.pTexelBufferView = _texelBufferViews.data();
         }
 

--- a/src/vsg/viewer/GraphicsStage.cpp
+++ b/src/vsg/viewer/GraphicsStage.cpp
@@ -44,7 +44,7 @@ void GraphicsStage::populateCommandBuffer(CommandBuffer* commandBuffer, Framebuf
     clearValues[0].color = clearColor;
     clearValues[1].depthStencil = {1.0f, 0};
 
-    renderPassInfo.clearValueCount = clearValues.size();
+    renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
     renderPassInfo.pClearValues = clearValues.data();
     vkCmdBeginRenderPass(*commandBuffer, &renderPassInfo, VK_SUBPASS_CONTENTS_INLINE);
 

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -214,14 +214,14 @@ void Viewer::submitFrame()
         VkSubmitInfo submitInfo = {};
         submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
-        submitInfo.waitSemaphoreCount = pdo.waitSemaphores.size();
+        submitInfo.waitSemaphoreCount = static_cast<uint32_t>(pdo.waitSemaphores.size());
         submitInfo.pWaitSemaphores = pdo.waitSemaphores.data();
         submitInfo.pWaitDstStageMask = pdo.waitStages.data();
 
-        submitInfo.commandBufferCount = pdo.commandBuffers.size();
+        submitInfo.commandBufferCount = static_cast<uint32_t>(pdo.commandBuffers.size());
         submitInfo.pCommandBuffers = pdo.commandBuffers.data();
 
-        submitInfo.signalSemaphoreCount = pdo.signalSemaphores.size();
+        submitInfo.signalSemaphoreCount = static_cast<uint32_t>(pdo.signalSemaphores.size());
         submitInfo.pSignalSemaphores = pdo.signalSemaphores.data();
 
         if (vkQueueSubmit(pdo.graphicsQueue, 1, &submitInfo, VK_NULL_HANDLE) != VK_SUCCESS)
@@ -237,9 +237,9 @@ void Viewer::submitFrame()
 
         VkPresentInfoKHR presentInfo = {};
         presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-        presentInfo.waitSemaphoreCount = pdo.signalSemaphores.size();
+        presentInfo.waitSemaphoreCount = static_cast<uint32_t>(pdo.signalSemaphores.size());
         presentInfo.pWaitSemaphores = pdo.signalSemaphores.data();
-        presentInfo.swapchainCount = pdo.swapchains.size();
+        presentInfo.swapchainCount = static_cast<uint32_t>(pdo.swapchains.size());
         presentInfo.pSwapchains = pdo.swapchains.data();
         presentInfo.pImageIndices = pdo.imageIndices.data();
 

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -120,7 +120,7 @@ namespace vsg
             VkFramebufferCreateInfo framebufferInfo = {};
             framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
             framebufferInfo.renderPass = *_renderPass;
-            framebufferInfo.attachmentCount = attachments.size();
+            framebufferInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
             framebufferInfo.pAttachments = attachments.data();
             framebufferInfo.width = _extent2D.width;
             framebufferInfo.height = _extent2D.height;

--- a/src/vsg/vk/BindVertexBuffers.cpp
+++ b/src/vsg/vk/BindVertexBuffers.cpp
@@ -29,5 +29,5 @@ void BindVertexBuffers::popFrom(State& state) const
 
 void BindVertexBuffers::dispatch(CommandBuffer& commandBuffer) const
 {
-    vkCmdBindVertexBuffers(commandBuffer, _firstBinding, _buffers.size(), _vkBuffers.data(), _offsets.data());
+    vkCmdBindVertexBuffers(commandBuffer, _firstBinding, static_cast<uint32_t>(_buffers.size()), _vkBuffers.data(), _offsets.data());
 }

--- a/src/vsg/vk/Descriptor.cpp
+++ b/src/vsg/vk/Descriptor.cpp
@@ -43,9 +43,9 @@ ImageData vsg::transferImageData(Device* device, CommandPool* commandPool, VkQue
     VkImageCreateInfo imageCreateInfo = {};
     imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     imageCreateInfo.imageType = data->depth() > 1 ? VK_IMAGE_TYPE_3D : (data->width() > 1 ? VK_IMAGE_TYPE_2D : VK_IMAGE_TYPE_1D);
-    imageCreateInfo.extent.width = data->width();
-    imageCreateInfo.extent.height = data->height();
-    imageCreateInfo.extent.depth = data->depth();
+    imageCreateInfo.extent.width = static_cast<uint32_t>(data->width());
+    imageCreateInfo.extent.height = static_cast<uint32_t>(data->height());
+    imageCreateInfo.extent.depth = static_cast<uint32_t>(data->depth());
     imageCreateInfo.mipLevels = 1;
     imageCreateInfo.arrayLayers = 1;
     imageCreateInfo.format = data->getFormat();

--- a/src/vsg/vk/DescriptorPool.cpp
+++ b/src/vsg/vk/DescriptorPool.cpp
@@ -43,7 +43,7 @@ DescriptorPool::Result DescriptorPool::create(Device* device, uint32_t maxSets, 
 
     VkDescriptorPoolCreateInfo poolInfo = {};
     poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    poolInfo.poolSizeCount = descriptorPoolSizes.size();
+    poolInfo.poolSizeCount = static_cast<uint32_t>(descriptorPoolSizes.size());
     poolInfo.pPoolSizes = descriptorPoolSizes.data();
     poolInfo.maxSets = maxSets;
     poolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT; // will we need VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT_EXT later?

--- a/src/vsg/vk/DescriptorSet.cpp
+++ b/src/vsg/vk/DescriptorSet.cpp
@@ -70,7 +70,7 @@ void DescriptorSet::assign(const Descriptors& descriptors)
         _descriptors[i]->assignTo(descriptorWrites[i], _descriptorSet);
     }
 
-    vkUpdateDescriptorSets(*_device, descriptorWrites.size(), descriptorWrites.data(), 0, nullptr);
+    vkUpdateDescriptorSets(*_device, static_cast<uint32_t>(descriptorWrites.size()), descriptorWrites.data(), 0, nullptr);
 }
 
 void BindDescriptorSets::pushTo(State& state) const
@@ -87,5 +87,5 @@ void BindDescriptorSets::popFrom(State& state) const
 
 void BindDescriptorSets::dispatch(CommandBuffer& commandBuffer) const
 {
-    vkCmdBindDescriptorSets(commandBuffer, _bindPoint, *_pipelineLayout, 0, _vkDescriptorSets.size(), _vkDescriptorSets.data(), 0, nullptr);
+    vkCmdBindDescriptorSets(commandBuffer, _bindPoint, *_pipelineLayout, 0, static_cast<uint32_t>(_vkDescriptorSets.size()), _vkDescriptorSets.data(), 0, nullptr);
 }

--- a/src/vsg/vk/DescriptorSetLayout.cpp
+++ b/src/vsg/vk/DescriptorSetLayout.cpp
@@ -38,7 +38,7 @@ DescriptorSetLayout::Result DescriptorSetLayout::create(Device* device, const De
 
     VkDescriptorSetLayoutCreateInfo layoutInfo = {};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    layoutInfo.bindingCount = descriptorSetLayoutBindings.size();
+    layoutInfo.bindingCount = static_cast<uint32_t>(descriptorSetLayoutBindings.size());
     layoutInfo.pBindings = descriptorSetLayoutBindings.data();
 
     VkDescriptorSetLayout descriptorSetLayout;

--- a/src/vsg/vk/Device.cpp
+++ b/src/vsg/vk/Device.cpp
@@ -62,15 +62,15 @@ Device::Result Device::create(PhysicalDevice* physicalDevice, Names& layers, Nam
     VkDeviceCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 
-    createInfo.queueCreateInfoCount = queueCreateInfos.size();
+    createInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
     createInfo.pQueueCreateInfos = queueCreateInfos.empty() ? nullptr : queueCreateInfos.data();
 
     createInfo.pEnabledFeatures = &deviceFeatures;
 
-    createInfo.enabledExtensionCount = deviceExtensions.size();
+    createInfo.enabledExtensionCount = static_cast<uint32_t>(deviceExtensions.size());
     createInfo.ppEnabledExtensionNames = deviceExtensions.empty() ? nullptr : deviceExtensions.data();
 
-    createInfo.enabledLayerCount = layers.size();
+    createInfo.enabledLayerCount = static_cast<uint32_t>(layers.size());
     createInfo.ppEnabledLayerNames = layers.empty() ? nullptr : layers.data();
 
     VkDevice device;

--- a/src/vsg/vk/GraphicsPipeline.cpp
+++ b/src/vsg/vk/GraphicsPipeline.cpp
@@ -71,7 +71,7 @@ ShaderStages::~ShaderStages()
 
 void ShaderStages::apply(VkGraphicsPipelineCreateInfo& pipelineInfo) const
 {
-    pipelineInfo.stageCount = size();
+    pipelineInfo.stageCount = static_cast<uint32_t>(size());
     pipelineInfo.pStages = data();
 }
 
@@ -107,9 +107,9 @@ VertexInputState::VertexInputState(const Bindings& bindings, const Attributes& a
     _attributes(attributes)
 {
     sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-    vertexBindingDescriptionCount = _bindings.size();
+    vertexBindingDescriptionCount = static_cast<uint32_t>(_bindings.size());
     pVertexBindingDescriptions = _bindings.data();
-    vertexAttributeDescriptionCount = _attributes.size();
+    vertexAttributeDescriptionCount = static_cast<uint32_t>(_attributes.size());
     pVertexAttributeDescriptions = _attributes.data();
 }
 
@@ -267,7 +267,7 @@ ColorBlendState::ColorBlendState() :
 
     logicOpEnable = VK_FALSE;
     logicOp = VK_LOGIC_OP_COPY;
-    attachmentCount = _colorBlendAttachments.size();
+    attachmentCount = static_cast<uint32_t>(_colorBlendAttachments.size());
     pAttachments = _colorBlendAttachments.data();
     blendConstants[0] = 0.0f;
     blendConstants[1] = 0.0f;
@@ -286,6 +286,6 @@ void ColorBlendState::apply(VkGraphicsPipelineCreateInfo& pipelineInfo) const
 
 void ColorBlendState::update()
 {
-    attachmentCount = _colorBlendAttachments.size();
+    attachmentCount = static_cast<uint32_t>(_colorBlendAttachments.size());
     pAttachments = _colorBlendAttachments.data();
 }

--- a/src/vsg/vk/Instance.cpp
+++ b/src/vsg/vk/Instance.cpp
@@ -101,10 +101,10 @@ Instance::Result Instance::create(Names& instanceExtensions, Names& layers, Allo
     createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     createInfo.pApplicationInfo = &appInfo;
 
-    createInfo.enabledExtensionCount = instanceExtensions.size();
+    createInfo.enabledExtensionCount = static_cast<uint32_t>(instanceExtensions.size());
     createInfo.ppEnabledExtensionNames = instanceExtensions.empty() ? nullptr : instanceExtensions.data();
 
-    createInfo.enabledLayerCount = layers.size();
+    createInfo.enabledLayerCount = static_cast<uint32_t>(layers.size());
     createInfo.ppEnabledLayerNames = layers.empty() ? nullptr : layers.data();
 
     VkInstance instance;

--- a/src/vsg/vk/PipelineLayout.cpp
+++ b/src/vsg/vk/PipelineLayout.cpp
@@ -43,9 +43,9 @@ PipelineLayout::Result PipelineLayout::create(Device* device, const DescriptorSe
     VkPipelineLayoutCreateInfo pipelineLayoutInfo;
     pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
     pipelineLayoutInfo.flags = flags;
-    pipelineLayoutInfo.setLayoutCount = layouts.size();
+    pipelineLayoutInfo.setLayoutCount = static_cast<uint32_t>(layouts.size());
     pipelineLayoutInfo.pSetLayouts = layouts.data();
-    pipelineLayoutInfo.pushConstantRangeCount = pushConstantRanges.size();
+    pipelineLayoutInfo.pushConstantRangeCount = static_cast<uint32_t>(pushConstantRanges.size());
     pipelineLayoutInfo.pPushConstantRanges = pushConstantRanges.data();
 
     VkPipelineLayout pipelineLayout;

--- a/src/vsg/vk/PushConstants.cpp
+++ b/src/vsg/vk/PushConstants.cpp
@@ -42,6 +42,6 @@ void PushConstants::dispatch(CommandBuffer& commandBuffer) const
     if (pipelineLayout)
     {
 
-        vkCmdPushConstants(commandBuffer, *pipelineLayout, _stageFlags, _offset, _data->dataSize(), _data->dataPointer());
+        vkCmdPushConstants(commandBuffer, *pipelineLayout, _stageFlags, _offset, static_cast<uint32_t>(_data->dataSize()), _data->dataPointer());
     }
 }

--- a/src/vsg/vk/RenderPass.cpp
+++ b/src/vsg/vk/RenderPass.cpp
@@ -84,7 +84,7 @@ RenderPass::Result RenderPass::create(Device* device, VkFormat imageFormat, VkFo
 
     VkRenderPassCreateInfo renderPassInfo = {};
     renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-    renderPassInfo.attachmentCount = attachments.size();
+    renderPassInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
     renderPassInfo.pAttachments = attachments.data();
     renderPassInfo.subpassCount = 1;
     renderPassInfo.pSubpasses = &subpass;


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Compiler warning:
warning C4267: '=': conversion from 'size_t' to 'uint32_t', possible loss of data
added c-style casts to unint32_t - mostly for the results of vector.size() that are of type std::size_t 
Most seem to be required to be uint32_t for the vulcan api, except those in
src/vsg/vk/Descriptor.cpp (width,height,depth) that describe image dimensions. Those could be defined as size_t themselves, but I guessed leaving the 32bit limit on a single dimension is still reasonable.

Trying to get things running I found a few problems on win32, and to avoid duplicate work I would like to submit my fixes for merging. As I don't have an executable build yet, nothing is tested.

Regards, Laurens.
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Not tested

**Test Configuration**:
* OS: Win 10 1803 x64
* Hardware: i7 6700K / 32BG / GeForce 1080 417.22
* Toolchain: Visual Studio Community 2017
* SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
