### PR TITLE
minimize surprise truncation when array total size exceed uint_32_t

### DIFF
--- a/include/vsg/core/Array.h
+++ b/include/vsg/core/Array.h
@@ -40,21 +40,21 @@ namespace vsg
         Array() :
             _size(0),
             _data(nullptr) {}
-        Array(std::size_t numElements, value_type* data) :
+        Array(std::uint32_t numElements, value_type* data) :
             _size(numElements),
             _data(data) {}
-        Array(std::size_t numElements, value_type* data, Layout layout) :
+        Array(std::uint32_t numElements, value_type* data, Layout layout) :
             Data(layout),
             _size(numElements),
             _data(data) {}
         explicit Array(std::initializer_list<value_type> l) :
-            _size(l.size()),
+            _size(static_cast<std::uint32_t>(l.size())),
             _data(new value_type[l.size()])
         {
             value_type* ptr = _data;
             for (value_type const& v : l) { (*ptr++) = v; }
         }
-        explicit Array(std::size_t numElements) :
+        explicit Array(std::uint32_t numElements) :
             _size(numElements),
             _data(new value_type[numElements]) {}
 
@@ -83,7 +83,7 @@ namespace vsg
             std::size_t original_total_size = size();
 
             Data::read(input);
-            std::uint32_t width_size = input.readValue<uint32_t>("Size");
+            std::uint32_t width_size = input.readValue<std::uint32_t>("Size");
             std::size_t new_total_size = computeValueCountIncludingMipmaps(width_size, 1, 1, _layout.maxNumMipmaps);
 
             if (input.matchPropertyName("Data"))
@@ -110,7 +110,7 @@ namespace vsg
         void write(Output& output) const override
         {
             Data::write(output);
-            output.writeValue<uint32_t>("Size", _size);
+            output.writeValue<std::uint32_t>("Size", _size);
             output.writePropertyName("Data");
             output.write(size(), _data);
         }
@@ -153,8 +153,8 @@ namespace vsg
         void* dataPointer() override { return _data; }
         const void* dataPointer() const override { return _data; }
 
-        void* dataPointer(size_t i) override { return _data + i; }
-        const void* dataPointer(size_t i) const override { return _data + i; }
+        void* dataPointer(std::size_t i) override { return _data + i; }
+        const void* dataPointer(std::size_t i) const override { return _data + i; }
 
         std::uint32_t width() const override { return _size; }
         std::uint32_t height() const override { return 1; }

--- a/include/vsg/core/Array2D.h
+++ b/include/vsg/core/Array2D.h
@@ -41,19 +41,19 @@ namespace vsg
             _width(0),
             _height(0),
             _data(nullptr) {}
-        Array2D(std::size_t width, std::size_t height, value_type* data) :
+        Array2D(std::uint32_t width, std::uint32_t height, value_type* data) :
             _width(width),
             _height(height),
             _data(data) {}
-        Array2D(std::size_t width, std::size_t height, value_type* data, Layout layout) :
+        Array2D(std::uint32_t width, std::uint32_t height, value_type* data, Layout layout) :
             Data(layout),
             _width(width),
             _height(height),
             _data(data) {}
-        Array2D(std::size_t width, std::size_t height) :
+        Array2D(std::uint32_t width, std::uint32_t height) :
             _width(width),
             _height(height),
-            _data(new value_type[width * height]) {}
+            _data(new value_type[static_cast<std::size_t>(width) * height]) {}
 
         template<typename... Args>
         static ref_ptr<Array2D> create(Args... args)
@@ -74,8 +74,8 @@ namespace vsg
             std::size_t original_size = size();
 
             Data::read(input);
