### PR TITLE
transferImageData: use ceil(sampler->info().maxLod) instead of floor(to estimate required number of mipmaps.

### DIFF
--- a/src/vsg/vk/ImageData.cpp
+++ b/src/vsg/vk/ImageData.cpp
@@ -54,7 +54,7 @@ ImageData vsg::transferImageData(Context& context, const Data* data, Sampler* sa
     // copy image data to staging memory
     imageStagingMemory->copy(imageStagingBuffer->getMemoryOffset() + stagingBufferData._offset, imageTotalSize, data->dataPointer());
 
-    uint32_t mipLevels = sampler != nullptr ? sampler->info().maxLod : 1;
+    uint32_t mipLevels = sampler != nullptr ? static_cast<uint32_t>(ceil(sampler->info().maxLod)) : 1;
     if (mipLevels == 0)
     {
         mipLevels = 1;


### PR DESCRIPTION
transferImageData: use ceil(sampler->info().maxLod) instead of floor(to estimate required number of mipmaps.

fix compile warning in visual studio community 2019 16.1.4
VulkanSceneGraph\src\vsg\vk\ImageData.cpp(57,24): warning C4244:  'initializing': conversion from 'float' to 'uint32_t', possible loss of data

## Description

If I understand the vulkan documentation correctly the maximum mip level is limited by the ceil(maxLod), which differs from truncating the float value to an uint32_t.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not tested.

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
