### PR TITLE
fix compiler warnings for size_t to uint32_t conversion

### DIFF
--- a/src/vsg/vk/ComputePipeline.cpp
+++ b/src/vsg/vk/ComputePipeline.cpp
@@ -98,7 +98,7 @@ ComputePipeline::Implementation::Result ComputePipeline::Implementation::create(
         stageInfo.pSpecializationInfo = &specializationInfo;
 
         // assign the values from the ShaderStage into the specializationInfo
-        specializationInfo.mapEntryCount = shaderStage->getSpecializationMapEntries().size();
+        specializationInfo.mapEntryCount = static_cast<uint32_t>(shaderStage->getSpecializationMapEntries().size());
         specializationInfo.pMapEntries = shaderStage->getSpecializationMapEntries().data();
         specializationInfo.dataSize = shaderStage->getSpecializationData()->dataSize();
         specializationInfo.pData = shaderStage->getSpecializationData()->dataPointer();

--- a/src/vsg/vk/GraphicsPipeline.cpp
+++ b/src/vsg/vk/GraphicsPipeline.cpp
@@ -142,14 +142,14 @@ GraphicsPipeline::Implementation::Result GraphicsPipeline::Implementation::creat
             shaderStageCreateInfo[i].pSpecializationInfo = &specializationInfo;
 
             // assign the values from the ShaderStage into the specializationInfo
-            specializationInfo.mapEntryCount = shaderStage->getSpecializationMapEntries().size();
+            specializationInfo.mapEntryCount = static_cast<uint32_t>(shaderStage->getSpecializationMapEntries().size());
             specializationInfo.pMapEntries = shaderStage->getSpecializationMapEntries().data();
             specializationInfo.dataSize = shaderStage->getSpecializationData()->dataSize();
             specializationInfo.pData = shaderStage->getSpecializationData()->dataPointer();
         }
     }
 
-    pipelineInfo.stageCount = shaderStageCreateInfo.size();
+    pipelineInfo.stageCount = static_cast<uint32_t>(shaderStageCreateInfo.size());
     pipelineInfo.pStages = shaderStageCreateInfo.data();
 
     for (auto pipelineState : pipelineStates)


### PR DESCRIPTION
## Description

fix compile warning in visual studio community 2019 16.1.4
warning C4267: '=': conversion from 'size_t' to 'uint32_t', possible loss of data

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not tested (binary unchanged)

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
