### PR TITLE
Implement a vsg::Buffer bool and available space mechanism to enable …

### DIFF
--- a/include/vsg/traversals/CompileTraversal.h
+++ b/include/vsg/traversals/CompileTraversal.h
@@ -37,15 +37,20 @@ namespace vsg
         ref_ptr<mat4Value> projMatrix;
         ref_ptr<mat4Value> viewMatrix;
 #if 1
+        VkDeviceSize minimumBufferSize = 16 * 1024 * 1024;
         VkDeviceSize minimumBufferDeviceMemorySize = 16 * 1024 * 1024;
         VkDeviceSize minimumImageDeviceMemorySize = 16 * 1024 * 1024;
 #else
+        VkDeviceSize minimumBufferSize = 1; //1024 * 1024;
         VkDeviceSize minimumBufferDeviceMemorySize = 1; //1024 * 1024;
         VkDeviceSize minimumImageDeviceMemorySize = 1;  //1024 * 1024;
 #endif
 
         using MemoryPools = std::vector<ref_ptr<DeviceMemory>>;
         MemoryPools memoryPools;
+
+        using BufferPools = std::vector<ref_ptr<Buffer>>;
+        BufferPools bufferPools;
     };
 
     class VSG_DECLSPEC CompileTraversal : public Visitor

--- a/include/vsg/vk/Buffer.h
+++ b/include/vsg/vk/Buffer.h
@@ -19,7 +19,7 @@ namespace vsg
     class VSG_DECLSPEC Buffer : public Inherit<Object, Buffer>
     {
     public:
-        Buffer(VkBuffer Buffer, VkBufferUsageFlags usage, VkSharingMode sharingMode, Device* device, AllocationCallbacks* allocator = nullptr);
+        Buffer(VkBuffer Buffer, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode, Device* device, AllocationCallbacks* allocator = nullptr);
 
         using Result = vsg::Result<Buffer, VkResult, VK_SUCCESS>;
         static Result create(Device* device, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode, AllocationCallbacks* allocator = nullptr);
@@ -47,6 +47,11 @@ namespace vsg
 
         operator VkBuffer() const { return _buffer; }
 
+        using OptionalBufferOffset = std::pair<bool, VkDeviceSize>;
+        OptionalBufferOffset reserve(VkDeviceSize size, VkDeviceSize alignment);
+
+        bool full() const { return _availableMemory.empty(); }
+
     protected:
         virtual ~Buffer();
 
@@ -59,5 +64,9 @@ namespace vsg
 
         ref_ptr<DeviceMemory> _deviceMemory;
         VkDeviceSize _memoryOffset;
+
+        using MemorySlots = std::multimap<VkDeviceSize, VkDeviceSize>;
+        using MemorySlot = MemorySlots::value_type;
+        MemorySlots _availableMemory;
     };
 } // namespace vsg


### PR DESCRIPTION
…multiple vertex & index arrays to share the same Buffer

## Description

A best practice for Vukan is to share Buffers between multiple Arrays and to facilitate this sharing a vsg::Buffer pool has been added to vsg::Context and now used the compile traversal.

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Test using osg2vsg and vsgexamples examples with a range of datasets.