### PR TITLE
Updated all.h, fix for DescriptorImages fixes

### DIFF
--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -105,6 +105,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/Framebuffer.h>
 #include <vsg/vk/GraphicsPipeline.h>
 #include <vsg/vk/Image.h>
+#include <vsg/vk/ImageData.h>
 #include <vsg/vk/ImageView.h>
 #include <vsg/vk/Instance.h>
 #include <vsg/vk/MemoryManager.h>
@@ -115,6 +116,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/Sampler.h>
 #include <vsg/vk/Semaphore.h>
 #include <vsg/vk/ShaderModule.h>
+#include <vsg/vk/ShaderStage.h>
+#include <vsg/vk/Stage.h>
 #include <vsg/vk/State.h>
 #include <vsg/vk/Surface.h>
 #include <vsg/vk/Swapchain.h>
@@ -131,7 +134,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/ReaderWriter.h>
 #include <vsg/io/stream.h>
 
-// Utility header files
+// Utiltiy header files
 #include <vsg/utils/CommandLine.h>
 
 // Introspection header files

--- a/src/vsg/vk/Descriptor.cpp
+++ b/src/vsg/vk/Descriptor.cpp
@@ -80,7 +80,7 @@ void DescriptorImage::compile(Context& context)
     else _imageInfo.sampler = 0;
 
     if (_imageData._imageView) _imageInfo.imageView = *(_imageData._imageView);
-    else _imageData._imageView = 0;
+    else _imageInfo.imageView = 0;
 
     _imageInfo.imageLayout = _imageData._imageLayout;
 }
@@ -138,7 +138,7 @@ void DescriptorImages::write(Output& output) const
 void DescriptorImages::compile(Context& context)
 {
     // check if we have already compiled the imageData.
-    if (_imageInfos.size() == _imageDataList.size() || _samplerImages.empty()) return;
+    if ((_imageInfos.size() == _imageDataList.size() && _imageInfos.size() != 0) || _samplerImages.empty()) return;
 
     if (!_samplerImages.empty())
     {


### PR DESCRIPTION
# Pull Request Template

## Description

Compile would always return early due to _imageInfos and _imageDataList both being zero. Fixed a copy and paste error in DescriptorImage compile

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with vsgUnity terrain export, loaded export into vsgviewer
