### PR TITLE
DescriptorImage/DescriptorImages refactor

### DIFF
--- a/include/vsg/vk/Descriptor.h
+++ b/include/vsg/vk/Descriptor.h
@@ -103,6 +103,31 @@ namespace vsg
         std::vector<VkDescriptorImageInfo> _imageInfos;
     };
 
+    class VSG_DECLSPEC DescriptorImages : public Inherit<Descriptor, DescriptorImages>
+    {
+    public:
+
+        using SamplerImage = std::pair<ref_ptr<Sampler>, ref_ptr<Data>>;
+        using SamplerImages = std::vector<SamplerImage>;
+
+        DescriptorImages();
+
+        DescriptorImages(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const SamplerImages& sampleImages);
+
+        void read(Input& input) override;
+        void write(Output& output) const override;
+
+        void compile(Context& context) override;
+
+        bool assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const override;
+
+    protected:
+        SamplerImages _samplerImages;
+        ImageDataList _imageDataList;
+        std::vector<VkDescriptorImageInfo> _imageInfos;
+    };
+    VSG_type_name(vsg::DescriptorImages)
+
     class VSG_DECLSPEC DescriptorBuffer : public Inherit<Descriptor, DescriptorBuffer>
     {
     public:
@@ -188,7 +213,7 @@ namespace vsg
     };
     VSG_type_name(vsg::Texture)
 
-        class VSG_DECLSPEC Uniform : public Inherit<Descriptor, Uniform>
+    class VSG_DECLSPEC Uniform : public Inherit<Descriptor, Uniform>
     {
     public:
         Uniform();

--- a/include/vsg/vk/Descriptor.h
+++ b/include/vsg/vk/Descriptor.h
@@ -71,48 +71,52 @@ namespace vsg
 
     using Descriptors = std::vector<vsg::ref_ptr<vsg::Descriptor>>;
 
+    using SamplerImage = std::pair<ref_ptr<Sampler>, ref_ptr<Data>>;
+    using SamplerImages = std::vector<SamplerImage>;
+
     class VSG_DECLSPEC DescriptorImage : public Inherit<Descriptor, DescriptorImage>
     {
     public:
-        DescriptorImage(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const ImageDataList& imageDataList) :
-            Inherit(dstBinding, dstArrayElement, descriptorType),
-            _imageDataList(imageDataList)
-        {
-            // convert from VSG to Vk
-            _imageInfos.resize(_imageDataList.size());
-            for (size_t i = 0; i < _imageDataList.size(); ++i)
-            {
-                const ImageData& data = _imageDataList[i];
-                VkDescriptorImageInfo& info = _imageInfos[i];
-                info.sampler = *(data._sampler);
-                info.imageView = *(data._imageView);
-                info.imageLayout = data._imageLayout;
-            }
-        }
+        DescriptorImage();
 
-        virtual bool assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const
-        {
-            Descriptor::assignTo(wds, descriptorSet);
-            wds.descriptorCount = static_cast<uint32_t>(_imageInfos.size());
-            wds.pImageInfo = _imageInfos.data();
-            return true;
-        }
+        DescriptorImage(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, ref_ptr<Sampler> sampler, ref_ptr<Data> image);
+
+        DescriptorImage(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const SamplerImage& samplerImage);
+
+        Sampler* getSampler() { return _samplerImage.first; }
+        const Sampler* getSampler() const { return _samplerImage.first; }
+
+        Data* getImage() { return _samplerImage.second; }
+        const Data* getImage() const { return _samplerImage.second; }
+
+        SamplerImage& getSamplerImage() { return _samplerImage; }
+        const SamplerImage& getSamplerImage() const { return _samplerImage; }
+
+        void read(Input& input) override;
+        void write(Output& output) const override;
+
+        void compile(Context& context) override;
+
+        bool assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const override;
 
     protected:
-        ImageDataList _imageDataList;
-        std::vector<VkDescriptorImageInfo> _imageInfos;
+        SamplerImage _samplerImage;
+
+        ImageData _imageData;
+        VkDescriptorImageInfo _imageInfo;
     };
+    VSG_type_name(vsg::DescriptorImage)
 
     class VSG_DECLSPEC DescriptorImages : public Inherit<Descriptor, DescriptorImages>
     {
     public:
-
-        using SamplerImage = std::pair<ref_ptr<Sampler>, ref_ptr<Data>>;
-        using SamplerImages = std::vector<SamplerImage>;
-
         DescriptorImages();
 
         DescriptorImages(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const SamplerImages& sampleImages);
+
+
+        SamplerImages& getSamplerImages() { return _samplerImages; }
+        const SamplerImages& getSamplerImages() const { return _samplerImages; }
 
         void read(Input& input) override;
         void write(Output& output) const override;
@@ -123,6 +127,8 @@ namespace vsg
 
     protected:
         SamplerImages _samplerImages;
+
+        // populated by compile()
         ImageDataList _imageDataList;
         std::vector<VkDescriptorImageInfo> _imageInfos;
     };
@@ -192,26 +198,6 @@ namespace vsg
         BufferViewList _texelBufferViewList;
         std::vector<VkBufferView> _texelBufferViews;
     };
