### PR TITLE
State decoupling

### DIFF
--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -37,6 +37,7 @@ namespace vsg
 
     // forward declare vulkan classes
     class Command;
+    class StateCommand;
     class CommandBuffer;
     class RenderPass;
     class BindDescriptorSet;
@@ -164,6 +165,7 @@ namespace vsg
 
         // Vulkan nodes
         virtual void apply(const Command&);
+        virtual void apply(const StateCommand&);
         virtual void apply(const CommandBuffer&);
         virtual void apply(const RenderPass&);
         virtual void apply(const BindDescriptorSet&);

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -37,6 +37,7 @@ namespace vsg
 
     // forward declare vulkan classes
     class Command;
+    class StateCommand;
     class CommandBuffer;
     class RenderPass;
     class BindDescriptorSet;
@@ -164,6 +165,7 @@ namespace vsg
 
         // Vulkan nodes
         virtual void apply(Command&);
+        virtual void apply(StateCommand&);
         virtual void apply(CommandBuffer&);
         virtual void apply(RenderPass&);
         virtual void apply(BindDescriptorSet&);

--- a/include/vsg/nodes/MatrixTransform.h
+++ b/include/vsg/nodes/MatrixTransform.h
@@ -18,7 +18,6 @@ namespace vsg
 {
 
 #define USE_MATRIX_DOUBLE 0
-#define USE_MATRIX_VALUE 0
 
     class MatrixTransform : public Inherit<Group, MatrixTransform>
     {
@@ -30,7 +29,6 @@ namespace vsg
         using value_type = float;
 #endif
         using Matrix = t_mat4<value_type>;
-        using MatrixValue = Value<Matrix>;
 
         MatrixTransform(Allocator* allocator = nullptr);
         MatrixTransform(const Matrix& matrix, Allocator* allocator = nullptr);
@@ -38,22 +36,12 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-#if USE_MATRIX_VALUE
-        void setMatrix(const Matrix& matrix) { (*_matrix) = matrix; }
-        Matrix& getMatrix() { return _matrix->value(); }
-        const Matrix& getMatrix() const { return _matrix->value(); }
-#else
         void setMatrix(const Matrix& matrix) { _matrix = matrix; }
         Matrix& getMatrix() { return _matrix; }
         const Matrix& getMatrix() const { return _matrix; }
-#endif
 
     protected:
-#if USE_MATRIX_VALUE
-        ref_ptr<MatrixValue> _matrix;
-#else
         Matrix _matrix;
-#endif
     };
     VSG_type_name(vsg::MatrixTransform);
 

--- a/include/vsg/nodes/StateGroup.h
+++ b/include/vsg/nodes/StateGroup.h
@@ -22,7 +22,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
     // forward declare
-    class State;
     class CommandBuffer;
 
     class VSG_DECLSPEC StateGroup : public Inherit<Group, StateGroup>
@@ -41,21 +40,6 @@ namespace vsg
         void add(ref_ptr<StateCommand> stateCommand)
         {
             _stateCommands.push_back(stateCommand);
-        }
-
-        inline void pushTo(State& state) const
-        {
-            for (auto& stateCommand : _stateCommands)
-            {
-                stateCommand->pushTo(state);
-            }
-        }
-        inline void popFrom(State& state) const
-        {
-            for (auto& stateCommand : _stateCommands)
-            {
-                stateCommand->popFrom(state);
-            }
         }
 
         virtual void compile(Context& context);

--- a/include/vsg/traversals/DispatchTraversal.h
+++ b/include/vsg/traversals/DispatchTraversal.h
@@ -31,6 +31,7 @@ namespace vsg
     class Command;
     class Commands;
     class CommandBuffer;
+    class State;
 
     class VSG_DECLSPEC DispatchTraversal : public Object
     {
@@ -57,7 +58,6 @@ namespace vsg
         void apply(const Command& command);
 
     protected:
-        class InternalData;
-        InternalData* _data;
+        State* _state;
     };
 } // namespace vsg

--- a/include/vsg/traversals/DispatchTraversal.h
+++ b/include/vsg/traversals/DispatchTraversal.h
@@ -36,7 +36,7 @@ namespace vsg
     class VSG_DECLSPEC DispatchTraversal : public Object
     {
     public:
-        explicit DispatchTraversal(CommandBuffer* commandBuffer = nullptr);
+        explicit DispatchTraversal(CommandBuffer* commandBuffer = nullptr, uint32_t maxSlot = 2);
         ~DispatchTraversal();
 
         void setProjectionMatrix(const dmat4& projMatrix);

--- a/include/vsg/viewer/GraphicsStage.h
+++ b/include/vsg/viewer/GraphicsStage.h
@@ -31,6 +31,7 @@ namespace vsg
         vsg::ref_ptr<ViewportState> _viewport;
 
         VkExtent2D _extent2D;
+        uint32_t _maxSlot = 2;
 
         void populateCommandBuffer(CommandBuffer* commandBuffer, Framebuffer* framebuffer, RenderPass* renderPass, const VkExtent2D& extent2D, const VkClearColorValue& clearColor) override;
     };

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -25,7 +25,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/DeviceMemory.h>
 #include <vsg/vk/Framebuffer.h>
 #include <vsg/vk/Semaphore.h>
