### PR TITLE
Refactored Object, Auxliary to use a std::mutex in Auxiliary to prote…

### DIFF
--- a/include/vsg/core/Auxiliary.h
+++ b/include/vsg/core/Auxiliary.h
@@ -16,6 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/ref_ptr.h>
 
 #include <map>
+#include <mutex>
 
 namespace vsg
 {
@@ -24,6 +25,8 @@ namespace vsg
     class VSG_DECLSPEC Auxiliary
     {
     public:
+        std::mutex& getMutex() const { return _mutex; }
+
         Object* getConnectedObject() { return _connectedObject; }
         const Object* getConnectedObject() const { return _connectedObject; }
 
@@ -61,7 +64,10 @@ namespace vsg
         friend class Allocator;
 
         mutable std::atomic_uint _referenceCount;
-        std::atomic<Object*> _connectedObject;
+
+        mutable std::mutex _mutex;
+        Object* _connectedObject;
+
         ref_ptr<Allocator> _allocator;
         ObjectMap _objectMap;
     };

--- a/include/vsg/core/Object.h
+++ b/include/vsg/core/Object.h
@@ -65,7 +65,7 @@ namespace vsg
         inline void ref() const noexcept { _referenceCount.fetch_add(1, std::memory_order_relaxed); }
         inline void unref() const noexcept
         {
-            if (_referenceCount.fetch_sub(1, std::memory_order_seq_cst) <= 1) _delete();
+            if (_referenceCount.fetch_sub(1, std::memory_order_seq_cst) <= 1) _attemptDelete();
         }
         inline void unref_nodelete() const noexcept { _referenceCount.fetch_sub(1, std::memory_order_seq_cst); }
         inline unsigned int referenceCount() const noexcept { return _referenceCount.load(); }
@@ -93,7 +93,7 @@ namespace vsg
     protected:
         virtual ~Object();
 
-        virtual void _delete() const;
+        virtual void _attemptDelete() const;
         void setAuxiliary(Auxiliary* auxiliary);
 
     private:

--- a/include/vsg/core/observer_ptr.h
+++ b/include/vsg/core/observer_ptr.h
@@ -21,27 +21,32 @@ namespace vsg
     class observer_ptr
     {
     public:
-        observer_ptr() {}
+        observer_ptr() :
+            _ptr(nullptr) {}
 
         observer_ptr(const observer_ptr& rhs) :
+            _ptr(rhs._ptr),
             _auxiliary(rhs._auxiliary)
         {
         }
 
         template<class R>
         explicit observer_ptr(R* ptr) :
+            _ptr(ptr),
             _auxiliary(ptr ? ptr->getOrCreateUniqueAuxiliary() : nullptr)
         {
         }
 
         template<class R>
         explicit observer_ptr(const observer_ptr<R>& ptr) :
+            _ptr(ptr._ptr),
             _auxiliary(ptr._auxiliary)
         {
         }
 
         template<class R>
         explicit observer_ptr(const ref_ptr<R>& ptr) :
+            _ptr(ptr.get()),
             _auxiliary(ptr.valid() ? ptr->getOrCreateUniqueAuxiliary() : nullptr)
         {
         }
@@ -53,12 +58,14 @@ namespace vsg
         template<class R>
         observer_ptr& operator=(R* ptr)
         {
+            _ptr = ptr;
             _auxiliary = ptr ? ptr->getOrCreateUniqueAuxiliary() : nullptr;
             return *this;
         }
 
         observer_ptr& operator=(const observer_ptr& rhs)
         {
+            _ptr = rhs._ptr;
             _auxiliary = rhs._auxiliary;
             return *this;
         }
@@ -66,6 +73,7 @@ namespace vsg
         template<class R>
         observer_ptr& operator=(const observer_ptr<R>& rhs)
         {
+            _ptr = rhs._ptr;
             _auxiliary = rhs._auxiliary;
             return *this;
         }
@@ -73,6 +81,7 @@ namespace vsg
         template<class R>
         observer_ptr& operator=(const ref_ptr<R>& rhs)
         {
+            _ptr = rhs.get();
             _auxiliary = rhs.valid() ? rhs->getOrCreateUniqueAuxiliary() : nullptr;
             return *this;
         }
@@ -85,14 +94,20 @@ namespace vsg
         template<class R>
         operator ref_ptr<R>() const
         {
-            if (!_auxiliary.valid()) return ref_ptr<R>();
-            return ref_ptr<R>(static_cast<T*>(_auxiliary->getConnectedObject()));
+            if (!_auxiliary) return ref_ptr<R>();
+
+            std::lock_guard<std::mutex> guard(_auxiliary->getMutex());
+            if (_auxiliary->getConnectedObject() != nullptr)
+                return ref_ptr<R>(_ptr);
+            else
+                ref_ptr<R>();
         }
 
     protected:
         template<class R>
         friend class observer_ptr;
 
+        T* _ptr;
         ref_ptr<Auxiliary> _auxiliary;
     };
 

--- a/include/vsg/io/AsciiInput.h
+++ b/include/vsg/io/AsciiInput.h
@@ -15,8 +15,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/Object.h>
 
 #include <vsg/io/Input.h>
-#include <vsg/io/Options.h>
 #include <vsg/io/ObjectFactory.h>
+#include <vsg/io/Options.h>
 
 #include <fstream>
 

--- a/include/vsg/io/AsciiOutput.h
+++ b/include/vsg/io/AsciiOutput.h
@@ -12,8 +12,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/io/Output.h>
 #include <vsg/io/Options.h>
+#include <vsg/io/Output.h>
 
 #include <algorithm>
 #include <fstream>

--- a/include/vsg/io/BinaryOutput.h
+++ b/include/vsg/io/BinaryOutput.h
@@ -12,8 +12,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/io/Output.h>
 #include <vsg/io/Options.h>
+#include <vsg/io/Output.h>
 
 #include <fstream>
 

--- a/include/vsg/io/ReaderWriter.h
+++ b/include/vsg/io/ReaderWriter.h
@@ -13,8 +13,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/core/Inherit.h>
-#include <vsg/io/Options.h>
 #include <vsg/io/FileSystem.h>
+#include <vsg/io/Options.h>
 
 namespace vsg
 {
@@ -45,10 +45,8 @@ namespace vsg
         /// write object to specified file, return true on success, return false on failure.
         virtual bool write(const vsg::Object* /*object*/, const vsg::Path& /*filename*/, vsg::ref_ptr<const vsg::Options> = {}) const { return false; }
         virtual bool write(const vsg::Object* /*object*/, std::ostream& /*fout*/, vsg::ref_ptr<const vsg::Options> = {}) const { return false; }
-
     };
     VSG_type_name(vsg::ReaderWriter);
-
 
     class VSG_DECLSPEC CompositeReaderWriter : public Inherit<ReaderWriter, CompositeReaderWriter>
     {

--- a/src/vsg/core/Object.cpp
+++ b/src/vsg/core/Object.cpp
@@ -55,7 +55,7 @@ Object::~Object()
     }
 }
 
-void Object::_delete() const
+void Object::_attemptDelete() const
 {
     // what should happen when _delete is called on an Object with ref() of zero?  Need to decide whether this buggy application usage should be tested for.
 


### PR DESCRIPTION
…ct the Auxiliar::_connectedObject

## Description

Refactored observer_ptr<> to store a local C pointer to enable support for classes that use virtual inheritance where static_cast<> can't be used to get the type of interest.
Ran clang-format to standardize formatting

Fixes # (issue)

Thread safety of use of vsg::observert_ptr<>
Ability of vsg::observer_ptr<> to handle classes that use virtual inheritance.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Test with modified versions of vsgExamples/Core/vsgio that tested use of classes that have multiple inheritance and virtual inheritance.