### PR TITLE
vsg::External feature for reading/writing vsg::Objects from/to external files

### DIFF
--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -21,6 +21,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/ConstVisitor.h>
 #include <vsg/core/Data.h>
 #include <vsg/core/Export.h>
+#include <vsg/core/External.h>
 #include <vsg/core/Inherit.h>
 #include <vsg/core/Object.h>
 #include <vsg/core/Objects.h>

--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -19,8 +19,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    // forward declare Objects
+    // forward declare core Objects
     class Objects;
+    class External;
 
     // forward declare nodes classes
     class Node;
@@ -91,6 +92,7 @@ namespace vsg
 
         virtual void apply(const Object&);
         virtual void apply(const Objects&);
+        virtual void apply(const External&);
 
         // Values
         virtual void apply(const stringValue&);

--- a/include/vsg/core/External.h
+++ b/include/vsg/core/External.h
@@ -1,0 +1,57 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/core/Inherit.h>
+#include <vsg/core/ref_ptr.h>
+
+namespace vsg
+{
+    VSG_type_name(vsg::External);
+
+    class VSG_DECLSPEC External : public Inherit<Object, External>
+    {
+    public:
+        External();
+        External(const std::string& filename, ref_ptr<Object> object);
+        External(Allocator* allocator);
+
+        template<class N, class V>
+        static void t_traverse(N& node, V& visitor)
+        {
+            if (node._object) node._object->accept(visitor);
+        }
+
+        void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
+        void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(DispatchTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(CullTraversal& visitor) const override { t_traverse(*this, visitor); }
+
+        void read(Input& input) override;
+        void write(Output& output) const override;
+
+        void setFilename(const std::string& filename) { _filename = filename; }
+        std::string getFilename() const { return _filename; }
+
+        void setObject(ref_ptr<Object> object) { _object = object; }
+        Object* getObject() { return _object; }
+        const Object* getObject() const { return _object; }
+
+    protected:
+        virtual ~External();
+
+        std::string _filename;
+        ref_ptr<Object> _object;
+    };
+
+} // namespace vsg

--- a/include/vsg/core/External.h
+++ b/include/vsg/core/External.h
@@ -15,6 +15,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/Inherit.h>
 #include <vsg/core/ref_ptr.h>
 
+#include <vsg/io/FileSystem.h>
+
 namespace vsg
 {
     VSG_type_name(vsg::External);
@@ -40,8 +42,8 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void setFilename(const std::string& filename) { _filename = filename; }
-        std::string getFilename() const { return _filename; }
+        void setFilename(const Path& filename) { _filename = filename; }
+        const Path& getFilename() const { return _filename; }
 
         void setObject(ref_ptr<Object> object) { _object = object; }
         Object* getObject() { return _object; }
@@ -50,7 +52,7 @@ namespace vsg
     protected:
         virtual ~External();
 
-        std::string _filename;
+        Path _filename;
         ref_ptr<Object> _object;
     };
 

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -19,8 +19,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    // forward declare Objects
+    // forward declare core Objects
     class Objects;
+    class External;
 
     // forward declare nodes classes
     class Node;
@@ -91,6 +92,7 @@ namespace vsg
 
         virtual void apply(Object&);
         virtual void apply(Objects&);
+        virtual void apply(External&);
 
         // Values
         virtual void apply(stringValue&);

--- a/include/vsg/core/observer_ptr.h
+++ b/include/vsg/core/observer_ptr.h
@@ -86,9 +86,9 @@ namespace vsg
             return *this;
         }
 
-        bool valid() const { return _auxiliary.valid() && _auxiliary->getConnectedObject() != nullptr; }
+        bool valid() const noexcept { return _auxiliary.valid() && _auxiliary->getConnectedObject() != nullptr; }
 
-        explicit operator bool() const { return valid(); }
+        explicit operator bool() const noexcept { return valid(); }
 
         /// convert observer_ptr into a ref_ptr so that Object that pointed to can be safely accessed.
         template<class R>

--- a/include/vsg/core/observer_ptr.h
+++ b/include/vsg/core/observer_ptr.h
@@ -100,7 +100,7 @@ namespace vsg
             if (_auxiliary->getConnectedObject() != nullptr)
                 return ref_ptr<R>(_ptr);
             else
