### PR TITLE
Descriptor.cpp - Added "#include <algorithm>" statement

### DIFF
--- a/src/vsg/vk/Descriptor.cpp
+++ b/src/vsg/vk/Descriptor.cpp
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/CommandBuffer.h>
 #include <vsg/vk/Descriptor.h>
 
+#include <algorithm>
 #include <iostream>
 
 using namespace vsg;


### PR DESCRIPTION
Fixed C2039: 'max': is not a member of 'std' compiler error on Windows

# Pull Request Template

## Description

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Compiler error on Windows

## How Has This Been Tested?

Executed tests found in this project

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