-
-    class VSG_DECLSPEC Texture : public Inherit<Descriptor, Texture>
-    {
-    public:
-        Texture();
-
-        void read(Input& input) override;
-        void write(Output& output) const override;
-
-        void compile(Context& context) override;
-
-        bool assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const override;
-
-        // settings
-        VkSamplerCreateInfo _samplerInfo;
-        ref_ptr<Data> _textureData;
-
-        ref_ptr<vsg::Descriptor> _implementation;
-    };
-    VSG_type_name(vsg::Texture)
 
     class VSG_DECLSPEC Uniform : public Inherit<Descriptor, Uniform>
     {

--- a/include/vsg/vk/ImageData.h
+++ b/include/vsg/vk/ImageData.h
@@ -51,7 +51,7 @@ namespace vsg
     };
 
     /// transfer Data to graphics memory, returning ImageData configuration.
-    extern VSG_DECLSPEC vsg::ImageData transferImageData(Context& context, const Data* data, Sampler* sampler = nullptr);
+    extern VSG_DECLSPEC vsg::ImageData transferImageData(Context& context, const Data* data, Sampler* sampler = nullptr, VkImageLayout targetImageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     using ImageDataList = std::vector<ImageData>;
 

--- a/include/vsg/vk/Sampler.h
+++ b/include/vsg/vk/Sampler.h
@@ -16,31 +16,50 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
+    class Context;
+
     class VSG_DECLSPEC Sampler : public Inherit<Object, Sampler>
     {
     public:
-        Sampler(VkSampler Sampler, const VkSamplerCreateInfo& info, Device* device, AllocationCallbacks* allocator = nullptr);
+        Sampler();
 
-        using Result = vsg::Result<Sampler, VkResult, VK_SUCCESS>;
-        static Result create(Device* device, const VkSamplerCreateInfo& createSamplerInfo, AllocationCallbacks* allocator = nullptr);
+        void read(Input& input) override;
+        void write(Output& output) const override;
 
-        static Result create(Device* device, AllocationCallbacks* allocator = nullptr);
+        void compile(Context& context);
 
-        VkSampler sampler() const { return _sampler; }
-        operator VkSampler() const { return _sampler; }
+        class VSG_DECLSPEC Implementation : public Inherit<Object, Implementation>
+        {
+        public:
+            Implementation(VkSampler Sampler, Device* device, AllocationCallbacks* allocator = nullptr);
 
-        const VkSamplerCreateInfo& info() { return _info; }
+            using Result = vsg::Result<Implementation, VkResult, VK_SUCCESS>;
 
-        Device* getDevice() { return _device; }
-        const Device* getDevice() const { return _device; }
+            static Result create(Device* device, const VkSamplerCreateInfo& createSamplerInfo, AllocationCallbacks* allocator = nullptr);
+
+            operator VkSampler() const { return _sampler; }
+
+        protected:
+            virtual ~Implementation();
+
+            VkSampler _sampler;
+            ref_ptr<Device> _device;
+            ref_ptr<AllocationCallbacks> _allocator;
+        };
+
+        VkSamplerCreateInfo& info() { return _samplerInfo; }
+        const VkSamplerCreateInfo& info() const { return _samplerInfo; }
+
+        VkSampler sampler() const { return *_implementation; }
+        operator VkSampler() const { return *_implementation; }
 
     protected:
         virtual ~Sampler();
 
-        VkSampler _sampler;
-        VkSamplerCreateInfo _info;
-        ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
+        VkSamplerCreateInfo _samplerInfo;
+
+        ref_ptr<Implementation> _implementation;
     };
+    VSG_type_name(vsg::Sampler)
 
 } // namespace vsg