-                ref_ptr<R>();
+                return {};
         }
 
     protected:

--- a/include/vsg/io/AsciiInput.h
+++ b/include/vsg/io/AsciiInput.h
@@ -94,7 +94,7 @@ namespace vsg
         vsg::ref_ptr<vsg::Object> read() override;
 
         // read object from file
-        virtual ref_ptr<Object> readFile(const Path& path);
+        ref_ptr<Object> readFile(const Path& path) override;
 
     protected:
         std::istream& _input;

--- a/include/vsg/io/AsciiInput.h
+++ b/include/vsg/io/AsciiInput.h
@@ -93,6 +93,9 @@ namespace vsg
         // read object
         vsg::ref_ptr<vsg::Object> read() override;
 
+        // read object from file
+        virtual ref_ptr<Object> readFile(const Path& path);
+
     protected:
         std::istream& _input;
         ref_ptr<const Options> _options;

--- a/include/vsg/io/AsciiOutput.h
+++ b/include/vsg/io/AsciiOutput.h
@@ -117,6 +117,9 @@ namespace vsg
         // write object
         void write(const vsg::Object* object) override;
 
+        // write external file if reqquired
+        virtual void writeFile(const Object* object, const Path& path);
+
     protected:
         std::ostream& _output;
         ref_ptr<const Options> _options;

--- a/include/vsg/io/AsciiOutput.h
+++ b/include/vsg/io/AsciiOutput.h
@@ -118,7 +118,7 @@ namespace vsg
         void write(const vsg::Object* object) override;
 
         // write external file if reqquired
-        virtual void writeFile(const Object* object, const Path& path);
+        bool writeFile(const Object* object, const Path& path) override;
 
     protected:
         std::ostream& _output;

--- a/include/vsg/io/BinaryInput.h
+++ b/include/vsg/io/BinaryInput.h
@@ -63,6 +63,9 @@ namespace vsg
         // read object
         vsg::ref_ptr<vsg::Object> read() override;
 
+        // read object from file
+        virtual ref_ptr<Object> readFile(const Path& path);
+
     protected:
         std::istream& _input;
         ref_ptr<const Options> _options;

--- a/include/vsg/io/BinaryInput.h
+++ b/include/vsg/io/BinaryInput.h
@@ -64,7 +64,7 @@ namespace vsg
         vsg::ref_ptr<vsg::Object> read() override;
 
         // read object from file
-        virtual ref_ptr<Object> readFile(const Path& path);
+        ref_ptr<Object> readFile(const Path& path) override;
 
     protected:
         std::istream& _input;

--- a/include/vsg/io/BinaryOutput.h
+++ b/include/vsg/io/BinaryOutput.h
@@ -58,6 +58,9 @@ namespace vsg
         // write object
         void write(const vsg::Object* object) override;
 
+        // write external file if reqquired
+        virtual void writeFile(const Object* object, const Path& path);
+
     protected:
         std::ostream& _output;
         ref_ptr<const Options> _options;

--- a/include/vsg/io/BinaryOutput.h
+++ b/include/vsg/io/BinaryOutput.h
@@ -59,7 +59,7 @@ namespace vsg
         void write(const vsg::Object* object) override;
 
         // write external file if reqquired
-        virtual void writeFile(const Object* object, const Path& path);
+        bool writeFile(const Object* object, const Path& path) override;
 
     protected:
         std::ostream& _output;

--- a/include/vsg/io/Input.h
+++ b/include/vsg/io/Input.h
@@ -75,6 +75,12 @@ namespace vsg
         void read(size_t num, ubvec2* value) { read(num * value->size(), value->data()); }
         void read(size_t num, ubvec3* value) { read(num * value->size(), value->data()); }
         void read(size_t num, ubvec4* value) { read(num * value->size(), value->data()); }
+        void read(size_t num, usvec2* value) { read(num * value->size(), value->data()); }
+        void read(size_t num, usvec3* value) { read(num * value->size(), value->data()); }
+        void read(size_t num, usvec4* value) { read(num * value->size(), value->data()); }
+        void read(size_t num, uivec2* value) { read(num * value->size(), value->data()); }
+        void read(size_t num, uivec3* value) { read(num * value->size(), value->data()); }
+        void read(size_t num, uivec4* value) { read(num * value->size(), value->data()); }
         void read(size_t num, mat4* value) { read(num * value->size(), value->data()); }
         void read(size_t num, dmat4* value) { read(num * value->size(), value->data()); }
         void read(size_t num, sphere* value) { read(num * value->size(), value->data()); }
