### PR TITLE
fix compiler warning about size_t to unsigned int conversion.

### DIFF
--- a/include/vsg/threading/OperationQueue.h
+++ b/include/vsg/threading/OperationQueue.h
@@ -35,7 +35,7 @@ namespace vsg
 
     struct Latch : public Object
     {
-        Latch(uint32_t num) :
+        Latch(unsigned int num) :
             count(num) {}
 
         void count_down()

--- a/src/vsg/io/read.cpp
+++ b/src/vsg/io/read.cpp
@@ -95,7 +95,7 @@ PathObjects vsg::read(const Paths& filenames, ref_ptr<const Options> options)
         };
 
         // use latch to syncronize this thread with the file reading threads
-        ref_ptr<Latch> latch(new Latch(filenames.size()));
+        ref_ptr<Latch> latch(new Latch(static_cast<unsigned int>(filenames.size())));
 
         // add operations
         for (auto& [filename, object] : entries)


### PR DESCRIPTION
fix compiler warning about size_t to unsigned int conversion;
changed Latch constructor to take unsigned int instead of uint_32_t to match std::atomic_uint

## Description

fix compiler warning about size_t to uint_32_t with a static_cast - assuming the number of files will never exceed MAX_UINT. Then changed the uint_32_t in the cast and the Latch constructor to match the underling type of std::atomic_uint (unsigned int) to minimize surprise when the size of uint_32_t and unsigned int are not identical.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested?

Not tested; all my compilers have 32 bit int so binaries will be unchanged.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain: Visual Studio 2019 16.2.3
* SDK:

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
