### PR TITLE
Converted LOD, MatrixTransform, CullGroup and CullNode across using d…

### DIFF
--- a/include/vsg/maths/sphere.h
+++ b/include/vsg/maths/sphere.h
@@ -60,7 +60,7 @@ namespace vsg
             value{s[0], s[1], s[2], s[3]} {}
 
         template<typename R>
-        constexpr explicit t_sphere(const t_sphere<R>& s) :
+        constexpr t_sphere(const t_sphere<R>& s) :
             value{static_cast<value_type>(s[0]), static_cast<value_type>(s[1]), static_cast<value_type>(s[2]), static_cast<value_type>(s[3])} {}
 
         template<typename R>

--- a/include/vsg/nodes/CullGroup.h
+++ b/include/vsg/nodes/CullGroup.h
@@ -22,18 +22,18 @@ namespace vsg
     public:
         CullGroup(Allocator* allocator = nullptr);
 
-        CullGroup(const sphere& bound, Allocator* allocator = nullptr);
+        CullGroup(const dsphere& bound, Allocator* allocator = nullptr);
 
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void setBound(const sphere& bound) { _bound = bound; }
-        inline const sphere& getBound() const { return _bound; }
+        void setBound(const dsphere& bound) { _bound = bound; }
+        inline const dsphere& getBound() const { return _bound; }
 
     protected:
         virtual ~CullGroup();
 
-        sphere _bound;
+        dsphere _bound;
     };
     VSG_type_name(vsg::CullGroup);
 

--- a/include/vsg/nodes/CullNode.h
+++ b/include/vsg/nodes/CullNode.h
@@ -23,12 +23,9 @@ namespace vsg
     class VSG_DECLSPEC CullNode : public Inherit<Node, CullNode>
     {
     public:
-        using value_type = TRANSFORM_VALUE_TYPE;
-        using Sphere = t_sphere<value_type>;
-
         CullNode(Allocator* allocator = nullptr);
 
-        CullNode(const Sphere& bound, Node* child, Allocator* allocator = nullptr);
+        CullNode(const dsphere& bound, Node* child, Allocator* allocator = nullptr);
 
         void traverse(Visitor& visitor) override { _child->accept(visitor); }
         void traverse(ConstVisitor& visitor) const override { _child->accept(visitor); }
@@ -38,8 +35,8 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void setBound(const Sphere& bound) { _bound = bound; }
-        inline const Sphere& getBound() const { return _bound; }
+        void setBound(const dsphere& bound) { _bound = bound; }
+        inline const dsphere& getBound() const { return _bound; }
 
         void setChild(Node* child) { _child = child; }
         Node* getChild() { return _child; }
@@ -48,7 +45,7 @@ namespace vsg
     protected:
         virtual ~CullNode();
 
-        Sphere _bound;
+        dsphere _bound;
         ref_ptr<vsg::Node> _child;
     };
     VSG_type_name(vsg::CullNode);

--- a/include/vsg/nodes/LOD.h
+++ b/include/vsg/nodes/LOD.h
@@ -34,12 +34,9 @@ namespace vsg
     public:
         LOD(Allocator* allocator = nullptr);
 
-        using value_type = TRANSFORM_VALUE_TYPE;
-        using Sphere = t_sphere<value_type>;
-
         struct LODChild
         {
-            value_type minimumScreenHeightRatio = 0.0; // 0.0 is always visible
+            double minimumScreenHeightRatio = 0.0; // 0.0 is always visible
             ref_ptr<Node> child;
         };
 
@@ -59,8 +56,8 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void setBound(const Sphere& bound) { _bound = bound; }
-        inline const Sphere& getBound() const { return _bound; }
+        void setBound(const dsphere& bound) { _bound = bound; }
+        inline const dsphere& getBound() const { return _bound; }
 
         void setChild(std::size_t pos, const LODChild& lodChild) { _children[pos] = lodChild; }
         LODChild& getChild(std::size_t pos) { return _children[pos]; }
@@ -76,7 +73,7 @@ namespace vsg
     protected:
         virtual ~LOD();
 
-        Sphere _bound;
+        dsphere _bound;
         Children _children;
     };
     VSG_type_name(vsg::LOD);