@@ -135,7 +141,7 @@ namespace vsg
         }
 
         using ObjectID = uint32_t;
-        using ObjectIDMap = std::unordered_map<ObjectID, ref_ptr<Object>>;
+        using ObjectIDMap = std::map<ObjectID, ref_ptr<Object>>;
         ObjectIDMap& getObjectIDMap() { return _objectIDMap; }
         const ObjectIDMap& getObjectIDMap() const { return _objectIDMap; }
 

--- a/include/vsg/io/Input.h
+++ b/include/vsg/io/Input.h
@@ -24,6 +24,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/maths/vec4.h>
 
 #include <vsg/io/ObjectFactory.h>
+#include <vsg/io/FileSystem.h>
 
 #include <unordered_map>
 
@@ -56,6 +57,9 @@ namespace vsg
 
         // read object
         virtual ref_ptr<Object> read() = 0;
+
+        // read object from file
+        virtual ref_ptr<Object> readFile(const Path& path) = 0;
 
         // map char to int8_t
         void read(size_t num, char* value) { read(num, reinterpret_cast<int8_t*>(value)); }

--- a/include/vsg/io/Options.h
+++ b/include/vsg/io/Options.h
@@ -13,21 +13,26 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/core/Inherit.h>
+#include <vsg/core/observer_ptr.h>
 #include <vsg/io/FileSystem.h>
 
 namespace vsg
 {
 
+    class FileCache;
+    class ObjectCache;
+    class ReaderWriter;
+
     class Options : public Inherit<Object, Options>
     {
     public:
         Options();
-        // TODO:
-        //    add support for FileCache
-        //    add support for ObjectCache
-        //    add support for Finding paths
-        //    add support for Reading nested files
-        //    add support for Writing nested files
+
+        observer_ptr<FileCache> fileCache;
+        observer_ptr<ObjectCache> objectCache;
+        observer_ptr<ReaderWriter> readerWriter;
+
+        Paths paths;
     };
     VSG_type_name(vsg::Options);
 

--- a/include/vsg/io/Output.h
+++ b/include/vsg/io/Output.h
@@ -53,7 +53,7 @@ namespace vsg
         virtual void write(const Object* object) = 0;
 
         // write external file if reqquired
-        virtual void writeFile(const Object* object, const Path& path) = 0;
+        virtual bool writeFile(const Object* object, const Path& path) = 0;
 
         // map char to int8_t
         void write(size_t num, const char* value) { write(num, reinterpret_cast<const int8_t*>(value)); }

--- a/include/vsg/io/Output.h
+++ b/include/vsg/io/Output.h
@@ -69,6 +69,12 @@ namespace vsg
         void write(size_t num, const ubvec2* value) { write(num * value->size(), value->data()); }
         void write(size_t num, const ubvec3* value) { write(num * value->size(), value->data()); }
         void write(size_t num, const ubvec4* value) { write(num * value->size(), value->data()); }
+        void write(size_t num, const usvec2* value) { write(num * value->size(), value->data()); }
+        void write(size_t num, const usvec3* value) { write(num * value->size(), value->data()); }
+        void write(size_t num, const usvec4* value) { write(num * value->size(), value->data()); }
+        void write(size_t num, const uivec2* value) { write(num * value->size(), value->data()); }
+        void write(size_t num, const uivec3* value) { write(num * value->size(), value->data()); }
+        void write(size_t num, const uivec4* value) { write(num * value->size(), value->data()); }
         void write(size_t num, const mat4* value) { write(num * value->size(), value->data()); }
         void write(size_t num, const dmat4* value) { write(num * value->size(), value->data()); }
         void write(size_t num, const sphere* value) { write(num * value->size(), value->data()); }
@@ -105,9 +111,16 @@ namespace vsg
             write(propertyName, v);
         }
 
-    protected:
         using ObjectID = uint32_t;