-#include <vsg/vk/State.h>
+#include <vsg/vk/Stage.h>
 
 namespace vsg
 {

--- a/include/vsg/vk/BindIndexBuffer.h
+++ b/include/vsg/vk/BindIndexBuffer.h
@@ -19,19 +19,32 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
+    /** Compute the VkIndexType from Data source's value size.*/
+    inline VkIndexType computeIndexType(Data* indices)
+    {
+        if (indices)
+        {
+            switch(indices->valueSize())
+            {
+                case(2) : return VK_INDEX_TYPE_UINT16;
+                case(4) : return VK_INDEX_TYPE_UINT32;
+                default : return VK_INDEX_TYPE_NONE_NV;
+            }
+        }
+        return VK_INDEX_TYPE_NONE_NV;
+    }
+
     class VSG_DECLSPEC BindIndexBuffer : public Inherit<Command, BindIndexBuffer>
     {
     public:
-        BindIndexBuffer(Data* indices = nullptr) :
-            _bufferData(nullptr, 0, 0, indices),
-            _indexType(VK_INDEX_TYPE_UINT16) {}
+        BindIndexBuffer() : _indexType(VK_INDEX_TYPE_NONE_NV) {}
+
+        BindIndexBuffer(Data* indices);
+
+        BindIndexBuffer(const BufferData& bufferData);
 
         BindIndexBuffer(Buffer* buffer, VkDeviceSize offset, VkIndexType indexType) :
             _bufferData(buffer, offset, 0),
-            _indexType(indexType) {}
-
-        BindIndexBuffer(const BufferData& bufferData, VkIndexType indexType) :
-            _bufferData(bufferData),
             _indexType(indexType) {}
 
         void setIndices(ref_ptr<Data> indices) { _bufferData._data = indices; }

--- a/include/vsg/vk/Command.h
+++ b/include/vsg/vk/Command.h
@@ -19,7 +19,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
     class CommandBuffer;
-    class State;
     class Context;
 
     class Command : public Inherit<Node, Command>
@@ -36,14 +35,21 @@ namespace vsg
     class StateCommand : public Inherit<Command, StateCommand>
     {
     public:
-        StateCommand(Allocator* allocator = nullptr) :
-            Inherit(allocator) {}
+        StateCommand(uint32_t slot = 0, Allocator* allocator = nullptr) :
+            Inherit(allocator),
+            _slot(slot) {}
 
-        virtual void pushTo(State& state) const = 0;
-        virtual void popFrom(State& state) const = 0;
+        void read(Input& input) override;
+        void write(Output& output) const override;
+
+        void setSlot(uint32_t slot) { _slot = slot; }
+        uint32_t getSlot() const { return _slot; }
+
 
     protected:
         virtual ~StateCommand() {}
+
+        uint32_t _slot;
     };
     VSG_type_name(vsg::StateCommand);
 

--- a/include/vsg/vk/ComputePipeline.h
+++ b/include/vsg/vk/ComputePipeline.h
@@ -83,8 +83,6 @@ namespace vsg
         ComputePipeline* getPipeline() { return _pipeline; }
         const ComputePipeline* getPipeline() const { return _pipeline; }
 
-        void pushTo(State& state) const override;
-        void popFrom(State& state) const override;
         void dispatch(CommandBuffer& commandBuffer) const override;
 
         // compile the Vulkan object, context parameter used for Device

--- a/include/vsg/vk/DescriptorSet.h
+++ b/include/vsg/vk/DescriptorSet.h
@@ -95,6 +95,7 @@ namespace vsg
         BindDescriptorSets();
 
         BindDescriptorSets(VkPipelineBindPoint bindPoint, PipelineLayout* pipelineLayout, uint32_t firstSet, const DescriptorSets& descriptorSets) :
+            Inherit(1), // slot 1
             _bindPoint(bindPoint),
             _firstSet(firstSet),
             _vkPipelineLayout(0),
@@ -104,6 +105,7 @@ namespace vsg
         }
 
         BindDescriptorSets(VkPipelineBindPoint bindPoint, PipelineLayout* pipelineLayout, const DescriptorSets& descriptorSets) :
+            Inherit(1), // slot 1
             _bindPoint(bindPoint),
             _firstSet(0),
             _vkPipelineLayout(0),

--- a/include/vsg/vk/DescriptorSet.h
+++ b/include/vsg/vk/DescriptorSet.h
@@ -130,8 +130,6 @@ namespace vsg
         uint32_t getFirstSet() { return _firstSet; }
         const DescriptorSets& getDescriptorSets() const { return _descriptorSets; }
 
-        void pushTo(State& state) const override;
-        void popFrom(State& state) const override;
         void dispatch(CommandBuffer& commandBuffer) const override;
 
         // compile the Vulkan object, context parameter used for Device
@@ -159,6 +157,7 @@ namespace vsg
         BindDescriptorSet();
 
         BindDescriptorSet(VkPipelineBindPoint bindPoint, PipelineLayout* pipelineLayout, uint32_t firstSet, DescriptorSet* descriptorSet) :
+            Inherit(1), // slot 1
             _bindPoint(bindPoint),
             _firstSet(firstSet),
             _vkPipelineLayout(0),
@@ -169,6 +168,7 @@ namespace vsg
         }
 
         BindDescriptorSet(VkPipelineBindPoint bindPoint, PipelineLayout* pipelineLayout, DescriptorSet* descriptorSet) :
