### PR TITLE
Added vsg::ObjectCache class for caching data loaded from files.

### DIFF
--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -131,6 +131,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/BinaryOutput.h>
 #include <vsg/io/FileSystem.h>
 #include <vsg/io/Input.h>
+#include <vsg/io/ObjectCache.h>
 #include <vsg/io/ObjectFactory.h>
 #include <vsg/io/Options.h>
 #include <vsg/io/Output.h>

--- a/include/vsg/io/AsciiOutput.h
+++ b/include/vsg/io/AsciiOutput.h
@@ -117,8 +117,7 @@ namespace vsg
         // write object
         void write(const vsg::Object* object) override;
 
-        // write external file if reqquired
-        bool writeFile(const Object* object, const Path& path) override;
+        bool writeFile(ref_ptr<Object> object, const Path& path) override;
 
     protected:
         std::ostream& _output;

--- a/include/vsg/io/AsciiOutput.h
+++ b/include/vsg/io/AsciiOutput.h
@@ -114,10 +114,11 @@ namespace vsg
 
         void write(size_t num, const std::string* value) override;
 
-        // write object
+        /// write object
         void write(const vsg::Object* object) override;
 
-        bool writeFile(ref_ptr<Object> object, const Path& path) override;
+        /// write external file if reqquired
+        bool write(ref_ptr<Object> object, const Path& filename) override;
 
     protected:
         std::ostream& _output;

--- a/include/vsg/io/BinaryOutput.h
+++ b/include/vsg/io/BinaryOutput.h
@@ -58,8 +58,7 @@ namespace vsg
         // write object
         void write(const vsg::Object* object) override;
 
-        // write external file if reqquired
-        bool writeFile(const Object* object, const Path& path) override;
+        bool writeFile(ref_ptr<Object> object, const Path& path) override;
 
     protected:
         std::ostream& _output;

--- a/include/vsg/io/BinaryOutput.h
+++ b/include/vsg/io/BinaryOutput.h
@@ -55,10 +55,11 @@ namespace vsg
 
         void write(size_t num, const std::string* value) override;
 
-        // write object
+        /// write object
         void write(const vsg::Object* object) override;
 
-        bool writeFile(ref_ptr<Object> object, const Path& path) override;
+        /// write external file if reqquired
+        bool write(ref_ptr<Object> object, const Path& filename) override;
 
     protected:
         std::ostream& _output;

--- a/include/vsg/io/FileSystem.h
+++ b/include/vsg/io/FileSystem.h
@@ -20,8 +20,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
+    class Options;
     using Path = std::string;
-
     using Paths = std::vector<Path>;
 
     extern VSG_DECLSPEC Paths getEnvPaths(const char* env_var);
@@ -35,5 +35,7 @@ namespace vsg
     extern VSG_DECLSPEC Path concatPaths(const Path& left, const Path& right);
 
     extern VSG_DECLSPEC Path findFile(const Path& filename, const Paths& paths);
+
+    extern VSG_DECLSPEC Path findFile(const Path& filename, const Options* options);
 
 } // namespace vsg

--- a/include/vsg/io/Input.h
+++ b/include/vsg/io/Input.h
@@ -23,8 +23,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/maths/vec3.h>
 #include <vsg/maths/vec4.h>
 
-#include <vsg/io/ObjectFactory.h>
 #include <vsg/io/FileSystem.h>
+#include <vsg/io/ObjectFactory.h>
 
 #include <unordered_map>
 

--- a/include/vsg/io/ObjectCache.h
+++ b/include/vsg/io/ObjectCache.h
@@ -15,6 +15,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/Inherit.h>
 #include <vsg/io/FileSystem.h>
 #include <vsg/io/Options.h>