+        void setObjectID(ObjectID id) { _objectID = id; }
+        ObjectID getObjectID() const { return _objectID; }
+
+
         using ObjectIDMap = std::unordered_map<const vsg::Object*, ObjectID>;
+        ObjectIDMap& getObjectIDMap() { return _objectIDMap; }
+        const ObjectIDMap& getObjectIDMap() const { return _objectIDMap; }
+
+    protected:
 
         ObjectIDMap _objectIDMap;
         ObjectID _objectID = 0;

--- a/include/vsg/io/Output.h
+++ b/include/vsg/io/Output.h
@@ -23,6 +23,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/maths/vec3.h>
 #include <vsg/maths/vec4.h>
 
+#include <vsg/io/FileSystem.h>
+
 #include <unordered_map>
 
 namespace vsg
@@ -49,6 +51,9 @@ namespace vsg
 
         // write object
         virtual void write(const Object* object) = 0;
+
+        // write external file if reqquired
+        virtual void writeFile(const Object* object, const Path& path) = 0;
 
         // map char to int8_t
         void write(size_t num, const char* value) { write(num, reinterpret_cast<const int8_t*>(value)); }

--- a/include/vsg/io/ReaderWriter.h
+++ b/include/vsg/io/ReaderWriter.h
@@ -64,4 +64,10 @@ namespace vsg
     };
     VSG_type_name(vsg::CompositeReaderWriter);
 
+    /** convience method for reading objects from file.*/
+    ref_ptr<Object> readFile(const Path& path, ref_ptr<const Options> options = {});
+
+    /** convience method for writing objects to file.*/
+    bool writeFile(const Object* object, const Path& path, ref_ptr<const Options> options = {});
+
 } // namespace vsg

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     core/Auxiliary.cpp
     core/ConstVisitor.cpp
     core/Data.cpp
+    core/External.cpp
     core/Object.cpp
     core/Objects.cpp
     core/Result.cpp

--- a/src/vsg/core/ConstVisitor.cpp
+++ b/src/vsg/core/ConstVisitor.cpp
@@ -12,6 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/core/ConstVisitor.h>
 #include <vsg/core/Objects.h>
+#include <vsg/core/External.h>
 
 #include <vsg/nodes/Commands.h>
 #include <vsg/nodes/CullGroup.h>
@@ -52,6 +53,11 @@ void ConstVisitor::apply(const Object&)
 void ConstVisitor::apply(const Objects& value)
 {
     apply(static_cast<const Object&>(value));
+}
+
+void ConstVisitor::apply(const External& value)
+{
+    apply(static_cast<const External&>(value));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/vsg/core/External.cpp
+++ b/src/vsg/core/External.cpp
@@ -1,0 +1,62 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/core/External.h>
+
+#include <vsg/io/Input.h>
+#include <vsg/io/Output.h>
+
+using namespace vsg;
+
+External::External()
+{
+}
+
+External::External(Allocator* allocator) :
+    Inherit(allocator)
+{
+}
+
+External::External(const std::string& filename, ref_ptr<Object> object):
+    _filename(filename),
+    _object(object)
+{
+}
+
+External::~External()
+{
+}
+
+void External::read(Input& input)
+{
+    Object::read(input);
+
+    input.read("Filename", _filename);
+
+    if (!_filename.empty())
+    {
+        // if we need to invoke ReaderWriter for it.
+
+    }
+}
+
+void External::write(Output& output) const
+{
+    Object::write(output);
+
+    output.write("Filename", _filename);
+
+    // if we should write out object then need to invoke ReaderWriter for it.
+    // if (!_filename.empty())
+    // {
+    // }
+}

--- a/src/vsg/core/External.cpp
+++ b/src/vsg/core/External.cpp
@@ -44,8 +44,7 @@ void External::read(Input& input)
 
     if (!_filename.empty())
     {
-        // if we need to invoke ReaderWriter for it.
-
+        _object = input.readFile(_filename);
     }
 }
 
@@ -56,7 +55,8 @@ void External::write(Output& output) const
     output.write("Filename", _filename);
 
     // if we should write out object then need to invoke ReaderWriter for it.
-    // if (!_filename.empty())
-    // {
-    // }
+    if (!_filename.empty() && _object.valid())
+    {
+        output.writeFile(_object, _filename);
+    }
 }