+            Inherit(1), // slot 1
             _bindPoint(bindPoint),
             _firstSet(0),
             _vkPipelineLayout(0),
@@ -196,8 +196,6 @@ namespace vsg
         uint32_t getFirstSet() { return _firstSet; }
         const DescriptorSet* getDescriptorSet() const { return _descriptorSet; }
 
-        void pushTo(State& state) const override;
-        void popFrom(State& state) const override;
         void dispatch(CommandBuffer& commandBuffer) const override;
 
         // compile the Vulkan object, context parameter used for Device

--- a/include/vsg/vk/GraphicsPipeline.h
+++ b/include/vsg/vk/GraphicsPipeline.h
@@ -116,8 +116,6 @@ namespace vsg
         GraphicsPipeline* getPipeline() { return _pipeline; }
         const GraphicsPipeline* getPipeline() const { return _pipeline; }
 
-        void pushTo(State& state) const override;
-        void popFrom(State& state) const override;
         void dispatch(CommandBuffer& commandBuffer) const override;
 
         // compile the Vulkan object, context parameter used for Device

--- a/include/vsg/vk/PushConstants.h
+++ b/include/vsg/vk/PushConstants.h
@@ -27,8 +27,6 @@ namespace vsg
         Data* getData() noexcept { return _data; }
         const Data* getData() const noexcept { return _data; }
 
-        void pushTo(State& state) const override;
-        void popFrom(State& state) const override;
         void dispatch(CommandBuffer& commandBuffer) const override;
 
     protected:

--- a/include/vsg/vk/Stage.h
+++ b/include/vsg/vk/Stage.h
@@ -12,27 +12,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/vk/Stage.h>
-
-#include <vsg/viewer/Camera.h>
+#include <vsg/vk/CommandBuffer.h>
+#include <vsg/vk/Framebuffer.h>
+#include <vsg/vk/RenderPass.h>
 
 namespace vsg
 {
-
-    class VSG_DECLSPEC GraphicsStage : public Inherit<Stage, GraphicsStage>
+    class Framebuffer;
+    class Renderpass;
+    class Stage : public Inherit<Object, Stage>
     {
     public:
-        GraphicsStage(ref_ptr<Node> commandGraph, ref_ptr<Camera> camera = ref_ptr<Camera>());
+        Stage() {}
 
-        ref_ptr<Camera> _camera;
-        ref_ptr<Node> _commandGraph;
-        vsg::ref_ptr<vsg::mat4Value> _projMatrix;
-        vsg::ref_ptr<vsg::mat4Value> _viewMatrix;
-        vsg::ref_ptr<ViewportState> _viewport;
-
-        VkExtent2D _extent2D;
-
-        void populateCommandBuffer(CommandBuffer* commandBuffer, Framebuffer* framebuffer, RenderPass* renderPass, const VkExtent2D& extent2D, const VkClearColorValue& clearColor) override;
+        virtual void populateCommandBuffer(CommandBuffer* commandBuffer, Framebuffer* framebuffer, RenderPass* renderPass, const VkExtent2D& extent, const VkClearColorValue& clearColor) = 0;
     };
-
 } // namespace vsg

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -201,13 +201,4 @@ namespace vsg
         }
     };
 
-    class Framebuffer;
-    class Renderpass;
-    class Stage : public Inherit<Object, Stage>
-    {
-    public:
-        Stage() {}
-
-        virtual void populateCommandBuffer(CommandBuffer* commandBuffer, Framebuffer* framebuffer, RenderPass* renderPass, const VkExtent2D& extent, const VkClearColorValue& clearColor) = 0;
-    };
 } // namespace vsg

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -23,7 +23,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <map>
 #include <stack>
 
-
 namespace vsg
 {
 

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -133,13 +133,13 @@ namespace vsg
 
         inline void pushAndPreMult(const Matrix& matrix)
         {
-            matrixStack.emplace( matrix * matrixStack.top() );
+            matrixStack.emplace( matrixStack.top() * matrix );
             dirty = true;
         }
 
         inline void pushAndPreMult(const AlternativeMatrix& matrix)
         {
-            matrixStack.emplace( Matrix(matrix) * matrixStack.top() );
+            matrixStack.emplace( matrixStack.top() * Matrix(matrix) );
             dirty = true;
         }
 
@@ -190,8 +190,7 @@ namespace vsg
         DescriptorStacks descriptorStacks;
 
         MatrixStack projectionMatrixStack{0};
-        MatrixStack viewMatrixStack{64};
-        MatrixStack modelMatrixStack{128};
+        MatrixStack modelviewMatrixStack{64};
 
 #if USE_PUSH_CONSTNANT_STACK
         PushConstantsMap pushConstantsMap;
@@ -211,8 +210,7 @@ namespace vsg
                 }
 
                 projectionMatrixStack.dispatch(commandBuffer);