+#include <vsg/ui/UIEvent.h>
 
 namespace vsg
 {
@@ -23,18 +24,29 @@ namespace vsg
     {
     public:
 
-        using FilenameOption = std::pair<Path, ref_ptr<const Options>>;
-        using ObjectCacheMap = std::map<FilenameOption, ref_ptr<Object>>;
+        void setDefaultUnusedDuration(double duration) { _defaultUnusedDuration = duration; }
+        double getDefaultUnusedDuration() const { return _defaultUnusedDuration; }
+
+        /// remove any objects that no longer have an external referneces from cache.that are are haven't been referenced within their expiry time
+        void removeExpiredUnusedObjects();
+
+        /// remove all objects from cache
+        void clear();
 
         /// get entry from ObjectCache that matches filename and option. return null when no object matches.
-        ref_ptr<Object> get(const Path& filename, ref_ptr<const Options> options = {}) const;
+        ref_ptr<Object> get(const Path& filename, ref_ptr<const Options> options = {});
 
         /// add entry from ObjectCache that matches filename and option.
         void add(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options = {});
 
     protected:
 
+        using FilenameOption = std::pair<Path, ref_ptr<const Options>>;
+        using ObjectTimepoint = std::tuple<ref_ptr<Object>, double, clock::time_point>;
+        using ObjectCacheMap = std::map<FilenameOption, ObjectTimepoint>;
+
         mutable std::mutex _mutex;
+        double _defaultUnusedDuration = 1.0;
         ObjectCacheMap _objectCacheMap;
     };
     VSG_type_name(vsg::ObjectCache);

--- a/include/vsg/io/ObjectCache.h
+++ b/include/vsg/io/ObjectCache.h
@@ -33,11 +33,20 @@ namespace vsg
         /// remove all objects from cache
         void clear();
 
+        /// check if a cache entry contains an entry for specificied filename.
+        bool contains(const Path& filename, ref_ptr<const Options> options = {});
+
         /// get entry from ObjectCache that matches filename and option. return null when no object matches.
         ref_ptr<Object> get(const Path& filename, ref_ptr<const Options> options = {});
 
         /// add entry from ObjectCache that matches filename and option.
         void add(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options = {});
+
+        /// remove entry matching filename and option.
+        void remove(const Path& filename, ref_ptr<const Options> options = {});
+
+        /// remove entry matching object.
+        void remove(ref_ptr<Object> object);
 
     protected:
 

--- a/include/vsg/io/ObjectCache.h
+++ b/include/vsg/io/ObjectCache.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/core/Inherit.h>
+#include <vsg/io/FileSystem.h>
+#include <vsg/io/Options.h>
+
+namespace vsg
+{
+
+    class ObjectCache : public Inherit<Object, ObjectCache>
+    {
+    public:
+
+        using FilenameOption = std::pair<Path, ref_ptr<const Options>>;
+        using ObjectCacheMap = std::map<FilenameOption, ref_ptr<Object>>;
+
+        /// get entry from ObjectCache that matches filename and option. return null when no object matches.
+        ref_ptr<Object> get(const Path& filename, ref_ptr<const Options> options = {}) const;
+
+        /// add entry from ObjectCache that matches filename and option.
+        void add(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options = {});
+
+    protected:
+
+        mutable std::mutex _mutex;
+        ObjectCacheMap _objectCacheMap;
+    };
+    VSG_type_name(vsg::ObjectCache);
+
+} // namespace vsg

--- a/include/vsg/io/ObjectCache.h
+++ b/include/vsg/io/ObjectCache.h
@@ -23,7 +23,6 @@ namespace vsg
     class ObjectCache : public Inherit<Object, ObjectCache>
     {
     public:
-
         void setDefaultUnusedDuration(double duration) { _defaultUnusedDuration = duration; }
         double getDefaultUnusedDuration() const { return _defaultUnusedDuration; }
 
@@ -49,7 +48,6 @@ namespace vsg
         void remove(ref_ptr<Object> object);
 
     protected:
-
         struct ObjectTimepoint
         {
             ref_ptr<Object> object;

--- a/include/vsg/io/ObjectCache.h
+++ b/include/vsg/io/ObjectCache.h
@@ -41,12 +41,18 @@ namespace vsg
 
     protected:
 
+        struct ObjectTimepoint
+        {
+            ref_ptr<Object> object;
+            double unusedDurationBeforeExpiry = 0.0;
+            clock::time_point lastUsedTimepoint;
+        };
+
         using FilenameOption = std::pair<Path, ref_ptr<const Options>>;
-        using ObjectTimepoint = std::tuple<ref_ptr<Object>, double, clock::time_point>;
         using ObjectCacheMap = std::map<FilenameOption, ObjectTimepoint>;
 
         mutable std::mutex _mutex;
-        double _defaultUnusedDuration = 1.0;
+        double _defaultUnusedDuration = 0.0;
         ObjectCacheMap _objectCacheMap;
     };
     VSG_type_name(vsg::ObjectCache);

--- a/include/vsg/io/Options.h
+++ b/include/vsg/io/Options.h
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    class FileCache;
+    //class FileCache;
     class ObjectCache;
     class ReaderWriter;
 
@@ -27,12 +27,17 @@ namespace vsg
     {
     public:
         Options();
+        Options(const Options& options);
+        Options& operator=(const Options& rhs) = delete;
 
-        observer_ptr<FileCache> fileCache;
-        observer_ptr<ObjectCache> objectCache;
-        observer_ptr<ReaderWriter> readerWriter;
+        //ref_ptr<FileCache> fileCache;
+        ref_ptr<ObjectCache> objectCache;
+        ref_ptr<ReaderWriter> readerWriter;
 
         Paths paths;
+
+    protected:
+        virtual ~Options();
     };
     VSG_type_name(vsg::Options);
 

--- a/include/vsg/io/Output.h
+++ b/include/vsg/io/Output.h
@@ -53,7 +53,7 @@ namespace vsg
         virtual void write(const Object* object) = 0;
 
         // write external file if reqquired
-        virtual bool writeFile(const Object* object, const Path& path) = 0;
+        virtual bool writeFile(ref_ptr<Object> object, const Path& path) = 0;
 
         // map char to int8_t
         void write(size_t num, const char* value) { write(num, reinterpret_cast<const int8_t*>(value)); }

--- a/include/vsg/io/Output.h
+++ b/include/vsg/io/Output.h
@@ -49,13 +49,13 @@ namespace vsg
         virtual void write(size_t num, const double* value) = 0;
         virtual void write(size_t num, const std::string* value) = 0;
 
-        // write object
+        /// write object
         virtual void write(const Object* object) = 0;
 
-        // write external file if reqquired
-        virtual bool writeFile(ref_ptr<Object> object, const Path& path) = 0;
+        /// write external file if reqquired
+        virtual bool write(ref_ptr<Object> object, const Path& filename) = 0;
 
-        // map char to int8_t
+        /// map char to int8_t
         void write(size_t num, const char* value) { write(num, reinterpret_cast<const int8_t*>(value)); }
         void write(size_t num, const bool* value) { write(num, reinterpret_cast<const int8_t*>(value)); }
 

--- a/include/vsg/io/Output.h
+++ b/include/vsg/io/Output.h
@@ -115,13 +115,11 @@ namespace vsg
         void setObjectID(ObjectID id) { _objectID = id; }
         ObjectID getObjectID() const { return _objectID; }
 
-
         using ObjectIDMap = std::unordered_map<const vsg::Object*, ObjectID>;
         ObjectIDMap& getObjectIDMap() { return _objectIDMap; }
         const ObjectIDMap& getObjectIDMap() const { return _objectIDMap; }
 
     protected:
-
         ObjectIDMap _objectIDMap;
         ObjectID _objectID = 0;
     };

--- a/include/vsg/io/ReaderWriter.h
+++ b/include/vsg/io/ReaderWriter.h
@@ -65,16 +65,16 @@ namespace vsg
     VSG_type_name(vsg::CompositeReaderWriter);
 
     /** convience method for reading objects from file.*/
-    ref_ptr<Object> read(const Path& path, ref_ptr<const Options> options = {});
+    ref_ptr<Object> read(const Path& filename, ref_ptr<const Options> options = {});
 
     template<class T>
-    ref_ptr<T> read_cast(const Path& path, ref_ptr<const Options> options = {})
+    ref_ptr<T> read_cast(const Path& filename, ref_ptr<const Options> options = {})
     {
-        auto object = read(path, options);
+        auto object = read(filename, options);
         return vsg::ref_ptr<T>(dynamic_cast<T*>(object.get()));
     }
 
     /** convience method for writing objects to file.*/
-    bool writeFile(ref_ptr<Object> object, const Path& path, ref_ptr<const Options> options = {});
+    bool write(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options = {});
 
 } // namespace vsg

