### PR TITLE
Small typo in texture write function

### DIFF
--- a/src/vsg/io/AsciiInput.cpp
+++ b/src/vsg/io/AsciiInput.cpp
@@ -45,7 +45,7 @@ bool AsciiInput::matchPropertyName(const char* propertyName)
     _input >> _readPropertyName;
     if (_readPropertyName != propertyName)
     {
-        std::cout << "Error: unable to match " << propertyName << std::endl;
+        std::cout << "Error: unable to match " << propertyName << " got " << _readPropertyName << " instead." << std::endl;
         return false;
     }
     return true;

--- a/src/vsg/vk/Descriptor.cpp
+++ b/src/vsg/vk/Descriptor.cpp
@@ -426,7 +426,7 @@ void Texture::write(Output& output) const
     output.write("maxAnisotropy", _samplerInfo.maxAnisotropy);
     output.writeValue<uint32_t>("compareEnable", _samplerInfo.compareEnable);
     output.writeValue<uint32_t>("compareOp", _samplerInfo.compareOp);
-    output.write("minlod", _samplerInfo.minLod);
+    output.write("minLod", _samplerInfo.minLod);
     output.write("maxLod", _samplerInfo.maxLod);
     output.writeValue<uint32_t>("borderColor", _samplerInfo.borderColor);
     output.writeValue<uint32_t>("unnormalizedCoordinates", _samplerInfo.unnormalizedCoordinates);


### PR DESCRIPTION
# Pull Request Template

## Description

The texture write function had a lower case 'l' in minLod. Also added a bit more debug output when the property doesn't match what it's looking for.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


- [x] Write then read a vsg file with a texture now working
- [ ] Test B