-                viewMatrixStack.dispatch(commandBuffer);
-                modelMatrixStack.dispatch(commandBuffer);
+                modelviewMatrixStack.dispatch(commandBuffer);
 
 #if USE_PUSH_CONSTNANT_STACK
                 for (auto& pushConstantsStack : pushConstantsMap)

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -171,10 +171,10 @@ namespace vsg
     {
     public:
 
-        explicit State(CommandBuffer* commandBuffer) :
+        explicit State(CommandBuffer* commandBuffer, uint32_t maxSlot) :
             _commandBuffer(commandBuffer),
             dirty(false),
-            stateStacks(3)
+            stateStacks(maxSlot+1)
         {
             _frustumUnit = Polytope{{
                 Plane(1.0, 0.0, 0.0, 1.0),  // left plane

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -176,8 +176,6 @@ namespace vsg
         using ComputePipelineStack = StateStack<BindComputePipeline>;
         using GraphicsPipelineStack = StateStack<BindGraphicsPipeline>;
         using DescriptorStacks = std::vector<StateStack<Command>>;
-        using VertexBuffersStack = StateStack<BindVertexBuffers>;
-        using IndexBufferStack = StateStack<BindIndexBuffer>;
         using PushConstantsMap = std::map<uint32_t, StateStack<PushConstants>>;
 
         bool dirty;

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -61,6 +61,7 @@ set(SOURCES
     vk/BufferView.cpp
     vk/BindIndexBuffer.cpp
     vk/BindVertexBuffers.cpp
+    vk/Command.cpp
     vk/CommandBuffer.cpp
     vk/CommandPool.cpp
     vk/ComputePipeline.cpp

--- a/src/vsg/core/ConstVisitor.cpp
+++ b/src/vsg/core/ConstVisitor.cpp
@@ -331,6 +331,10 @@ void ConstVisitor::apply(const Command& value)
 {
     apply(static_cast<const Node&>(value));
 }
+void ConstVisitor::apply(const StateCommand& value)
+{
+    apply(static_cast<const Command&>(value));
+}
 void ConstVisitor::apply(const CommandBuffer& value)
 {
     apply(static_cast<const Object&>(value));
@@ -341,11 +345,11 @@ void ConstVisitor::apply(const RenderPass& value)
 }
 void ConstVisitor::apply(const BindDescriptorSet& value)
 {
-    apply(static_cast<const Command&>(value));
+    apply(static_cast<const StateCommand&>(value));
 }
 void ConstVisitor::apply(const BindDescriptorSets& value)
 {
-    apply(static_cast<const Command&>(value));
+    apply(static_cast<const StateCommand&>(value));
 }
 void ConstVisitor::apply(const DescriptorSet& value)
 {
@@ -361,11 +365,11 @@ void ConstVisitor::apply(const BindIndexBuffer& value)
 }
 void ConstVisitor::apply(const BindComputePipeline& value)
 {
-    apply(static_cast<const Object&>(value));
+    apply(static_cast<const StateCommand&>(value));
 }
 void ConstVisitor::apply(const BindGraphicsPipeline& value)
 {
-    apply(static_cast<const Object&>(value));
+    apply(static_cast<const StateCommand&>(value));
 }
 void ConstVisitor::apply(const GraphicsPipeline& value)
 {

--- a/src/vsg/core/Visitor.cpp
+++ b/src/vsg/core/Visitor.cpp
@@ -331,6 +331,10 @@ void Visitor::apply(Command& value)
 {
     apply(static_cast<Node&>(value));
 }
+void Visitor::apply(StateCommand& value)
+{
+    apply(static_cast<Command&>(value));
+}
 void Visitor::apply(CommandBuffer& value)
 {
     apply(static_cast<Object&>(value));
@@ -341,11 +345,11 @@ void Visitor::apply(RenderPass& value)
 }
 void Visitor::apply(BindDescriptorSet& value)
 {
-    apply(static_cast<Command&>(value));
+    apply(static_cast<StateCommand&>(value));
 }
 void Visitor::apply(BindDescriptorSets& value)
 {
-    apply(static_cast<Command&>(value));
+    apply(static_cast<StateCommand&>(value));
 }
 void Visitor::apply(DescriptorSet& value)
 {
@@ -361,11 +365,11 @@ void Visitor::apply(BindIndexBuffer& value)
 }
 void Visitor::apply(BindComputePipeline& value)
 {
-    apply(static_cast<Object&>(value));
+    apply(static_cast<StateCommand&>(value));
 }
 void Visitor::apply(BindGraphicsPipeline& value)
 {
-    apply(static_cast<Object&>(value));
+    apply(static_cast<StateCommand&>(value));
 }
 void Visitor::apply(GraphicsPipeline& value)
 {

--- a/src/vsg/nodes/Geometry.cpp
+++ b/src/vsg/nodes/Geometry.cpp
@@ -101,7 +101,7 @@ void Geometry::compile(Context& context)
             else
                 failure = true;
 
-            vsg::ref_ptr<vsg::BindIndexBuffer> bindIndexBuffer = vsg::BindIndexBuffer::create(bufferData.back(), VK_INDEX_TYPE_UINT16);
+            vsg::ref_ptr<vsg::BindIndexBuffer> bindIndexBuffer = vsg::BindIndexBuffer::create(bufferData.back());
             if (bindIndexBuffer)
                 _renderImplementation.emplace_back(bindIndexBuffer);
             else

--- a/src/vsg/nodes/MatrixTransform.cpp
+++ b/src/vsg/nodes/MatrixTransform.cpp
@@ -18,39 +18,24 @@ using namespace vsg;
 MatrixTransform::MatrixTransform(Allocator* allocator) :
     Inherit(allocator)
 {
-#if USE_MATRIX_VALUE
-    _matrix = new MatrixValue;
-#endif
 }
 
 MatrixTransform::MatrixTransform(const Matrix& matrix, Allocator* allocator) :
-    Inherit(allocator)
+    Inherit(allocator),
+    _matrix(matrix)
 {
-#if USE_MATRIX_VALUE
-    _matrix = new MatrixValue(matrix);
-#else
-    _matrix = matrix;
-#endif
 }
 
 void MatrixTransform::read(Input& input)
 {
     Group::read(input);
 
-#if USE_MATRIX_VALUE
-    input.read("Matrix", _matrix->value());
-#else
     input.read("Matrix", _matrix);
-#endif
 }
 
 void MatrixTransform::write(Output& output) const
 {
     Group::write(output);
 
-#if USE_MATRIX_VALUE
-    output.write("Matrix", _matrix->value());
-#else
     output.write("Matrix", _matrix);
-#endif
 }

--- a/src/vsg/platform/unix/Xcb_Window.cpp
+++ b/src/vsg/platform/unix/Xcb_Window.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <cstring>
 
 namespace vsg
 {

--- a/src/vsg/traversals/DispatchTraversal.cpp
+++ b/src/vsg/traversals/DispatchTraversal.cpp
@@ -28,8 +28,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/maths/plane.h>
 
-#include <iostream>
-
 using namespace vsg;
 
 #define INLINE_TRAVERSE 1

--- a/src/vsg/traversals/DispatchTraversal.cpp
+++ b/src/vsg/traversals/DispatchTraversal.cpp
@@ -32,7 +32,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-#define USE_TRANSFORM_ACCUMULATION 1
 #define INLINE_TRAVERSE 1
 #define USE_FRUSTUM_ARRAY 1
 
@@ -82,7 +81,7 @@ public:
     {
         if (_frustumDirty)
         {
-            auto pmv = _state.projectionMatrixStack.top() * _state.viewMatrixStack.top() * _state.modelMatrixStack.top();
+            auto pmv = _state.projectionMatrixStack.top() * _state.modelviewMatrixStack.top();
 
 #if USE_FRUSTUM_ARRAY
             _frustum[0] = _frustumUnit[0] * pmv;
@@ -120,7 +119,7 @@ void DispatchTraversal::setProjectionMatrix(const dmat4& projMatrix)
 
 void DispatchTraversal::setViewMatrix(const dmat4& viewMatrix)
 {
-    _data->_state.viewMatrixStack.set(viewMatrix);
+    _data->_state.modelviewMatrixStack.set(viewMatrix);
 }
 
 void DispatchTraversal::apply(const Object& object)
@@ -203,18 +202,12 @@ void DispatchTraversal::apply(const StateGroup& stateGroup)
 
 void DispatchTraversal::apply(const MatrixTransform& mt)
 {
-#if USE_TRANSFORM_ACCUMULATION
-    //std::cout<<"Using accumulation"<<std::endl;
-    _data->_state.modelMatrixStack.pushAndPreMult(mt.getMatrix());
-#else
-    _data->_state.modelMatrixStack.push(mt.getMatrix());
-#endif
-
+    _data->_state.modelviewMatrixStack.pushAndPreMult(mt.getMatrix());
     _data->_state.dirty = true;
 
     mt.traverse(*this);
 
-    _data->_state.modelMatrixStack.pop();
+    _data->_state.modelviewMatrixStack.pop();
     _data->_state.dirty = true;
 }
 

--- a/src/vsg/traversals/DispatchTraversal.cpp
+++ b/src/vsg/traversals/DispatchTraversal.cpp
@@ -34,8 +34,8 @@ using namespace vsg;
 #define USE_FRUSTUM_ARRAY 1
 
 
-DispatchTraversal::DispatchTraversal(CommandBuffer* commandBuffer) :
-    _state(new State(commandBuffer))
+DispatchTraversal::DispatchTraversal(CommandBuffer* commandBuffer, uint32_t maxSlot) :
+    _state(new State(commandBuffer, maxSlot))
 {
 }
 

--- a/src/vsg/viewer/GraphicsStage.cpp
+++ b/src/vsg/viewer/GraphicsStage.cpp
@@ -10,7 +10,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <vsg/nodes/StateGroup.h>
+
 #include <vsg/viewer/GraphicsStage.h>
+
+#include <vsg/traversals/CompileTraversal.h>
 
 #include <array>
 #include <limits>

--- a/src/vsg/viewer/GraphicsStage.cpp
+++ b/src/vsg/viewer/GraphicsStage.cpp
@@ -170,7 +170,7 @@ void GraphicsStage::populateCommandBuffer(CommandBuffer* commandBuffer, Framebuf
     }
 
     // set up the dispatching of the commands into the command buffer
-    DispatchTraversal dispatchTraversal(commandBuffer);
+    DispatchTraversal dispatchTraversal(commandBuffer, _maxSlot);
     dispatchTraversal.setProjectionMatrix(_projMatrix->value());
     dispatchTraversal.setViewMatrix(_viewMatrix->value());
 

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -328,8 +328,6 @@ public:
 
     void apply(const StateCommand& stateCommand) override
     {
-        std::cout<<"apply(const StateCommand& stateCommand)"<<std::endl;
-
         if (stateCommand.getSlot() > maxSlot) maxSlot = stateCommand.getSlot();
 
         stateCommand.traverse(*this);
@@ -399,7 +397,7 @@ void Viewer::compile()
         uint32_t maxSets = collectStats.computeNumDescriptorSets();
         DescriptorPoolSizes descriptorPoolSizes = collectStats.computeDescriptorPoolSizes();
 
-#if 1
+#if 0
         std::cout << "maxSlot = " << collectStats.maxSlot << std::endl;
         std::cout << "maxSets = " << maxSets << std::endl;
         std::cout << "    type\tcount" << std::endl;
@@ -421,6 +419,8 @@ void Viewer::compile()
             GraphicsStage* gs = dynamic_cast<GraphicsStage*>(stage.get());
             if (gs)
             {
+                gs->_maxSlot = collectStats.maxSlot;
+
                 if (gs->_camera->getViewportState())
                     compile.context.viewport = gs->_camera->getViewportState();
                 else if (gs->_viewport)

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -11,6 +11,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/traversals/CompileTraversal.h>
+
+#include <vsg/nodes/StateGroup.h>
+
+#include <vsg/vk/Descriptor.h>
+
 #include <vsg/viewer/GraphicsStage.h>
 #include <vsg/viewer/Viewer.h>
 

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -326,6 +326,14 @@ public:
         stategroup.traverse(*this);
     }
 
+    void apply(const StateCommand& stateCommand) override
+    {
+        std::cout<<"apply(const StateCommand& stateCommand)"<<std::endl;
+
+        if (stateCommand.getSlot() > maxSlot) maxSlot = stateCommand.getSlot();
+
+        stateCommand.traverse(*this);
+    }
     void apply(const DescriptorSet& descriptorSet)
     {
         if (descriptorSets.count(&descriptorSet) == 0)
@@ -365,6 +373,7 @@ public:
     Descriptors descriptors;
     DescriptorSets descriptorSets;
     DescriptorTypeMap descriptorTypeMap;
+    uint32_t maxSlot = 0;
 };
 
 void Viewer::compile()
@@ -390,7 +399,8 @@ void Viewer::compile()
         uint32_t maxSets = collectStats.computeNumDescriptorSets();
         DescriptorPoolSizes descriptorPoolSizes = collectStats.computeDescriptorPoolSizes();
 
-#if 0
+#if 1
+        std::cout << "maxSlot = " << collectStats.maxSlot << std::endl;
         std::cout << "maxSets = " << maxSets << std::endl;
         std::cout << "    type\tcount" << std::endl;
         for (auto& [type, count] : descriptorPoolSizes)

--- a/src/vsg/vk/BindIndexBuffer.cpp
+++ b/src/vsg/vk/BindIndexBuffer.cpp
@@ -15,6 +15,18 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
+BindIndexBuffer::BindIndexBuffer(Data* indices) :
+    _bufferData(nullptr, 0, 0, indices),
+    _indexType(computeIndexType(indices))
+{
+}
+
+BindIndexBuffer::BindIndexBuffer(const BufferData& bufferData) :
+    _bufferData(bufferData),
+    _indexType(computeIndexType(bufferData._data))
+{
+}
+
 void BindIndexBuffer::read(Input& input)
 {
     Command::read(input);

--- a/src/vsg/vk/BindIndexBuffer.cpp
+++ b/src/vsg/vk/BindIndexBuffer.cpp
@@ -11,7 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/vk/BindIndexBuffer.h>
-#include <vsg/vk/State.h>
+#include <vsg/vk/CommandBuffer.h>
 
 using namespace vsg;
 

--- a/src/vsg/vk/BindVertexBuffers.cpp
+++ b/src/vsg/vk/BindVertexBuffers.cpp
@@ -11,7 +11,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/vk/BindVertexBuffers.h>
-#include <vsg/vk/State.h>
+#include <vsg/vk/CommandBuffer.h>
+
+#include <vsg/traversals/CompileTraversal.h>
 
 using namespace vsg;
 

--- a/src/vsg/vk/BufferData.cpp
+++ b/src/vsg/vk/BufferData.cpp
@@ -53,7 +53,7 @@ BufferDataList vsg::createBufferAndTransferData(Context& context, const DataList
     bufferDataList.reserve(dataList.size());
     for (auto& data : dataList)
     {
-        bufferDataList.push_back(BufferData(0, offset, data->dataSize()));
+        bufferDataList.push_back(BufferData(0, offset, data->dataSize(), data));
         VkDeviceSize endOfEntry = offset + data->dataSize();
         offset = (alignment == 1 || (endOfEntry % alignment) == 0) ? endOfEntry : ((endOfEntry / alignment) + 1) * alignment;
     }

--- a/src/vsg/vk/Command.cpp
+++ b/src/vsg/vk/Command.cpp
@@ -1,0 +1,29 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/vk/BindIndexBuffer.h>
+
+using namespace vsg;
+
+void StateCommand::read(Input& input)
+{
+    Command::read(input);
+
+    input.read("slot", _slot);
+}
+
+void StateCommand::write(Output& output) const
+{
+    Command::write(output);
+
+    output.write("slot", _slot);
+}

--- a/src/vsg/vk/Command.cpp
+++ b/src/vsg/vk/Command.cpp
@@ -18,12 +18,12 @@ void StateCommand::read(Input& input)
 {
     Command::read(input);
 
-    input.read("slot", _slot);
+    input.read("Slot", _slot);
 }
 
 void StateCommand::write(Output& output) const
 {
     Command::write(output);
 
-    output.write("slot", _slot);
+    output.write("Slot", _slot);
 }

--- a/src/vsg/vk/ComputePipeline.cpp
+++ b/src/vsg/vk/ComputePipeline.cpp
@@ -115,6 +115,7 @@ ComputePipeline::Implementation::Result ComputePipeline::Implementation::create(
 // BindComputePipeline
 //
 BindComputePipeline::BindComputePipeline(ComputePipeline* pipeline) :
+    Inherit(0), // slot 0
     _pipeline(pipeline)
 {
 }
@@ -135,22 +136,6 @@ void BindComputePipeline::write(Output& output) const
     StateCommand::write(output);
 
     output.writeObject("ComputePipeline", _pipeline.get());
-}
-
-void BindComputePipeline::pushTo(State& state) const
-{
-#if USE_COMPUTE_PIPELIE_STACK
-    state.dirty = true;
-    state.computePipelineStack.push(this);
-#endif
-}
-
-void BindComputePipeline::popFrom(State& state) const
-{
-#if USE_COMPUTE_PIPELIE_STACK
-    state.dirty = true;
-    state.computePipelineStack.pop();
-#endif
 }
 
 void BindComputePipeline::dispatch(CommandBuffer& commandBuffer) const

--- a/src/vsg/vk/ComputePipeline.cpp
+++ b/src/vsg/vk/ComputePipeline.cpp
@@ -11,8 +11,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/traversals/CompileTraversal.h>
+
 #include <vsg/vk/ComputePipeline.h>
-#include <vsg/vk/State.h>
+#include <vsg/vk/CommandBuffer.h>
 
 using namespace vsg;
 

--- a/src/vsg/vk/DescriptorSet.cpp
+++ b/src/vsg/vk/DescriptorSet.cpp
@@ -145,6 +145,7 @@ void DescriptorSet::Implementation::assign(const Descriptors& descriptors)
 // BindDescriptorSets
 //
 BindDescriptorSets::BindDescriptorSets() :
+    Inherit(1), // slot 1
     _bindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS),
     _firstSet(0),
     _vkPipelineLayout(0)
@@ -179,23 +180,6 @@ void BindDescriptorSets::write(Output& output) const
     {
         output.writeObject("DescriptorSets", descriptorSet.get());
     }
-}
-
-void BindDescriptorSets::pushTo(State& state) const
-{
-    state.dirty = true;
-
-    // make sure there is an appropriate descriptorStack entry available.
-    if (_firstSet >= state.descriptorStacks.size()) state.descriptorStacks.resize(_firstSet + 1);
-
-    // push this to the appropriate descriptorStack
-    state.descriptorStacks[_firstSet].push(this);
-}
-
-void BindDescriptorSets::popFrom(State& state) const
-{
-    state.dirty = true;
-    state.descriptorStacks[_firstSet].pop();
 }
 
 void BindDescriptorSets::dispatch(CommandBuffer& commandBuffer) const
@@ -236,7 +220,7 @@ BindDescriptorSet::BindDescriptorSet() :
 
 void BindDescriptorSet::read(Input& input)
 {
-    Object::read(input);
+    StateCommand::read(input);
 
     _pipelineLayout = input.readObject<PipelineLayout>("PipelineLayout");
 
@@ -247,30 +231,13 @@ void BindDescriptorSet::read(Input& input)
 
 void BindDescriptorSet::write(Output& output) const
 {
-    Object::write(output);
+    StateCommand::write(output);
 
     output.writeObject("PipelineLayout", _pipelineLayout.get());
 
     output.write("firstSet", _firstSet);
 
     output.writeObject("DescriptorSet", _descriptorSet.get());
-}
-
-void BindDescriptorSet::pushTo(State& state) const
-{
-    state.dirty = true;
-
-    // make sure there is an appropriate descriptorStack entry available.
-    if (_firstSet >= state.descriptorStacks.size()) state.descriptorStacks.resize(_firstSet + 1);
-
-    // push this to the appropriate descriptorStack
-    state.descriptorStacks[_firstSet].push(this);
-}
-
-void BindDescriptorSet::popFrom(State& state) const
-{
-    state.dirty = true;
-    state.descriptorStacks[_firstSet].pop();
 }
 
 void BindDescriptorSet::dispatch(CommandBuffer& commandBuffer) const

--- a/src/vsg/vk/DescriptorSet.cpp
+++ b/src/vsg/vk/DescriptorSet.cpp
@@ -11,7 +11,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/vk/DescriptorSet.h>
-#include <vsg/vk/State.h>
+#include <vsg/vk/CommandBuffer.h>
+
+#include <vsg/traversals/CompileTraversal.h>
 
 using namespace vsg;
 

--- a/src/vsg/vk/GraphicsPipeline.cpp
+++ b/src/vsg/vk/GraphicsPipeline.cpp
@@ -133,6 +133,7 @@ GraphicsPipeline::Implementation::~Implementation()
 // BindGraphicsPipeline
 //
 BindGraphicsPipeline::BindGraphicsPipeline(GraphicsPipeline* pipeline) :
+    Inherit(0), // slot 0
     _pipeline(pipeline)
 {
 }
@@ -153,18 +154,6 @@ void BindGraphicsPipeline::write(Output& output) const
     StateCommand::write(output);
 
     output.writeObject("GraphicsPipeline", _pipeline.get());
-}
-
-void BindGraphicsPipeline::pushTo(State& state) const
-{
-    state.dirty = true;
-    state.graphicsPipelineStack.push(this);
-}
-
-void BindGraphicsPipeline::popFrom(State& state) const
-{
-    state.dirty = true;
-    state.graphicsPipelineStack.pop();
 }
 
 void BindGraphicsPipeline::dispatch(CommandBuffer& commandBuffer) const

--- a/src/vsg/vk/GraphicsPipeline.cpp
+++ b/src/vsg/vk/GraphicsPipeline.cpp
@@ -11,7 +11,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/vk/GraphicsPipeline.h>
-#include <vsg/vk/State.h>
+#include <vsg/vk/CommandBuffer.h>
+
+#include <vsg/traversals/CompileTraversal.h>
 
 using namespace vsg;
 

--- a/src/vsg/vk/PushConstants.cpp
+++ b/src/vsg/vk/PushConstants.cpp
@@ -16,6 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 using namespace vsg;
 
 PushConstants::PushConstants(VkShaderStageFlags stageFlags, uint32_t offset, Data* data) :
+    Inherit(2), // slot 0
     _stageFlags(stageFlags),
     _offset(offset),
     _data(data)
@@ -24,22 +25,6 @@ PushConstants::PushConstants(VkShaderStageFlags stageFlags, uint32_t offset, Dat
 
 PushConstants::~PushConstants()
 {
-}
-
-void PushConstants::pushTo(State& state) const
-{
-#if USE_PUSH_CONSTNANT_STACK
-    state.pushConstantsMap[_offset].push(this);
-    state.dirty = true;
-#endif
-}
-
-void PushConstants::popFrom(State& state) const
-{
-#if USE_PUSH_CONSTNANT_STACK
-    state.pushConstantsMap[_offset].pop();
-    state.dirty = true;
-#endif
 }
 
 void PushConstants::dispatch(CommandBuffer& commandBuffer) const

--- a/src/vsg/vk/PushConstants.cpp
+++ b/src/vsg/vk/PushConstants.cpp
@@ -11,7 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/vk/PushConstants.h>
-#include <vsg/vk/State.h>
+#include <vsg/vk/CommandBuffer.h>
 
 using namespace vsg;
 


### PR DESCRIPTION
Refactor of the way that StateCommands are tracked in vsg::State to make it more flexible and faster. 

Added support accumulation of matrices and double versions of MatrixTransform/CullNode/CullGroup and vsg::State internal matrices.

Tested with a range of datasets, osg2vsg and vsgExamples.  Both osg2vsg and vsgExamples will need updating to master handle this merge to VSG master.