--- a/include/vsg/io/ReaderWriter.h
+++ b/include/vsg/io/ReaderWriter.h
@@ -65,7 +65,7 @@ namespace vsg
     VSG_type_name(vsg::CompositeReaderWriter);
 
     /** convience method for reading objects from file.*/
-    ref_ptr<Object> read(const Path& filename, ref_ptr<const Options> options = {});
+    extern VSG_DECLSPEC ref_ptr<Object> read(const Path& filename, ref_ptr<const Options> options = {});
 
     template<class T>
     ref_ptr<T> read_cast(const Path& filename, ref_ptr<const Options> options = {})
@@ -75,6 +75,6 @@ namespace vsg
     }
 
     /** convience method for writing objects to file.*/
-    bool write(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options = {});
+    extern VSG_DECLSPEC bool write(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options = {});
 
 } // namespace vsg

--- a/include/vsg/io/ReaderWriter.h
+++ b/include/vsg/io/ReaderWriter.h
@@ -65,7 +65,14 @@ namespace vsg
     VSG_type_name(vsg::CompositeReaderWriter);
 
     /** convience method for reading objects from file.*/
-    ref_ptr<Object> readFile(const Path& path, ref_ptr<const Options> options = {});
+    ref_ptr<Object> read(const Path& path, ref_ptr<const Options> options = {});
+
+    template<class T>
+    ref_ptr<T> read_cast(const Path& path, ref_ptr<const Options> options = {})
+    {
+        auto object = read(path, options);
+        return vsg::ref_ptr<T>(dynamic_cast<T*>(object.get()));
+    }
 
     /** convience method for writing objects to file.*/
     bool writeFile(const Object* object, const Path& path, ref_ptr<const Options> options = {});