--- a/src/vsg/io/ObjectFactory.cpp
+++ b/src/vsg/io/ObjectFactory.cpp
@@ -187,6 +187,7 @@ ObjectFactory::ObjectFactory()
     VSG_REGISTER_create(vsg::BindIndexBuffer);
     VSG_REGISTER_create(vsg::DescriptorSet);
     VSG_REGISTER_create(vsg::DescriptorSetLayout);
+    VSG_REGISTER_create(vsg::DescriptorImage);
     VSG_REGISTER_create(vsg::DescriptorImages);
     VSG_REGISTER_create(vsg::Sampler);
 }

--- a/src/vsg/io/ObjectFactory.cpp
+++ b/src/vsg/io/ObjectFactory.cpp
@@ -39,6 +39,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/GraphicsPipeline.h>
 #include <vsg/vk/PipelineLayout.h>
 #include <vsg/vk/ShaderModule.h>
+#include <vsg/vk/Sampler.h>
 
 #include <iostream>
 
@@ -187,6 +188,8 @@ ObjectFactory::ObjectFactory()
     VSG_REGISTER_create(vsg::BindIndexBuffer);
     VSG_REGISTER_create(vsg::DescriptorSet);
     VSG_REGISTER_create(vsg::DescriptorSetLayout);
+    VSG_REGISTER_create(vsg::DescriptorImages);
+    VSG_REGISTER_create(vsg::Sampler);
     VSG_REGISTER_create(vsg::Texture);
     VSG_REGISTER_create(vsg::Uniform);
 }

--- a/src/vsg/io/ObjectFactory.cpp
+++ b/src/vsg/io/ObjectFactory.cpp
@@ -169,7 +169,6 @@ ObjectFactory::ObjectFactory()
     VSG_REGISTER_create(vsg::ComputePipeline);
     VSG_REGISTER_create(vsg::ShaderStages);
     VSG_REGISTER_create(vsg::ShaderModule);
-    VSG_REGISTER_create(vsg::Texture);
     VSG_REGISTER_create(vsg::Uniform);
     VSG_REGISTER_create(vsg::VertexInputState);
     VSG_REGISTER_create(vsg::InputAssemblyState);
@@ -190,8 +189,6 @@ ObjectFactory::ObjectFactory()
     VSG_REGISTER_create(vsg::DescriptorSetLayout);
     VSG_REGISTER_create(vsg::DescriptorImages);
     VSG_REGISTER_create(vsg::Sampler);
-    VSG_REGISTER_create(vsg::Texture);
-    VSG_REGISTER_create(vsg::Uniform);
 }
 
 vsg::ref_ptr<vsg::Object> ObjectFactory::create(const std::string& className)

--- a/src/vsg/vk/Descriptor.cpp
+++ b/src/vsg/vk/Descriptor.cpp
@@ -68,8 +68,12 @@ void DescriptorImage::compile(Context& context)
     _imageData = vsg::transferImageData(context, _samplerImage.second, _samplerImage.first);
 
     // convert from VSG to Vk
-    _imageInfo.sampler = *(_imageData._sampler);
-    _imageInfo.imageView = *(_imageData._imageView);
+    if (_imageData._sampler) _imageInfo.sampler = *(_imageData._sampler);
+    else _imageInfo.sampler = 0;
+
+    if (_imageData._imageView) _imageInfo.imageView = *(_imageData._imageView);
+    else _imageData._imageView = 0;
+
     _imageInfo.imageLayout = _imageData._imageLayout;
 }
 