--- a/include/vsg/nodes/MatrixTransform.h
+++ b/include/vsg/nodes/MatrixTransform.h
@@ -20,24 +20,21 @@ namespace vsg
     class MatrixTransform : public Inherit<Group, MatrixTransform>
     {
     public:
-        using value_type = TRANSFORM_VALUE_TYPE;
-        using Matrix = t_mat4<value_type>;
-
         MatrixTransform(Allocator* allocator = nullptr);
-        MatrixTransform(const Matrix& matrix, Allocator* allocator = nullptr);
+        MatrixTransform(const dmat4& matrix, Allocator* allocator = nullptr);
 
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void setMatrix(const Matrix& matrix) { _matrix = matrix; }
-        Matrix& getMatrix() { return _matrix; }
-        const Matrix& getMatrix() const { return _matrix; }
+        void setMatrix(const dmat4& matrix) { _matrix = matrix; }
+        dmat4& getMatrix() { return _matrix; }
+        const dmat4& getMatrix() const { return _matrix; }
 
         void setSubgraphRequiresLocalFrustum(bool flag) { _subgraphRequiresLocalFrustum = flag; }
         bool getSubgraphRequiresLocalFrustum() const { return _subgraphRequiresLocalFrustum; }
 
     protected:
-        Matrix _matrix;
+        dmat4 _matrix;
         bool _subgraphRequiresLocalFrustum;
     };
     VSG_type_name(vsg::MatrixTransform);

--- a/include/vsg/nodes/Node.h
+++ b/include/vsg/nodes/Node.h
@@ -16,8 +16,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-#define TRANSFORM_VALUE_TYPE float
-
     class VSG_DECLSPEC Node : public Inherit<Object, Node>
     {
     public:

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -26,7 +26,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-#define MATRIX_STACK_TYPE 0
+#define USE_DOUBLE_MATRIX_STACK 1
 
     template<class T>
     class StateStack
@@ -157,6 +157,7 @@ namespace vsg
                 mat4 newmatrix(matrixStack.top());
                 vkCmdPushConstants(commandBuffer, commandBuffer.getCurrentPipelineLayout(), stageFlags, offset, sizeof(newmatrix), newmatrix.data());
 #else
+
                 vkCmdPushConstants(commandBuffer, commandBuffer.getCurrentPipelineLayout(), stageFlags, offset, sizeof(Matrix), matrixStack.top().data());
 #endif
                 dirty = false;

--- a/src/vsg/nodes/CullGroup.cpp
+++ b/src/vsg/nodes/CullGroup.cpp
@@ -20,7 +20,7 @@ CullGroup::CullGroup(Allocator* allocator) :
 {
 }
 
-CullGroup::CullGroup(const sphere& bound, Allocator* allocator) :
+CullGroup::CullGroup(const dsphere& bound, Allocator* allocator) :
     Inherit(allocator)
 {
     _bound = bound;

--- a/src/vsg/nodes/CullNode.cpp
+++ b/src/vsg/nodes/CullNode.cpp
@@ -20,7 +20,7 @@ CullNode::CullNode(Allocator* allocator) :
 {
 }
 
-CullNode::CullNode(const sphere& bound, Node* child, Allocator* allocator) :
+CullNode::CullNode(const dsphere& bound, Node* child, Allocator* allocator) :
     Inherit(allocator),
     _bound(bound),
     _child(child)

--- a/src/vsg/nodes/MatrixTransform.cpp
+++ b/src/vsg/nodes/MatrixTransform.cpp
@@ -21,7 +21,7 @@ MatrixTransform::MatrixTransform(Allocator* allocator) :
 {
 }
 
-MatrixTransform::MatrixTransform(const Matrix& matrix, Allocator* allocator) :
+MatrixTransform::MatrixTransform(const dmat4& matrix, Allocator* allocator) :
     Inherit(allocator),
     _matrix(matrix),
     _subgraphRequiresLocalFrustum(true)


### PR DESCRIPTION
…oubles

## Description

To improve numerical precision when handling large datasets changed MatrixTransform, LOD, CullGroup and CullNode to use doubles for vec and matrices.

This improvement results in a small performance regression (<2%) with scenes with lots of transforms, I've made the decision that this is acceptable tradeoff for avoiding jitter artifacts. 

Fixes # (issue)

Avoid previsions issues when handling large, world scale models.

## Type of change

Please delete options that are not relevant.

- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tested with a range of large city and town models.  Requires all native vsg models to be updated as the format changes.