### PR TITLE
added msvc specific option for multi process compilation

### DIFF
--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -140,6 +140,12 @@ if(MSVC)
     endmacro()
 
     SET_OUTPUT_DIR_PROPERTY(vsg "")
+	
+    option(ENABLE_MP_FLAG "Turning on this option will add the multi-processor flag in MSVC for VSG and it's included projects" OFF)
+	
+    if(ENABLE_MP_FLAG)
+        target_compile_options(vsg PRIVATE "/MP")
+    endif()
 
 endif()
 


### PR DESCRIPTION
# Pull Request Template

## Description

Added option to add use ```/MP``` in Visual Studio to speed up build times. This option is off by default and set as ```PRIVATE``` as to not be inherited into other projects making use of VSG.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Clean build using Visual Studio.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain: MSVC 2019 Version 16.1.0
* SDK:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