--- a/src/vsg/core/Visitor.cpp
+++ b/src/vsg/core/Visitor.cpp
@@ -10,8 +10,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/core/Objects.h>
 #include <vsg/core/Visitor.h>
+#include <vsg/core/Objects.h>
+#include <vsg/core/External.h>
 
 #include <vsg/nodes/Commands.h>
 #include <vsg/nodes/CullGroup.h>
@@ -52,6 +53,11 @@ void Visitor::apply(Object&)
 void Visitor::apply(Objects& value)
 {
     apply(static_cast<Object&>(value));
+}
+
+void Visitor::apply(External& value)
+{
+    apply(static_cast<External&>(value));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/vsg/io/AsciiInput.cpp
+++ b/src/vsg/io/AsciiInput.cpp
@@ -158,3 +158,9 @@ vsg::ref_ptr<vsg::Object> AsciiInput::read()
     }
     return vsg::ref_ptr<vsg::Object>();
 }
+
+ref_ptr<Object> AsciiInput::readFile(const Path& path)
+{
+    std::cout<<"AsciiInput::readFile("<<path<<")"<<std::endl;
+    return {};
+}

--- a/src/vsg/io/AsciiInput.cpp
+++ b/src/vsg/io/AsciiInput.cpp
@@ -11,6 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/io/AsciiInput.h>
+#include <vsg/io/ReaderWriter.h>
 
 #include <cstring>
 #include <iostream>
@@ -161,6 +162,5 @@ vsg::ref_ptr<vsg::Object> AsciiInput::read()
 
 ref_ptr<Object> AsciiInput::readFile(const Path& path)
 {
-    std::cout<<"AsciiInput::readFile("<<path<<")"<<std::endl;
-    return {};
+    return vsg::readFile(path, _options);
 }

--- a/src/vsg/io/AsciiOutput.cpp
+++ b/src/vsg/io/AsciiOutput.cpp
@@ -13,6 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/Version.h>
 
 #include <vsg/io/AsciiOutput.h>
+#include <vsg/io/ReaderWriter.h>
 
 #include <cstring>
 #include <iostream>
@@ -81,7 +82,7 @@ void AsciiOutput::write(const vsg::Object* object)
     }
 }
 
-void AsciiOutput::writeFile(const Object* object, const Path& path)
+bool AsciiOutput::writeFile(const Object* object, const Path& path)
 {
-    std::cout<<"AsciiOutput::writeFile("<<path<<")"<<std::endl;
+    return vsg::writeFile(object, path, _options);
 }

--- a/src/vsg/io/AsciiOutput.cpp
+++ b/src/vsg/io/AsciiOutput.cpp
@@ -15,6 +15,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/AsciiOutput.h>
 
 #include <cstring>
+#include <iostream>
 
 using namespace vsg;
 
@@ -78,4 +79,9 @@ void AsciiOutput::write(const vsg::Object* object)
     {
         _output << " id=" << id << " nullptr\n";
     }
+}
+
+void AsciiOutput::writeFile(const Object* object, const Path& path)
+{
+    std::cout<<"AsciiOutput::writeFile("<<path<<")"<<std::endl;
 }

--- a/src/vsg/io/BinaryInput.cpp
+++ b/src/vsg/io/BinaryInput.cpp
@@ -78,3 +78,9 @@ vsg::ref_ptr<vsg::Object> BinaryInput::read()
         return object;
     }
 }
+
+ref_ptr<Object> BinaryInput::readFile(const Path& path)
+{
+    std::cout<<"BinaryInput::readFile("<<path<<")"<<std::endl;
+    return {};
+}

--- a/src/vsg/io/BinaryInput.cpp
+++ b/src/vsg/io/BinaryInput.cpp
@@ -11,6 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/io/BinaryInput.h>
+#include <vsg/io/ReaderWriter.h>
 
 #include <cstring>
 #include <iostream>
@@ -81,6 +82,5 @@ vsg::ref_ptr<vsg::Object> BinaryInput::read()
 
 ref_ptr<Object> BinaryInput::readFile(const Path& path)
 {
-    std::cout<<"BinaryInput::readFile("<<path<<")"<<std::endl;
-    return {};
+    return vsg::readFile(path, _options);
 }

