### PR TITLE
Latch counter to atomic_size_t, made count private

### DIFF
--- a/include/vsg/threading/OperationQueue.h
+++ b/include/vsg/threading/OperationQueue.h
@@ -35,7 +35,7 @@ namespace vsg
 
     struct Latch : public Object
     {
-        Latch(uint32_t num) :
+        Latch(size_t num) :
             count(num) {}
 
         void count_down()
@@ -64,7 +64,8 @@ namespace vsg
             }
         }
 
-        std::atomic_uint count;
+    private:
+        std::atomic_size_t count;
         std::mutex _mutex;
         std::condition_variable cv;
 


### PR DESCRIPTION
changed Latch counter to atomic_size_t, constructor to size_t and made count, _mutex and cv private.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
## How Has This Been Tested?

Not tested; all my compilers have 32 bit int so binaries will be unchanged.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain: Visual Studio 2019 16.2.3
* SDK:

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
