### PR TITLE
Fixed <experimental/any> warning on macOS

### DIFF
--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -12,11 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#if __APPLE__
-#    include <experimental/any>
-#else
-#    include <any>
-#endif
+#include <any>
 
 #include <vsg/ui/UIEvent.h>
 
@@ -29,12 +25,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-
-#if __APPLE__
-    using std_any = std::experimental::any;
-#else
-    using std_any = std::any;
-#endif
 
     class VSG_DECLSPEC Window : public Inherit<Object, Window>
     {
@@ -86,7 +76,7 @@ namespace vsg
 
             AllocationCallbacks* allocator = nullptr;
 
-            std_any nativeHandle;
+            std::any nativeHandle;
             void* nativeWindow;
 
         protected:


### PR DESCRIPTION
Using latest macOS (`10.14.5 (18F132)`), XCode (`10.2.1 (10E1001)`) and clang (`Apple LLVM version 10.0.1 (clang-1001.0.46.4)`), I'm getting the following warning:

```c++
#if defined(_LIBCPP_WARN_ON_DEPRECATED_EXPERIMENTAL_HEADER)
#  warning "<experimental/any> is deprecated and will be removed in the next release. Please use C++17's <any> instead."
#endif
```

VulkanSceneGraph, OSG2VSG, vsgXChange and vsgExamples can be build with this change, all examples run without any problems on my system.