-            std::uint32_t width = input.readValue<uint32_t>("Width");
-            std::uint32_t height = input.readValue<uint32_t>("Height");
+            std::uint32_t width = input.readValue<std::uint32_t>("Width");
+            std::uint32_t height = input.readValue<std::uint32_t>("Height");
             std::size_t new_size = computeValueCountIncludingMipmaps(width, height, 1, _layout.maxNumMipmaps);
             if (input.matchPropertyName("Data"))
             {
@@ -102,13 +102,13 @@ namespace vsg
         void write(Output& output) const override
         {
             Data::write(output);
-            output.writeValue<uint32_t>("Width", _width);
-            output.writeValue<uint32_t>("Height", _height);
+            output.writeValue<std::uint32_t>("Width", _width);
+            output.writeValue<std::uint32_t>("Height", _height);
             output.writePropertyName("Data");
             output.write(valueCount(), _data);
         }
 
-        std::size_t size() const { return (_layout.maxNumMipmaps <= 1) ? (_width * _height) : computeValueCountIncludingMipmaps(_width, _height, 1, _layout.maxNumMipmaps); }
+        std::size_t size() const { return (_layout.maxNumMipmaps <= 1) ? static_cast<std::size_t>(_width) * _height : computeValueCountIncludingMipmaps(_width, _height, 1, _layout.maxNumMipmaps); }
 
         bool empty() const { return _width == 0 && _height == 0; }
 
@@ -148,8 +148,8 @@ namespace vsg
         void* dataPointer() override { return _data; }
         const void* dataPointer() const override { return _data; }
 
-        void* dataPointer(size_t i) override { return _data + i; }
-        const void* dataPointer(size_t i) const override { return _data + i; }
+        void* dataPointer(std::size_t i) override { return _data + i; }
+        const void* dataPointer(std::size_t i) const override { return _data + i; }
 
         std::uint32_t width() const override { return _width; }
         std::uint32_t height() const override { return _height; }
@@ -158,7 +158,7 @@ namespace vsg
         value_type* data() { return _data; }
         const value_type* data() const { return _data; }
 
-        size_t index(std::uint32_t i, std::uint32_t j) const noexcept { return i + j * _width; }
+        std::size_t index(std::uint32_t i, std::uint32_t j) const noexcept { return static_cast<std::size_t>(j) * _width + i; }
 
         value_type& operator[](std::size_t i) { return _data[i]; }
         const value_type& operator[](std::size_t i) const { return _data[i]; }

--- a/include/vsg/core/Array3D.h
+++ b/include/vsg/core/Array3D.h
@@ -42,22 +42,22 @@ namespace vsg
             _height(0),
             _depth(0),
             _data(nullptr) {}
-        Array3D(std::size_t width, std::size_t height, std::size_t depth, value_type* data) :
+        Array3D(std::uint32_t width, std::uint32_t height, std::uint32_t depth, value_type* data) :
             _width(width),
             _height(height),
             _depth(depth),
             _data(data) {}
-        Array3D(std::size_t width, std::size_t height, std::size_t depth, value_type* data, Layout layout) :
+        Array3D(std::uint32_t width, std::uint32_t height, std::uint32_t depth, value_type* data, Layout layout) :
             Data(layout),
             _width(width),
             _height(height),
             _depth(depth),
             _data(data) {}
-        Array3D(std::size_t width, std::size_t height, std::size_t depth) :
+        Array3D(std::uint32_t width, std::uint32_t height, std::uint32_t depth) :
             _width(width),
             _height(height),
             _depth(depth),
-            _data(new value_type[width * height * depth]) {}
+            _data(new value_type[static_cast<std::size_t>(width) * height * depth]) {}
 
         template<typename... Args>
         static ref_ptr<Array3D> create(Args... args)
@@ -78,9 +78,9 @@ namespace vsg
             std::size_t original_size = size();
 
             Data::read(input);
-            std::uint32_t width = input.readValue<uint32_t>("Width");
-            std::uint32_t height = input.readValue<uint32_t>("Height");
-            std::uint32_t depth = input.readValue<uint32_t>("Depth");
+            std::uint32_t width = input.readValue<std::uint32_t>("Width");
+            std::uint32_t height = input.readValue<std::uint32_t>("Height");
+            std::uint32_t depth = input.readValue<std::uint32_t>("Depth");
             std::size_t new_size = computeValueCountIncludingMipmaps(width, height, depth, _layout.maxNumMipmaps);
             if (input.matchPropertyName("Data"))
             {
@@ -108,14 +108,14 @@ namespace vsg
         void write(Output& output) const override
         {
             Data::write(output);
-            output.writeValue<uint32_t>("Width", _width);
-            output.writeValue<uint32_t>("Height", _height);
-            output.writeValue<uint32_t>("Depth", _depth);
+            output.writeValue<std::uint32_t>("Width", _width);
+            output.writeValue<std::uint32_t>("Height", _height);
+            output.writeValue<std::uint32_t>("Depth", _depth);
             output.writePropertyName("Data");
             output.write(valueCount(), _data);
         }
 
-        std::size_t size() const { return (_layout.maxNumMipmaps <= 1) ? (_width * _height * _depth) : computeValueCountIncludingMipmaps(_width, _height, _depth, _layout.maxNumMipmaps); }
+        std::size_t size() const { return (_layout.maxNumMipmaps <= 1) ? (static_cast<std::size_t>(_width) * _height * _depth) : computeValueCountIncludingMipmaps(_width, _height, _depth, _layout.maxNumMipmaps); }
 
         bool empty() const { return _width == 0 && _height == 0 && _depth == 0; }
 
@@ -158,8 +158,8 @@ namespace vsg
         void* dataPointer() override { return _data; }
         const void* dataPointer() const override { return _data; }
 
-        void* dataPointer(size_t i) override { return _data + i; }
-        const void* dataPointer(size_t i) const override { return _data + i; }
+        void* dataPointer(std::size_t i) override { return _data + i; }
+        const void* dataPointer(std::size_t i) const override { return _data + i; }
 
         std::uint32_t width() const override { return _width; }
         std::uint32_t height() const override { return _height; }
@@ -168,7 +168,7 @@ namespace vsg
         value_type* data() { return _data; }
         const value_type* data() const { return _data; }
 
-        size_t index(std::uint32_t i, std::uint32_t j, std::uint32_t k) const noexcept { return i + j * _width + k * (_width * _height); }
+        std::size_t index(std::uint32_t i, std::uint32_t j, std::uint32_t k) const noexcept {return static_cast<std::size_t>(k) * _width * _height + static_cast<std::size_t>(j) * _width + i; }
 
         value_type& operator[](std::size_t i) { return _data[i]; }
         const value_type& operator[](std::size_t i) const { return _data[i]; }

--- a/src/vsg/core/Data.cpp
+++ b/src/vsg/core/Data.cpp
@@ -51,7 +51,7 @@ Data::MipmapOffsets Data::computeMipmapOffsets() const
     offsets.push_back(lastPosition);
     while (numMipmaps > 1 && (w > 1 || h > 1 || d > 1))
     {
-        lastPosition += (w * h * d);
+        lastPosition += (static_cast<std::size_t>(w) * h * d);
         offsets.push_back(lastPosition);
 
         --numMipmaps;

--- a/src/vsg/core/Data.cpp
+++ b/src/vsg/core/Data.cpp
@@ -43,15 +43,15 @@ Data::MipmapOffsets Data::computeMipmapOffsets() const
     MipmapOffsets offsets;
     if (numMipmaps == 0) return offsets;
 
-    auto w = width();
-    auto h = height();
-    auto d = depth();
+    std::size_t w = width();
+    std::size_t h = height();
+    std::size_t d = depth();
 
     std::size_t lastPosition = 0;
     offsets.push_back(lastPosition);
     while (numMipmaps > 1 && (w > 1 || h > 1 || d > 1))
     {
-        lastPosition += (static_cast<std::size_t>(w) * h * d);
+        lastPosition += (w * h * d);
         offsets.push_back(lastPosition);
 
         --numMipmaps;


### PR DESCRIPTION
minimize surprise truncation when array dimension exceed uint32_t (illegal) or when total size exceed uint_32_t (legal)

# Pull Request Template

## Description

As the width,height and depth of arrays are stored internally as uint32_t I think they should not be passed to the constructors as size_t - as the truncation on 64 bit programs gets hidden from the user.
This change causes 2 compile warnings in vsgExamples' Desktop/vsginput/Text.cpp when calling vsg::vec4Array::create(_glyphs.size()), I'll create a PR to fix that.

For the index(), size() and computeMipmapOffsets() I added a cast to make the calculations in 64 bit, to avoid overflow if (width * height) exceed 32 bits - which seems valid usage on 64bit systems. On 32 bit systems this will still fail, (with size_t being 32 bits) but I suppose you'll be out of memory first, so I felt no need to guard against that.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Compiled osg2vsg, vsgExamples and vsgXchange 
with visual studio community 2019 (16.1.5) on windows 10 Enterprise 1803
- New warning when compiling vsgExamples
VSG\include\vsg/core/Array.h(63,1): warning C4267:  'argument': conversion from 'size_t' to 'uint32_t', possible loss of data
vsgExamples\Desktop\vsginput\Text.cpp(232): message :  see reference to function template instantiation 'vsg::ref_ptr<vsg::Array<vsg::vec4>> vsg::Array<vsg::vec4>::create<unsigned __int64>(unsigned __int64)' being compiled
repeated same warning for vsgExamples\Desktop\vsginput\Text.cpp(235)

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [- ] I have commented my code, particularly in hard-to-understand areas
- [- ] My changes generate no new warnings
