### PR TITLE
Refactor of DescriptorBuffer to replace Uniform

### DIFF
--- a/include/vsg/vk/Descriptor.h
+++ b/include/vsg/vk/Descriptor.h
@@ -152,20 +152,36 @@ namespace vsg
     class VSG_DECLSPEC DescriptorBuffer : public Inherit<Descriptor, DescriptorBuffer>
     {
     public:
-        DescriptorBuffer(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const BufferDataList& bufferDataList);
+        DescriptorBuffer();
+
+        DescriptorBuffer(ref_ptr<Data> data, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+
+        DescriptorBuffer(const DataList& dataList, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+
+        DescriptorBuffer(const BufferDataList& bufferDataList, uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+
+
+        DataList& getDataList() { return _dataList; }
+        const DataList& getDataList() const { return _dataList; }
+
+        void read(Input& input) override;
+        void write(Output& output) const override;
 
         void compile(Context& context) override;
 
         bool assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const override;
 
+        uint32_t getNumDescriptors() const override;
+
         void copyDataListToBuffers();
 
-        uint32_t getNumDescriptors() const override { return static_cast<uint32_t>(_bufferDataList.size()); }
 
     protected:
+        DataList _dataList;
         BufferDataList _bufferDataList;
         std::vector<VkDescriptorBufferInfo> _bufferInfos;
     };
+    VSG_type_name(vsg::DescriptorBuffer)
 
     using BufferViewList = std::vector<ref_ptr<BufferView>>;
 
@@ -199,29 +215,7 @@ namespace vsg
         BufferViewList _texelBufferViewList;
         std::vector<VkBufferView> _texelBufferViews;
     };
-
-    class VSG_DECLSPEC Uniform : public Inherit<Descriptor, Uniform>
-    {
-    public:
-        Uniform();
-
-        void read(Input& input) override;
-        void write(Output& output) const override;
-
-        void compile(Context& context) override;
-
-        bool assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const override;
-
-        void copyDataListToBuffers();
-
-        uint32_t getNumDescriptors() const override { return static_cast<uint32_t>(_dataList.size()); }
-
-        // settings
-        DataList _dataList;
-
-        ref_ptr<vsg::DescriptorBuffer> _implementation;
-    };
-    VSG_type_name(vsg::Uniform)
+    VSG_type_name(vsg::DescriptorTexelBufferView)
 
     struct Material
     {

--- a/include/vsg/vk/Descriptor.h
+++ b/include/vsg/vk/Descriptor.h
@@ -81,9 +81,9 @@ namespace vsg
     public:
         DescriptorImage();
 
-        DescriptorImage(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, ref_ptr<Sampler> sampler, ref_ptr<Data> image);
+        DescriptorImage(ref_ptr<Sampler> sampler, ref_ptr<Data> image, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 
-        DescriptorImage(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const SamplerImage& samplerImage);
+        DescriptorImage(const SamplerImage& samplerImage, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 
         Sampler* getSampler() { return _samplerImage.first; }
         const Sampler* getSampler() const { return _samplerImage.first; }
@@ -121,7 +121,7 @@ namespace vsg
     public:
         DescriptorImages();
 
-        DescriptorImages(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const SamplerImages& sampleImages);
+        DescriptorImages(const SamplerImages& sampleImages, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 
 
         SamplerImages& getSamplerImages() { return _samplerImages; }

--- a/include/vsg/vk/Descriptor.h
+++ b/include/vsg/vk/Descriptor.h
@@ -152,29 +152,11 @@ namespace vsg
     class VSG_DECLSPEC DescriptorBuffer : public Inherit<Descriptor, DescriptorBuffer>
     {
     public:
-        DescriptorBuffer(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const BufferDataList& bufferDataList) :
-            Inherit(dstBinding, dstArrayElement, descriptorType),
-            _bufferDataList(bufferDataList)
-        {
-            // convert from VSG to Vk
-            _bufferInfos.resize(_bufferDataList.size());
-            for (size_t i = 0; i < _bufferDataList.size(); ++i)
-            {
-                const BufferData& data = _bufferDataList[i];
-                VkDescriptorBufferInfo& info = _bufferInfos[i];
-                info.buffer = *(data._buffer);
-                info.offset = data._offset;
-                info.range = data._range;
-            }
-        }
+        DescriptorBuffer(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const BufferDataList& bufferDataList);
 
-        virtual bool assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const
-        {
-            Descriptor::assignTo(wds, descriptorSet);
-            wds.descriptorCount = static_cast<uint32_t>(_bufferInfos.size());
-            wds.pBufferInfo = _bufferInfos.data();
-            return true;
-        }
+        void compile(Context& context) override;
+
+        bool assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const override;
 
         void copyDataListToBuffers();
 

--- a/include/vsg/vk/Descriptor.h
+++ b/include/vsg/vk/Descriptor.h
@@ -85,19 +85,16 @@ namespace vsg
 
         DescriptorImage(const SamplerImage& samplerImage, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 
-        Sampler* getSampler() { return _samplerImage.first; }
-        const Sampler* getSampler() const { return _samplerImage.first; }
-
-        Data* getImage() { return _samplerImage.second; }
-        const Data* getImage() const { return _samplerImage.second; }
-
-        SamplerImage& getSamplerImage() { return _samplerImage; }
-        const SamplerImage& getSamplerImage() const { return _samplerImage; }
+        DescriptorImage(const SamplerImages& samplerImages, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 
 
-        /** ImageData is automatically filled in by the DecriptorImage::compile() using the sampler and image data objects.*/
-        ImageData& getImageData() { return _imageData; }
-        const ImageData& getImageData() const { return _imageData; }
+        SamplerImages& getSamplerImages() { return _samplerImages; }
+        const SamplerImages& getSamplerImages() const { return _samplerImages; }
+
+        /** ImageDataList is automatically filled in by the DecriptorImage::compile() using the sampler and image data objects.*/
+        ImageDataList& getImageDataList() { return _imageDataList; }
+        const ImageDataList& getImageDataList() const { return _imageDataList; }
+
 
         void read(Input& input) override;
         void write(Output& output) const override;
@@ -106,13 +103,14 @@ namespace vsg
 
         bool assignTo(VkWriteDescriptorSet& wds, VkDescriptorSet descriptorSet) const override;
 
-        uint32_t getNumDescriptors() const override { return 1; }
+        uint32_t getNumDescriptors() const override;
 
     protected:
-        SamplerImage _samplerImage;
+        SamplerImages _samplerImages;
 
-        ImageData _imageData;
-        VkDescriptorImageInfo _imageInfo;
+        // populated by compile()
+        ImageDataList _imageDataList;
+        std::vector<VkDescriptorImageInfo> _imageInfos;
     };
     VSG_type_name(vsg::DescriptorImage)
 

--- a/src/vsg/io/ObjectFactory.cpp
+++ b/src/vsg/io/ObjectFactory.cpp
@@ -169,7 +169,6 @@ ObjectFactory::ObjectFactory()
     VSG_REGISTER_create(vsg::ComputePipeline);
     VSG_REGISTER_create(vsg::ShaderStage);
     VSG_REGISTER_create(vsg::ShaderModule);
-    VSG_REGISTER_create(vsg::Uniform);
     VSG_REGISTER_create(vsg::VertexInputState);
     VSG_REGISTER_create(vsg::InputAssemblyState);
     VSG_REGISTER_create(vsg::RasterizationState);
@@ -189,6 +188,7 @@ ObjectFactory::ObjectFactory()
     VSG_REGISTER_create(vsg::DescriptorSetLayout);
     VSG_REGISTER_create(vsg::DescriptorImage);
     VSG_REGISTER_create(vsg::DescriptorImages);
+    VSG_REGISTER_create(vsg::DescriptorBuffer);
     VSG_REGISTER_create(vsg::Sampler);
 }
 

--- a/src/vsg/vk/Descriptor.cpp
+++ b/src/vsg/vk/Descriptor.cpp
@@ -30,14 +30,14 @@ DescriptorImage::DescriptorImage():
 {
 }
 
-DescriptorImage::DescriptorImage(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, ref_ptr<Sampler> sampler, ref_ptr<Data> image) :
+DescriptorImage::DescriptorImage(ref_ptr<Sampler> sampler, ref_ptr<Data> image, uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType) :
     Inherit(dstBinding, dstArrayElement, descriptorType),
     _samplerImage(sampler, image),
     _imageInfo{0, 0, VK_IMAGE_LAYOUT_UNDEFINED}
 {
 }
 
-DescriptorImage::DescriptorImage(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const SamplerImage& samplerImage) :
+DescriptorImage::DescriptorImage(const SamplerImage& samplerImage, uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType) :
     Inherit(dstBinding, dstArrayElement, descriptorType),
     _samplerImage(samplerImage),
     _imageInfo{0, 0, VK_IMAGE_LAYOUT_UNDEFINED}
@@ -102,7 +102,7 @@ DescriptorImages::DescriptorImages():
 {
 }
 
-DescriptorImages::DescriptorImages(uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType, const SamplerImages& samplerImages) :
+DescriptorImages::DescriptorImages(const SamplerImages& samplerImages, uint32_t dstBinding, uint32_t dstArrayElement, VkDescriptorType descriptorType) :
     Inherit(dstBinding, dstArrayElement, descriptorType),
     _samplerImages(samplerImages)
 {


### PR DESCRIPTION
vsg::DescriptorBuffer has been refactored to enable it to work with vsg::Data, vsg::DataList as well as the original vsg::BufferDataList.  This enables it to be used in place of vsg::Unforim which has been removed.

Changed the parameters order for DescriptorImage and DescriptorBuffer to make it more convenient to create.

Merged the DescriptorImages functionality into DescriptorImage and removed DescriptorImage to reduce the number of classes that have broad overlap in functionality.

Tested with vsgExamples and osg2vsg that required updates to continue building, and tested runtime with various large test models.