@@ -142,8 +146,12 @@ void DescriptorImages::compile(Context& context)
     {
         const ImageData& data = _imageDataList[i];
         VkDescriptorImageInfo& info = _imageInfos[i];
-        info.sampler = *(data._sampler);
-        info.imageView = *(data._imageView);
+        if (data._sampler) info.sampler = *(data._sampler);
+        else info.sampler = 0;
+
+        if (data._imageView) info.imageView = *(data._imageView);
+        else info.imageView = 0;
+
         info.imageLayout = data._imageLayout;
     }
 }

--- a/src/vsg/vk/Descriptor.cpp
+++ b/src/vsg/vk/Descriptor.cpp
@@ -20,6 +20,83 @@ using namespace vsg;
 
 /////////////////////////////////////////////////////////////////////////////////////////
 //
+// DescriptorImages
+//
+DescriptorImages::DescriptorImages():
+    Inherit(0, 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+{
+}
+
+DescriptorImages::DescriptorImages(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const SamplerImages& samplerImages) :
+    Inherit(dstBinding, dstArrayElement, descriptorType),
+    _samplerImages(samplerImages)
+{
+}
+
+void DescriptorImages::read(Input& input)
+{
+    _imageDataList.clear();
+    _imageInfos.clear();
+
+    Descriptor::read(input);
+
+    _samplerImages.resize(input.readValue<uint32_t>("NumImages"));
+    for (auto& samplerImage : _samplerImages)
+    {
+        samplerImage.first = input.readObject<Sampler>("Sampler");
+        samplerImage.second = input.readObject<Data>("Image");
+    }
+}
+
+void DescriptorImages::write(Output& output) const
+{
+    Descriptor::write(output);
+
+    output.writeValue<uint32_t>("NumImages", _samplerImages.size());
+    for (auto& samplerImage : _samplerImages)
+    {
+        output.writeObject("Sampler", samplerImage.first.get());
+        output.writeObject("Image", samplerImage.second.get());
+    }
+}
+
+void DescriptorImages::compile(Context& context)
+{
+    // check if we have already compiled the imageData.
+    if (_imageDataList.size()==_samplerImages.size()) return;
+
+    _imageDataList.clear();
+    _imageDataList.reserve(_samplerImages.size());
+    for(auto& samplerImage : _samplerImages)
+    {
+        samplerImage.first->compile(context);
+        _imageDataList.emplace_back(vsg::transferImageData(context, samplerImage.second, samplerImage.first));
+    }
+
+    // convert from VSG to Vk
+    _imageInfos.resize(_imageDataList.size());
+    for (size_t i = 0; i < _imageDataList.size(); ++i)
+    {
+        const ImageData& data = _imageDataList[i];
+        VkDescriptorImageInfo& info = _imageInfos[i];
+        info.sampler = *(data._sampler);
+        info.imageView = *(data._imageView);
+        info.imageLayout = data._imageLayout;
+    }
+}
+
+
+bool DescriptorImages::assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const
+{
+    Descriptor::assignTo(wds, descriptorSet);
+    wds.descriptorCount = static_cast<uint32_t>(_imageInfos.size());
+    wds.pImageInfo = _imageInfos.data();
+    return true;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+//
 // DescriptorBuffer
 //
 void DescriptorBuffer::copyDataListToBuffers()
@@ -108,7 +185,10 @@ void Texture::compile(Context& context)
 {
     if (_implementation) return;
 
-    ref_ptr<Sampler> sampler = Sampler::create(context.device, _samplerInfo, nullptr);
+    //ref_ptr<Sampler> sampler = Sampler::create(context.device, _samplerInfo, nullptr);
+    ref_ptr<Sampler> sampler = Sampler::create();
+    sampler->info() = _samplerInfo;
+    sampler->compile(context);
     vsg::ImageData imageData = vsg::transferImageData(context, _textureData, sampler);
     if (!imageData.valid())
     {

--- a/src/vsg/vk/Descriptor.cpp
+++ b/src/vsg/vk/Descriptor.cpp
@@ -18,6 +18,69 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
+
+/////////////////////////////////////////////////////////////////////////////////////////
+//
+// DescriptorImages
+//
+DescriptorImage::DescriptorImage():
+    Inherit(0, 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+{
+}
+
+DescriptorImage::DescriptorImage(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, ref_ptr<Sampler> sampler, ref_ptr<Data> image) :
+    Inherit(dstBinding, dstArrayElement, descriptorType),
+    _samplerImage(sampler, image)
+{
+}
+
+DescriptorImage::DescriptorImage(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const SamplerImage& samplerImage) :
+    Inherit(dstBinding, dstArrayElement, descriptorType),
+    _samplerImage(samplerImage)
+{
+}
+
+void DescriptorImage::read(Input& input)
+{
+    _imageData._sampler = nullptr;
+    _imageData._imageView = nullptr;
+
+    Descriptor::read(input);
+
+    _samplerImage.first = input.readObject<Sampler>("Sampler");
+    _samplerImage.second = input.readObject<Data>("Image");
+}
+
+void DescriptorImage::write(Output& output) const
+{
+    Descriptor::write(output);
+
+    output.writeObject("Sampler", _samplerImage.first.get());
+    output.writeObject("Image", _samplerImage.second.get());
+}
+
+void DescriptorImage::compile(Context& context)
+{
+    // check if we have already compiled the imageData.
+    if (_imageData) return;
+
+    _samplerImage.first->compile(context);
+    _imageData = vsg::transferImageData(context, _samplerImage.second, _samplerImage.first);
+
+    // convert from VSG to Vk
+    _imageInfo.sampler = *(_imageData._sampler);
+    _imageInfo.imageView = *(_imageData._imageView);
+    _imageInfo.imageLayout = _imageData._imageLayout;
+}
+
+bool DescriptorImage::assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const
+{
+    Descriptor::assignTo(wds, descriptorSet);
+    wds.descriptorCount = 1;
+    wds.pImageInfo = &_imageInfo;
+    return true;
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////
 //
 // DescriptorImages
@@ -85,7 +148,6 @@ void DescriptorImages::compile(Context& context)
     }
 }
 
-
 bool DescriptorImages::assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const
 {
     Descriptor::assignTo(wds, descriptorSet);
@@ -102,108 +164,6 @@ bool DescriptorImages::assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descr
 void DescriptorBuffer::copyDataListToBuffers()
 {
     vsg::copyDataListToBuffers(_bufferDataList);
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-//
-// Texture
-//
-Texture::Texture() :
-    Inherit(0, 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-{
-    // set default sampler info
-    _samplerInfo = {};
-    _samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    _samplerInfo.minFilter = VK_FILTER_LINEAR;
-    _samplerInfo.magFilter = VK_FILTER_LINEAR;
-    _samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    _samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    _samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-#if 1
-    // requires Logical device to have deviceFeatures.samplerAnisotropy = VK_TRUE; set when creating the vsg::Device
-    _samplerInfo.anisotropyEnable = VK_TRUE;
-    _samplerInfo.maxAnisotropy = 16;
-#else
-    _samplerInfo.anisotropyEnable = VK_FALSE;
-    _samplerInfo.maxAnisotropy = 1;
-#endif
-    _samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
-    _samplerInfo.unnormalizedCoordinates = VK_FALSE;
-    _samplerInfo.compareEnable = VK_FALSE;
-    _samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-}
-
-void Texture::read(Input& input)
-{
-    Descriptor::read(input);
-#if 1
-    input.readValue<uint32_t>("flags", _samplerInfo.flags);
-    input.readValue<uint32_t>("minFilter", _samplerInfo.minFilter);
-    input.readValue<uint32_t>("magFilter", _samplerInfo.magFilter);
-    input.readValue<uint32_t>("mipmapMode", _samplerInfo.mipmapMode);
-    input.readValue<uint32_t>("addressModeU", _samplerInfo.addressModeU);
-    input.readValue<uint32_t>("addressModeV", _samplerInfo.addressModeV);
-    input.readValue<uint32_t>("addressModeW", _samplerInfo.addressModeW);
-    input.read("mipLodBias", _samplerInfo.mipLodBias);
-    input.readValue<uint32_t>("anisotropyEnable", _samplerInfo.anisotropyEnable);
-    input.read("maxAnisotropy", _samplerInfo.maxAnisotropy);
-    input.readValue<uint32_t>("compareEnable", _samplerInfo.compareEnable);
-    input.readValue<uint32_t>("compareOp", _samplerInfo.compareOp);
-    input.read("minLod", _samplerInfo.minLod);
-    input.read("maxLod", _samplerInfo.maxLod);
-    input.readValue<uint32_t>("borderColor", _samplerInfo.borderColor);
-    input.readValue<uint32_t>("unnormalizedCoordinates", _samplerInfo.unnormalizedCoordinates);
-#endif
-    _textureData = input.readObject<Data>("TextureData");
-}
-
-void Texture::write(Output& output) const
-{
-    Descriptor::write(output);
-#if 1
-    output.writeValue<uint32_t>("flags", _samplerInfo.flags);
-    output.writeValue<uint32_t>("minFilter", _samplerInfo.minFilter);
-    output.writeValue<uint32_t>("magFilter", _samplerInfo.magFilter);
-    output.writeValue<uint32_t>("mipmapMode", _samplerInfo.mipmapMode);
-    output.writeValue<uint32_t>("addressModeU", _samplerInfo.addressModeU);
-    output.writeValue<uint32_t>("addressModeV", _samplerInfo.addressModeV);
-    output.writeValue<uint32_t>("addressModeW", _samplerInfo.addressModeW);
-    output.write("mipLodBias", _samplerInfo.mipLodBias);
-    output.writeValue<uint32_t>("anisotropyEnable", _samplerInfo.anisotropyEnable);
-    output.write("maxAnisotropy", _samplerInfo.maxAnisotropy);
-    output.writeValue<uint32_t>("compareEnable", _samplerInfo.compareEnable);
-    output.writeValue<uint32_t>("compareOp", _samplerInfo.compareOp);
-    output.write("minLod", _samplerInfo.minLod);
-    output.write("maxLod", _samplerInfo.maxLod);
-    output.writeValue<uint32_t>("borderColor", _samplerInfo.borderColor);
-    output.writeValue<uint32_t>("unnormalizedCoordinates", _samplerInfo.unnormalizedCoordinates);
-#endif
-    output.writeObject("TextureData", _textureData.get());
-}
-
-void Texture::compile(Context& context)
-{
-    if (_implementation) return;
-
-    //ref_ptr<Sampler> sampler = Sampler::create(context.device, _samplerInfo, nullptr);
-    ref_ptr<Sampler> sampler = Sampler::create();
-    sampler->info() = _samplerInfo;
-    sampler->compile(context);
-    vsg::ImageData imageData = vsg::transferImageData(context, _textureData, sampler);
-    if (!imageData.valid())
-    {
-        return;
-    }
-
-    _implementation = vsg::DescriptorImage::create(_dstBinding, _dstArrayElement, _descriptorType, vsg::ImageDataList{imageData});
-}
-
-bool Texture::assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const
-{
-    if (_implementation)
-        return _implementation->assignTo(wds, descriptorSet);
-    else
-        return false;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/vsg/vk/ImageData.cpp
+++ b/src/vsg/vk/ImageData.cpp
@@ -386,7 +386,7 @@ ImageData vsg::transferImageData(Context& context, const Data* data, Sampler* sa
     imageStagingBuffer = 0;
     imageStagingMemory = 0;
 
-    ref_ptr<Sampler> textureSampler = sampler != nullptr ? Sampler::Result(sampler) : Sampler::create(device);
+    ref_ptr<Sampler> textureSampler((sampler != nullptr) ? sampler : Sampler::create());
 
     VkImageViewCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;

--- a/src/vsg/vk/ImageData.cpp
+++ b/src/vsg/vk/ImageData.cpp
@@ -24,11 +24,11 @@ using namespace vsg;
 //
 // vsg::transferImageData
 //
-ImageData vsg::transferImageData(Context& context, const Data* data, Sampler* sampler)
+ImageData vsg::transferImageData(Context& context, const Data* data, Sampler* sampler, VkImageLayout targetImageLayout)
 {
     if (!data)
     {
-        return ImageData();
+        return ImageData(sampler, nullptr, targetImageLayout);
     }
 
     Device* device = context.device;
@@ -92,7 +92,6 @@ ImageData vsg::transferImageData(Context& context, const Data* data, Sampler* sa
 
     VkImageType imageType = depth > 1 ? VK_IMAGE_TYPE_3D : (width > 1 ? VK_IMAGE_TYPE_2D : VK_IMAGE_TYPE_1D);
     VkImageViewType imageViewType = depth > 1 ? VK_IMAGE_VIEW_TYPE_3D : (width > 1 ? VK_IMAGE_VIEW_TYPE_2D : VK_IMAGE_VIEW_TYPE_1D);
-    VkImageLayout targetImageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
     VkImageCreateInfo imageCreateInfo = {};
     imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -386,8 +385,6 @@ ImageData vsg::transferImageData(Context& context, const Data* data, Sampler* sa
     imageStagingBuffer = 0;
     imageStagingMemory = 0;
 
-    ref_ptr<Sampler> textureSampler((sampler != nullptr) ? sampler : Sampler::create());
-
     VkImageViewCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
     createInfo.image = *textureImage;
@@ -403,5 +400,5 @@ ImageData vsg::transferImageData(Context& context, const Data* data, Sampler* sa
     ref_ptr<ImageView> textureImageView = ImageView::create(device, createInfo);
     if (textureImageView) textureImageView->setImage(textureImage);
 
-    return ImageData(textureSampler, textureImageView, targetImageLayout);
+    return ImageData(sampler, textureImageView, targetImageLayout);
 }

--- a/src/vsg/vk/Sampler.cpp
+++ b/src/vsg/vk/Sampler.cpp
@@ -11,18 +11,95 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/vk/Sampler.h>
+#include <vsg/traversals/CompileTraversal.h>
 
 using namespace vsg;
 
-Sampler::Sampler(VkSampler sampler, const VkSamplerCreateInfo& info, Device* device, AllocationCallbacks* allocator) :
+Sampler::Sampler()
+{
+    // set default sampler info
+    _samplerInfo = {};
+    _samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    _samplerInfo.pNext = nullptr;
+    _samplerInfo.flags = 0;
+    _samplerInfo.minFilter = VK_FILTER_LINEAR;
+    _samplerInfo.magFilter = VK_FILTER_LINEAR;
+    _samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    _samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    _samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+#if 1
+    // requires Logical device to have deviceFeatures.samplerAnisotropy = VK_TRUE; set when creating the vsg::Device
+    _samplerInfo.anisotropyEnable = VK_TRUE;
+    _samplerInfo.maxAnisotropy = 16;
+#else
+    _samplerInfo.anisotropyEnable = VK_FALSE;
+    _samplerInfo.maxAnisotropy = 1;
+#endif
+    _samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+    _samplerInfo.unnormalizedCoordinates = VK_FALSE;
+    _samplerInfo.compareEnable = VK_FALSE;
+    _samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+}
+
+Sampler::~Sampler()
+{
+}
+
+void Sampler::read(Input& input)
+{
+    input.readValue<uint32_t>("flags", _samplerInfo.flags);
+    input.readValue<uint32_t>("minFilter", _samplerInfo.minFilter);
+    input.readValue<uint32_t>("magFilter", _samplerInfo.magFilter);
+    input.readValue<uint32_t>("mipmapMode", _samplerInfo.mipmapMode);
+    input.readValue<uint32_t>("addressModeU", _samplerInfo.addressModeU);
+    input.readValue<uint32_t>("addressModeV", _samplerInfo.addressModeV);
+    input.readValue<uint32_t>("addressModeW", _samplerInfo.addressModeW);
+    input.read("mipLodBias", _samplerInfo.mipLodBias);
+    input.readValue<uint32_t>("anisotropyEnable", _samplerInfo.anisotropyEnable);
+    input.read("maxAnisotropy", _samplerInfo.maxAnisotropy);
+    input.readValue<uint32_t>("compareEnable", _samplerInfo.compareEnable);
+    input.readValue<uint32_t>("compareOp", _samplerInfo.compareOp);
+    input.read("minLod", _samplerInfo.minLod);
+    input.read("maxLod", _samplerInfo.maxLod);
+    input.readValue<uint32_t>("borderColor", _samplerInfo.borderColor);
+    input.readValue<uint32_t>("unnormalizedCoordinates", _samplerInfo.unnormalizedCoordinates);
+}
+
+void Sampler::write(Output& output) const
+{
+    output.writeValue<uint32_t>("flags", _samplerInfo.flags);
+    output.writeValue<uint32_t>("minFilter", _samplerInfo.minFilter);
+    output.writeValue<uint32_t>("magFilter", _samplerInfo.magFilter);
+    output.writeValue<uint32_t>("mipmapMode", _samplerInfo.mipmapMode);
+    output.writeValue<uint32_t>("addressModeU", _samplerInfo.addressModeU);
+    output.writeValue<uint32_t>("addressModeV", _samplerInfo.addressModeV);
+    output.writeValue<uint32_t>("addressModeW", _samplerInfo.addressModeW);
+    output.write("mipLodBias", _samplerInfo.mipLodBias);
+    output.writeValue<uint32_t>("anisotropyEnable", _samplerInfo.anisotropyEnable);
+    output.write("maxAnisotropy", _samplerInfo.maxAnisotropy);
+    output.writeValue<uint32_t>("compareEnable", _samplerInfo.compareEnable);
+    output.writeValue<uint32_t>("compareOp", _samplerInfo.compareOp);
+    output.write("minLod", _samplerInfo.minLod);
+    output.write("maxLod", _samplerInfo.maxLod);
+    output.writeValue<uint32_t>("borderColor", _samplerInfo.borderColor);
+    output.writeValue<uint32_t>("unnormalizedCoordinates", _samplerInfo.unnormalizedCoordinates);
+}
+
+void Sampler::compile(Context& context)
+{
+    if (_implementation) return;
+
+    _implementation = Implementation::create(context.device, _samplerInfo);
+}
+
+Sampler::Implementation::Implementation(VkSampler sampler, Device* device, AllocationCallbacks* allocator) :
     _sampler(sampler),
-    _info(info),
     _device(device),
     _allocator(allocator)
 {
 }
 
-Sampler::~Sampler()
+Sampler::Implementation::~Implementation()
 {
     if (_sampler)
     {
@@ -30,7 +107,7 @@ Sampler::~Sampler()
     }
 }
 
-Sampler::Result Sampler::create(Device* device, const VkSamplerCreateInfo& createSamplerInfo, AllocationCallbacks* allocator)
+Sampler::Implementation::Result Sampler::Implementation::create(Device* device, const VkSamplerCreateInfo& createSamplerInfo, AllocationCallbacks* allocator)
 {
     if (!device)
     {
@@ -41,7 +118,7 @@ Sampler::Result Sampler::create(Device* device, const VkSamplerCreateInfo& creat
     VkResult result = vkCreateSampler(*device, &createSamplerInfo, allocator, &sampler);
     if (result == VK_SUCCESS)
     {
-        return Result(new Sampler(sampler, createSamplerInfo, device, allocator));
+        return Result(new Sampler::Implementation(sampler, device, allocator));
     }
     else
     {
@@ -49,28 +126,3 @@ Sampler::Result Sampler::create(Device* device, const VkSamplerCreateInfo& creat
     }
 }
 
-Sampler::Result Sampler::create(Device* device, AllocationCallbacks* allocator)
-{
-    VkSamplerCreateInfo samplerInfo = {};
-    samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    samplerInfo.minFilter = VK_FILTER_LINEAR;
-    samplerInfo.magFilter = VK_FILTER_LINEAR;
-    samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-#if 1
-    // requires Logical device to have deviceFeatures.samplerAnisotropy = VK_TRUE; set when creating the vsg::Device
-    samplerInfo.anisotropyEnable = VK_TRUE;
-    samplerInfo.maxAnisotropy = 16;
-#else
-    samplerInfo.anisotropyEnable = VK_FALSE;
-    samplerInfo.maxAnisotropy = 1;
-#endif
-    samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
-    samplerInfo.unnormalizedCoordinates = VK_FALSE;
-    samplerInfo.compareEnable = VK_FALSE;
-    samplerInfo.pNext = nullptr;
-
-    return create(device, samplerInfo, allocator);
-}


### PR DESCRIPTION
## Description

Replaced vsg::Texture with vsg::DescriptorImage that allows one to couple a vsg::Sampler with vsg::Data image data.

Added vsg::DescriptorImages that provide means of setting up an array of images.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tested with a range of large models.