--- a/include/vsg/io/ReaderWriter.h
+++ b/include/vsg/io/ReaderWriter.h
@@ -75,6 +75,6 @@ namespace vsg
     }
 
     /** convience method for writing objects to file.*/
-    bool writeFile(const Object* object, const Path& path, ref_ptr<const Options> options = {});
+    bool writeFile(ref_ptr<Object> object, const Path& path, ref_ptr<const Options> options = {});
 
 } // namespace vsg

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCES
     io/BinaryInput.cpp
     io/BinaryOutput.cpp
     io/Input.cpp
+    io/ObjectCache.cpp
     io/Output.cpp
     io/Options.cpp
     io/ObjectFactory.cpp

--- a/src/vsg/core/ConstVisitor.cpp
+++ b/src/vsg/core/ConstVisitor.cpp
@@ -11,8 +11,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/core/ConstVisitor.h>
-#include <vsg/core/Objects.h>
 #include <vsg/core/External.h>
+#include <vsg/core/Objects.h>
 
 #include <vsg/nodes/Commands.h>
 #include <vsg/nodes/CullGroup.h>

--- a/src/vsg/core/External.cpp
+++ b/src/vsg/core/External.cpp
@@ -107,7 +107,7 @@ void External::write(Output& output) const
     // if we should write out object then need to invoke ReaderWriter for it.
     if (!_filename.empty() && _object)
     {
-        output.writeFile(_object, _filename);
+        output.write(_object, _filename);
 
         CollectIDs collectIDs;
         collectIDs._objectID = idBegin;

--- a/src/vsg/core/External.cpp
+++ b/src/vsg/core/External.cpp
@@ -10,8 +10,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/core/External.h>
 #include <vsg/core/ConstVisitor.h>
+#include <vsg/core/External.h>
 
 #include <vsg/io/Input.h>
 #include <vsg/io/Output.h>
@@ -35,7 +35,6 @@ public:
             ObjectID id = _objectID++;
             _objectIDMap[&object] = id;
             object.traverse(*this);
-
         }
     }
 
@@ -44,9 +43,7 @@ public:
 
     ObjectID _objectID = 0;
     ObjectIDMap _objectIDMap;
-
 };
-
 
 External::External()
 {
@@ -57,7 +54,7 @@ External::External(Allocator* allocator) :
 {
 }
 
-External::External(const std::string& filename, ref_ptr<Object> object):
+External::External(const std::string& filename, ref_ptr<Object> object) :
     _filename(filename),
     _object(object)
 {
@@ -85,7 +82,7 @@ void External::read(Input& input)
             collectIDs._objectID = idBegin;
             _object->accept(collectIDs);
 
-            for(auto [object, objectID] : collectIDs._objectIDMap)
+            for (auto [object, objectID] : collectIDs._objectIDMap)
             {
                 if ((idBegin <= objectID) && (objectID < idEnd))
                 {
@@ -93,13 +90,11 @@ void External::read(Input& input)
                 }
                 else
                 {
-                    std::cout<<"External::read() : warning object out of ObjectIDRange "<<objectID<<", "<<object<<std::endl;
+                    std::cout << "External::read() : warning object out of ObjectIDRange " << objectID << ", " << object << std::endl;
                 }
             }
         }
     }
-
-
 }
 
 void External::write(Output& output) const
@@ -118,7 +113,7 @@ void External::write(Output& output) const
         collectIDs._objectID = idBegin;
         _object->accept(collectIDs);
 
-        for(auto [object, objectID] : collectIDs._objectIDMap)
+        for (auto [object, objectID] : collectIDs._objectIDMap)
         {
             output.getObjectIDMap()[object] = objectID;
         }