--- a/src/vsg/io/BinaryOutput.cpp
+++ b/src/vsg/io/BinaryOutput.cpp
@@ -13,6 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/Version.h>
 
 #include <vsg/io/BinaryOutput.h>
+#include <vsg/io/ReaderWriter.h>
 
 #include <cstring>
 #include <iostream>
@@ -65,7 +66,7 @@ void BinaryOutput::write(const vsg::Object* object)
     }
 }
 
-void BinaryOutput::writeFile(const Object* object, const Path& path)
+bool BinaryOutput::writeFile(const Object* object, const Path& path)
 {
-    std::cout<<"BinaryOutput::writeFile("<<path<<")"<<std::endl;
+    return vsg::writeFile(object, path, _options);
 }

--- a/src/vsg/io/BinaryOutput.cpp
+++ b/src/vsg/io/BinaryOutput.cpp
@@ -15,6 +15,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/BinaryOutput.h>
 
 #include <cstring>
+#include <iostream>
 
 using namespace vsg;
 
@@ -62,4 +63,9 @@ void BinaryOutput::write(const vsg::Object* object)
     {
         _write(std::string("nullptr"));
     }
+}
+
+void BinaryOutput::writeFile(const Object* object, const Path& path)
+{
+    std::cout<<"BinaryOutput::writeFile("<<path<<")"<<std::endl;
 }

--- a/src/vsg/io/ObjectFactory.cpp
+++ b/src/vsg/io/ObjectFactory.cpp
@@ -16,6 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/Array2D.h>
 #include <vsg/core/Array3D.h>
 #include <vsg/core/Objects.h>
+#include <vsg/core/External.h>
 #include <vsg/core/Value.h>
 
 #include <vsg/nodes/Commands.h>
@@ -54,6 +55,7 @@ ObjectFactory::ObjectFactory()
 
     VSG_REGISTER_new(vsg::Object);
     VSG_REGISTER_new(vsg::Objects);
+    VSG_REGISTER_new(vsg::External);
 
     // values
     VSG_REGISTER_new(vsg::stringValue);

--- a/src/vsg/io/ReaderWriter.cpp
+++ b/src/vsg/io/ReaderWriter.cpp
@@ -15,6 +15,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/BinaryInput.h>
 #include <vsg/io/BinaryOutput.h>
 #include <vsg/io/ReaderWriter.h>
+#include <vsg/io/ReaderWriter_vsg.h>
 
 using namespace vsg;
 
@@ -39,4 +40,48 @@ bool CompositeReaderWriter::write(const vsg::Object* object, const vsg::Path& fi
         if (writer->write(object, filename, options)) return true;
     }
     return false;
+}
+
+ref_ptr<Object> vsg::readFile(const Path& path, ref_ptr<const Options> options)
+{
+    if (options)
+    {
+        ref_ptr<ReaderWriter> rw = options->readerWriter;
+        if (rw)
+        {
+            auto object = rw->read(path, options);
+            if (object) return object;
+        }
+    }
+
+    auto ext = vsg::fileExtension(path);
+    if (ext == "vsga" || ext == "vsgt" || ext == "vsgb")
+    {
+        ReaderWriter_vsg rw;
+        return rw.read(path, options);
+    }
+
+    return {};
+}
+
+bool vsg::writeFile(const Object* object, const Path& path, ref_ptr<const Options> options)
+{
+    if (options)
+    {
+        ref_ptr<ReaderWriter> rw = options->readerWriter;
+        if (rw)
+        {
+            if (rw->write(object, path, options)) return true;
+        }
+    }
+
+    auto ext = vsg::fileExtension(path);
+    if (ext == "vsga" || ext == "vsgt" || ext == "vsgb")
+    {
+        ReaderWriter_vsg rw;
+        return rw.write(object, path, options);
+    }
+
+    return false;
+
 }


### PR DESCRIPTION
# Pull Request Template

## Description

To enable sharing of state between separately loaded files vsg::External class has been added that allows users to collect vsg::Objects that they want to be grouped together and stored in an external file that can be later loaded.

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested with an osg2vsg --external command line option that puts arrays into a vsg::External and has this written out to disk or read on loading.