### PR TITLE
remove unnecessary double to float conversion in lod child selection

### DIFF
--- a/src/vsg/traversals/DispatchTraversal.cpp
+++ b/src/vsg/traversals/DispatchTraversal.cpp
@@ -87,9 +87,8 @@ void DispatchTraversal::apply(const LOD& lod)
     const auto& proj = _state->projectionMatrixStack.top();
     const auto& mv = _state->modelviewMatrixStack.top();
     auto f = -proj[1][1];
-    vsg::vec4 lv(mv[0][2], mv[1][2], mv[2][2], mv[3][2]);
 
-    auto distance = std::abs(lv.x * sphere.x + lv.y * sphere.y + lv.z * sphere.z + lv.w);
+    auto distance = std::abs(mv[0][2] * sphere.x + mv[1][2] * sphere.y + mv[2][2] * sphere.z + mv[3][2]);
     auto rf = sphere.r * f;
 
     for (auto lodChild : lod.getChildren())


### PR DESCRIPTION
## Description

fix compile warning in visual studio community 2019 16.1.4
VulkanSceneGraph\src\vsg\traversals\DispatchTraversal.cpp(90,25): warning C4244:  'argument': conversion from 'double' to 'float', possible loss of data

While I guess the values in the modelview matrix should not be of a size that will show a difference between float and double, I understood that the intention is to do the calculations in doubles.
Instead of changing the vector type to vsg::dvec4 I have removed it and use the matrix values directly,
as I don't think the vector helps to explain the calculation.
Laurens.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Not tested

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