@@ -129,5 +124,4 @@ void External::write(Output& output) const
 
     output.write("ObjectIDRange", idBegin, idEnd);
     output.write("Filename", _filename);
-
 }

--- a/src/vsg/core/Visitor.cpp
+++ b/src/vsg/core/Visitor.cpp
@@ -10,9 +10,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/core/Visitor.h>
-#include <vsg/core/Objects.h>
 #include <vsg/core/External.h>
+#include <vsg/core/Objects.h>
+#include <vsg/core/Visitor.h>
 
 #include <vsg/nodes/Commands.h>
 #include <vsg/nodes/CullGroup.h>

--- a/src/vsg/io/AsciiInput.cpp
+++ b/src/vsg/io/AsciiInput.cpp
@@ -162,5 +162,5 @@ vsg::ref_ptr<vsg::Object> AsciiInput::read()
 
 ref_ptr<Object> AsciiInput::readFile(const Path& path)
 {
-    return vsg::readFile(path, _options);
+    return vsg::read(path, _options);
 }

--- a/src/vsg/io/AsciiOutput.cpp
+++ b/src/vsg/io/AsciiOutput.cpp
@@ -82,7 +82,7 @@ void AsciiOutput::write(const vsg::Object* object)
     }
 }
 
-bool AsciiOutput::writeFile(ref_ptr<Object> object, const Path& path)
+bool AsciiOutput::write(ref_ptr<Object> object, const Path& filename)
 {
-    return vsg::writeFile(object, path, _options);
+    return vsg::write(object, filename, _options);
 }

--- a/src/vsg/io/AsciiOutput.cpp
+++ b/src/vsg/io/AsciiOutput.cpp
@@ -82,7 +82,7 @@ void AsciiOutput::write(const vsg::Object* object)
     }
 }
 
-bool AsciiOutput::writeFile(const Object* object, const Path& path)
+bool AsciiOutput::writeFile(ref_ptr<Object> object, const Path& path)
 {
     return vsg::writeFile(object, path, _options);
 }

--- a/src/vsg/io/BinaryInput.cpp
+++ b/src/vsg/io/BinaryInput.cpp
@@ -82,5 +82,5 @@ vsg::ref_ptr<vsg::Object> BinaryInput::read()
 
 ref_ptr<Object> BinaryInput::readFile(const Path& path)
 {
-    return vsg::readFile(path, _options);
+    return vsg::read(path, _options);
 }

--- a/src/vsg/io/BinaryOutput.cpp
+++ b/src/vsg/io/BinaryOutput.cpp
@@ -66,7 +66,7 @@ void BinaryOutput::write(const vsg::Object* object)
     }
 }
 
-bool BinaryOutput::writeFile(ref_ptr<Object> object, const Path& path)
+bool BinaryOutput::write(ref_ptr<Object> object, const Path& filename)
 {
-    return vsg::writeFile(object, path, _options);
+    return vsg::write(object, filename, _options);
 }

--- a/src/vsg/io/BinaryOutput.cpp
+++ b/src/vsg/io/BinaryOutput.cpp
@@ -66,7 +66,7 @@ void BinaryOutput::write(const vsg::Object* object)
     }
 }
 
-bool BinaryOutput::writeFile(const Object* object, const Path& path)
+bool BinaryOutput::writeFile(ref_ptr<Object> object, const Path& path)
 {
     return vsg::writeFile(object, path, _options);
 }

--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -11,6 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/io/FileSystem.h>
+#include <vsg/io/Options.h>
 
 #if defined(WIN32) && !defined(__CYGWIN__)
 #    include <cstdlib>
@@ -139,4 +140,16 @@ Path vsg::findFile(const Path& filename, const Paths& paths)
         }
     }
     return Path();
+}
+
+Path vsg::findFile(const Path& filename, const Options* options)
+{
+    if (options && !options->paths.empty())
+    {
+        return findFile(filename, options->paths);
+    }
+    else
+    {
+        return fileExists(filename) ? filename : Path();
+    }
 }

--- a/src/vsg/io/ObjectCache.cpp
+++ b/src/vsg/io/ObjectCache.cpp
@@ -10,8 +10,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/io/ObjectCache.h>
 #include <iostream>
+#include <vsg/io/ObjectCache.h>
 
 using namespace vsg;
 
@@ -21,11 +21,11 @@ void ObjectCache::removeExpiredUnusedObjects()
     auto time = vsg::clock::now();
 
     std::lock_guard<std::mutex> guard(_mutex);
