### PR TITLE
Make sure index type is comuted in compile transversal 

### DIFF
--- a/src/vsg/nodes/VertexIndexDraw.cpp
+++ b/src/vsg/nodes/VertexIndexDraw.cpp
@@ -115,7 +115,7 @@ void VertexIndexDraw::compile(Context& context)
         }
 
         _bufferData = bufferDataList.back();
-        _indexType = VK_INDEX_TYPE_UINT16; // TODO need to check Index type
+        _indexType = computeIndexType(_indices); // TODO need to check Index type
     }
     else
     {

--- a/src/vsg/vk/BindIndexBuffer.cpp
+++ b/src/vsg/vk/BindIndexBuffer.cpp
@@ -62,5 +62,6 @@ void BindIndexBuffer::compile(Context& context)
     if (!bufferDataList.empty())
     {
         _bufferData = bufferDataList.back();
+        _indexType = computeIndexType(_bufferData._data);
     }
 }


### PR DESCRIPTION
For BindIndexBuffer and VertexDrawIndexed

Built against vsgUnity and tested export. Loaded with previewer and vsgviewer.