### PR TITLE
Fix for binary files not reading properly

### DIFF
--- a/src/vsg/io/ReaderWriter_vsg.cpp
+++ b/src/vsg/io/ReaderWriter_vsg.cpp
@@ -70,7 +70,7 @@ vsg::ref_ptr<vsg::Object> ReaderWriter_vsg::read(const vsg::Path& filename, ref_
     auto ext = vsg::fileExtension(filename);
     if ((ext=="vsga" || ext=="vsgt" || ext=="vsgb") && vsg::fileExists(filename))
     {
-        std::ifstream fin(filename);
+        std::ifstream fin(filename, std::ios::in | std::ios::binary);
         FormatType type = readHeader(fin);
         if (type == BINARY)
         {
@@ -98,12 +98,12 @@ vsg::ref_ptr<vsg::Object> ReaderWriter_vsg::read(std::istream& fin, vsg::ref_ptr
     FormatType type = readHeader(fin);
     if (type == BINARY)
     {
-        vsg::AsciiInput input(fin, _objectFactory, options);
+        vsg::BinaryInput input(fin, _objectFactory, options);
         return input.readObject("Root");
     }
     else if (type == ASCII)
     {
-        vsg::BinaryInput input(fin, _objectFactory, options);
+        vsg::AsciiInput input(fin, _objectFactory, options);
         return input.readObject("Root");
     }
 


### PR DESCRIPTION

## Description

Binary files have stopped reading properly due to the ifstream mode flag not being set to binary as it was previously. However now we're trying to determine the file type from it's header the ifstream is already open before we know what type to use. For now I've hard coded it as binary and text files still seem to work ok but I'm not sure if it's 100% safe.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Exported and loaded a vsgb and vsga files from vsgUnity. Both are now saving and loading