-    for(auto itr = _objectCacheMap.begin(); itr != _objectCacheMap.end();)
+    for (auto itr = _objectCacheMap.begin(); itr != _objectCacheMap.end();)
     {
         auto current_itr = itr++;
         ObjectTimepoint& ot = current_itr->second;
-        if (ot.object->referenceCount()>1)
+        if (ot.object->referenceCount() > 1)
         {
             ot.lastUsedTimepoint = time;
         }
@@ -98,21 +98,20 @@ void ObjectCache::remove(const Path& filename, ref_ptr<const Options> options)
     }
 }
 
-
 void ObjectCache::remove(ref_ptr<Object> object)
 {
-    std::cout<<"ObjectCache::remove("<<object.get()<<") "<<_objectCacheMap.size()<<std::endl;
+    std::cout << "ObjectCache::remove(" << object.get() << ") " << _objectCacheMap.size() << std::endl;
 
     std::lock_guard<std::mutex> guard(_mutex);
 
-    for(auto itr = _objectCacheMap.begin(); itr != _objectCacheMap.end();)
+    for (auto itr = _objectCacheMap.begin(); itr != _objectCacheMap.end();)
     {
         auto current_itr = itr++;
         if (current_itr->second.object == object)
         {
-            std::cout<<"    removing "<<object.get()<<" "<<current_itr->first.first<<std::endl;
+            std::cout << "    removing " << object.get() << " " << current_itr->first.first << std::endl;
             _objectCacheMap.erase(current_itr);
         }
     }
-    std::cout<<"after ObjectCache::remove("<<object.get()<<") "<<_objectCacheMap.size()<<std::endl;
+    std::cout << "after ObjectCache::remove(" << object.get() << ") " << _objectCacheMap.size() << std::endl;
 }

--- a/src/vsg/io/ObjectCache.cpp
+++ b/src/vsg/io/ObjectCache.cpp
@@ -10,14 +10,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <iostream>
 #include <vsg/io/ObjectCache.h>
 
 using namespace vsg;
 
 void ObjectCache::removeExpiredUnusedObjects()
 {
-    // TODO get current timestamp to use as a reference for expiry
     auto time = vsg::clock::now();
 
     std::lock_guard<std::mutex> guard(_mutex);
@@ -31,7 +29,6 @@ void ObjectCache::removeExpiredUnusedObjects()
         }
         else
         {
-            // TODO need to check if expired
             auto timeSinceLasUsed = std::chrono::duration<double, std::chrono::seconds::period>(time - ot.lastUsedTimepoint).count();
             if (timeSinceLasUsed > ot.unusedDurationBeforeExpiry)
             {
@@ -100,8 +97,6 @@ void ObjectCache::remove(const Path& filename, ref_ptr<const Options> options)
 
 void ObjectCache::remove(ref_ptr<Object> object)
 {
-    std::cout << "ObjectCache::remove(" << object.get() << ") " << _objectCacheMap.size() << std::endl;
-
     std::lock_guard<std::mutex> guard(_mutex);
 
     for (auto itr = _objectCacheMap.begin(); itr != _objectCacheMap.end();)
@@ -109,9 +104,7 @@ void ObjectCache::remove(ref_ptr<Object> object)
         auto current_itr = itr++;
         if (current_itr->second.object == object)
         {
-            std::cout << "    removing " << object.get() << " " << current_itr->first.first << std::endl;
             _objectCacheMap.erase(current_itr);
         }
     }
-    std::cout << "after ObjectCache::remove(" << object.get() << ") " << _objectCacheMap.size() << std::endl;
 }

--- a/src/vsg/io/ObjectCache.cpp
+++ b/src/vsg/io/ObjectCache.cpp
@@ -1,0 +1,43 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/io/ObjectCache.h>
+
+using namespace vsg;
+
+ref_ptr<Object> ObjectCache::get(const Path& filename, ref_ptr<const Options> options) const
+{
+    std::lock_guard<std::mutex> guard(_mutex);
+
+    FilenameOption filenameOption(filename, options);
+    if (auto itr = _objectCacheMap.find(filenameOption); itr != _objectCacheMap.end())
+    {
+        return itr->second;
+    }
+    else
+    {
+        return ref_ptr<Object>();
+    }
+}
+
+void ObjectCache::add(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options)
+{
+    std::lock_guard<std::mutex> guard(_mutex);
+
+    FilenameOption filenameOption(filename, options);
+    if (auto itr = _objectCacheMap.find(filenameOption); itr == _objectCacheMap.end())
+    {
+        _objectCacheMap[filenameOption] = object;
+    }
+}
+
+

--- a/src/vsg/io/ObjectFactory.cpp
+++ b/src/vsg/io/ObjectFactory.cpp
@@ -15,8 +15,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/Array.h>
 #include <vsg/core/Array2D.h>
 #include <vsg/core/Array3D.h>
-#include <vsg/core/Objects.h>
 #include <vsg/core/External.h>
+#include <vsg/core/Objects.h>
 #include <vsg/core/Value.h>
 
 #include <vsg/nodes/Commands.h>

--- a/src/vsg/io/Options.cpp
+++ b/src/vsg/io/Options.cpp
@@ -11,13 +11,23 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/io/Options.h>
-
-using namespace vsg;
-
-#include <vsg/io/Options.h>
+#include <vsg/io/ObjectCache.h>
+#include <vsg/io/ReaderWriter.h>
 
 using namespace vsg;
 
 Options::Options()
+{
+}
+
+Options::Options(const Options& options) :
+    Inherit(),
+//    fileCache(options.fileCache),
+    objectCache(options.objectCache),
+    readerWriter(options.readerWriter)
+{
+}
+
+Options::~Options()
 {
 }

--- a/src/vsg/io/Options.cpp
+++ b/src/vsg/io/Options.cpp
@@ -10,8 +10,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/io/Options.h>
 #include <vsg/io/ObjectCache.h>
+#include <vsg/io/Options.h>
 #include <vsg/io/ReaderWriter.h>
 
 using namespace vsg;
@@ -22,7 +22,7 @@ Options::Options()
 
 Options::Options(const Options& options) :
     Inherit(),
-//    fileCache(options.fileCache),
+    //    fileCache(options.fileCache),
     objectCache(options.objectCache),
     readerWriter(options.readerWriter)
 {

--- a/src/vsg/io/ReaderWriter.cpp
+++ b/src/vsg/io/ReaderWriter.cpp
@@ -90,7 +90,7 @@ ref_ptr<Object> vsg::read(const Path& filename, ref_ptr<const Options> options)
     return object;
 }
 
-bool vsg::writeFile(const Object* object, const Path& filename, ref_ptr<const Options> options)
+bool vsg::writeFile(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options)
 {
     bool fileWritten = false;
     if (options)
@@ -117,7 +117,7 @@ bool vsg::writeFile(const Object* object, const Path& filename, ref_ptr<const Op
 
     if (options->objectCache && fileWritten)
     {
-        options->objectCache->add(ref_ptr<Object>(const_cast<Object*>(object)), filename, options); // TODO
+        options->objectCache->add(object, filename, options); // TODO
     }
 
     return fileWritten;

--- a/src/vsg/io/ReaderWriter.cpp
+++ b/src/vsg/io/ReaderWriter.cpp
@@ -82,7 +82,7 @@ ref_ptr<Object> vsg::read(const Path& filename, ref_ptr<const Options> options)
     return object;
 }
 
-bool vsg::writeFile(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options)
+bool vsg::write(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options)
 {
     bool fileWritten = false;
     if (options)

--- a/src/vsg/io/ReaderWriter.cpp
+++ b/src/vsg/io/ReaderWriter.cpp
@@ -74,8 +74,9 @@ ref_ptr<Object> vsg::read(const Path& filename, ref_ptr<const Options> options)
         }
     }
 
-    if (options->objectCache && object)
+    if (object && options && options->objectCache)
     {
+        // place loaded object into the ObjectCache
         options->objectCache->add(object, filename, options);
     }
 

--- a/src/vsg/io/ReaderWriter.cpp
+++ b/src/vsg/io/ReaderWriter.cpp
@@ -18,8 +18,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/ReaderWriter.h>
 #include <vsg/io/ReaderWriter_vsg.h>
 
-#include <iostream>
-
 using namespace vsg;
 
 void CompositeReaderWriter::add(ref_ptr<ReaderWriter> reader)
@@ -47,19 +45,14 @@ bool CompositeReaderWriter::write(const vsg::Object* object, const vsg::Path& fi
 
 ref_ptr<Object> vsg::read(const Path& filename, ref_ptr<const Options> options)
 {
-    std::cout << "vsg::read(" << filename << ", " << options.get() << ")" << std::endl;
-
     ref_ptr<Object> object;
     if (options)
     {
         if (options->objectCache)
         {
-            std::cout << "We have an Object cache" << std::endl;
-
             object = options->objectCache->get(filename, options);
             if (object)
             {
-                std::cout << "Returning object from object cache : " << filename << std::endl;
                 return object;
             }
         }
@@ -83,7 +76,6 @@ ref_ptr<Object> vsg::read(const Path& filename, ref_ptr<const Options> options)
 
     if (options->objectCache && object)
     {
-        std::cout << "Adding Object to ObjectCche " << object.get() << std::endl;
         options->objectCache->add(object, filename, options);
     }
 
@@ -115,9 +107,9 @@ bool vsg::writeFile(ref_ptr<Object> object, const Path& filename, ref_ptr<const 
         }
     }
 
-    if (options->objectCache && fileWritten)
+    if (fileWritten && options && options->objectCache)
     {
-        options->objectCache->add(object, filename, options); // TODO
+        options->objectCache->add(object, filename, options);
     }
 
     return fileWritten;

--- a/src/vsg/io/ReaderWriter.cpp
+++ b/src/vsg/io/ReaderWriter.cpp
@@ -14,8 +14,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/AsciiOutput.h>
 #include <vsg/io/BinaryInput.h>
 #include <vsg/io/BinaryOutput.h>
-#include <vsg/io/ReaderWriter.h>
 #include <vsg/io/ObjectCache.h>
+#include <vsg/io/ReaderWriter.h>
 #include <vsg/io/ReaderWriter_vsg.h>
 
 #include <iostream>
@@ -47,19 +47,19 @@ bool CompositeReaderWriter::write(const vsg::Object* object, const vsg::Path& fi
 
 ref_ptr<Object> vsg::read(const Path& filename, ref_ptr<const Options> options)
 {
-    std::cout<<"vsg::read("<<filename<<", "<<options.get()<<")"<<std::endl;
+    std::cout << "vsg::read(" << filename << ", " << options.get() << ")" << std::endl;
 
     ref_ptr<Object> object;
     if (options)
     {
         if (options->objectCache)
         {
-            std::cout<<"We have an Object cache"<<std::endl;
+            std::cout << "We have an Object cache" << std::endl;
 
             object = options->objectCache->get(filename, options);
             if (object)
             {
-                std::cout<<"Returning object from object cache : "<<filename<<std::endl;
+                std::cout << "Returning object from object cache : " << filename << std::endl;
                 return object;
             }
         }
@@ -83,7 +83,7 @@ ref_ptr<Object> vsg::read(const Path& filename, ref_ptr<const Options> options)
 
     if (options->objectCache && object)
     {
-        std::cout<<"Adding Object to ObjectCche "<<object.get()<<std::endl;
+        std::cout << "Adding Object to ObjectCche " << object.get() << std::endl;
         options->objectCache->add(object, filename, options);
     }
 

--- a/src/vsg/io/ReaderWriter_vsg.cpp
+++ b/src/vsg/io/ReaderWriter_vsg.cpp
@@ -72,9 +72,12 @@ void ReaderWriter_vsg::writeHeader(std::ostream& fout, FormatType type) const
 vsg::ref_ptr<vsg::Object> ReaderWriter_vsg::read(const vsg::Path& filename, ref_ptr<const Options> options) const
 {
     auto ext = vsg::fileExtension(filename);
-    if ((ext == "vsga" || ext == "vsgt" || ext == "vsgb") && vsg::fileExists(filename))
+    if (ext == "vsga" || ext == "vsgt" || ext == "vsgb")
     {
-        std::ifstream fin(filename, std::ios::in | std::ios::binary);
+        vsg::Path filenameToUse = findFile(filename, options);
+        if (filenameToUse.empty()) return {};
+
+        std::ifstream fin(filenameToUse, std::ios::in | std::ios::binary);
         FormatType type = readHeader(fin);
         if (type == BINARY)
         {
@@ -86,15 +89,10 @@ vsg::ref_ptr<vsg::Object> ReaderWriter_vsg::read(const vsg::Path& filename, ref_
             vsg::AsciiInput input(fin, _objectFactory, options);
             return input.readObject("Root");
         }
-        else
-        {
-            return vsg::ref_ptr<vsg::Object>();
-        }
     }
-    else
-    {
-        return vsg::ref_ptr<vsg::Object>();
-    }
+
+    // return null as no means for loading file has been found
+    return {};
 }
 
 vsg::ref_ptr<vsg::Object> ReaderWriter_vsg::read(std::istream& fin, vsg::ref_ptr<const vsg::Options> options) const


### PR DESCRIPTION
## Description

To enable sharing of the objects loaded from files vsg::ObjectCache has been added that maintains an enteral map of files to objects loaded.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Test with vsgExamples/vsgdraw and modifications of osg2vsg application.