### PR TITLE
Ascii output formatting

### DIFF
--- a/include/vsg/core/Array.h
+++ b/include/vsg/core/Array.h
@@ -112,6 +112,7 @@ namespace vsg
             output.writeValue<std::uint32_t>("Size", _size);
             output.writePropertyName("Data");
             output.write(size(), _data);
+            output.writeEndOfLine();
         }
 
         std::size_t size() const { return (_layout.maxNumMipmaps <= 1) ? _size : computeValueCountIncludingMipmaps(_size, 1, 1, _layout.maxNumMipmaps); }

--- a/include/vsg/io/AsciiOutput.h
+++ b/include/vsg/io/AsciiOutput.h
@@ -32,20 +32,22 @@ namespace vsg
             return _output;
         }
 
-        // write property name if appropriate for format
+        /// write property name if appropriate for format
         void writePropertyName(const char* propertyName) override;
+
+        /// write end of line as an \n
+        void writeEndOfLine() override { _output << '\n'; }
 
         template<typename T>
         void _write(size_t num, const T* value)
         {
             if (num == 1)
             {
-                _output << ' ' << *value << '\n';
+                _output << ' ' << *value;
             }
             else
             {
                 for (; num > 0; --num, ++value) _output << ' ' << *value;
-                _output << '\n';
             }
         }
 
@@ -55,9 +57,9 @@ namespace vsg
             if (num == 1)
             {
                 if (std::isfinite(*value))
-                    _output << ' ' << *value << '\n';
+                    _output << ' ' << *value;
                 else
-                    _output << ' ' << 0.0 << '\n'; // fallback to using 0.0 when the value is NaN or Infinite to prevent problems when reading
+                    _output << ' ' << 0.0; // fallback to using 0.0 when the value is NaN or Infinite to prevent problems when reading
             }
             else
             {
@@ -68,7 +70,6 @@ namespace vsg
                     else
                         _output << ' ' << 0.0; // fallback to using 0.0 when the value is NaN or Infinite to prevent problems when reading
                 }
-                _output << '\n';
             }
         }
 
@@ -77,12 +78,11 @@ namespace vsg
         {
             if (num == 1)
             {
-                _output << ' ' << static_cast<R>(*value) << '\n';
+                _output << ' ' << static_cast<R>(*value);
             }
             else
             {
                 for (; num > 0; --num, ++value) _output << ' ' << static_cast<R>(*value);
-                _output << '\n';
             }
         }
 

--- a/include/vsg/io/AsciiOutput.h
+++ b/include/vsg/io/AsciiOutput.h
@@ -47,7 +47,17 @@ namespace vsg
             }
             else
             {
-                for (; num > 0; --num, ++value) _output << ' ' << *value;
+                for (size_t numInRow = 1; num > 0; --num, ++value, ++numInRow)
+                {
+                    _output << ' ' << *value;
+
+                    if (numInRow == _maximumNumbersPerLine && num>1)
+                    {
+                        numInRow = 0;
+                        writeEndOfLine();
+                        indent();
+                    }
+                }
             }
         }
 
@@ -63,12 +73,19 @@ namespace vsg
             }
             else
             {
-                for (; num > 0; --num, ++value)
+                for (size_t numInRow = 1; num > 0; --num, ++value, ++numInRow)
                 {
                     if (std::isfinite(*value))
                         _output << ' ' << *value;
                     else
                         _output << ' ' << 0.0; // fallback to using 0.0 when the value is NaN or Infinite to prevent problems when reading
+
+                    if (numInRow == _maximumNumbersPerLine && num > 1)
+                    {
+                        numInRow = 0;
+                        writeEndOfLine();
+                        indent();
+                    }
                 }
             }
         }
@@ -82,7 +99,17 @@ namespace vsg
             }
             else
             {
-                for (; num > 0; --num, ++value) _output << ' ' << static_cast<R>(*value);
+                for (size_t numInRow = 1; num > 0; --num, ++value, ++numInRow)
+                {
+                    _output << ' ' << static_cast<R>(*value);
+
+                    if (numInRow == _maximumNumbersPerLine && num>1)
+                    {
+                        numInRow = 0;
+                        writeEndOfLine();
+                        indent();
+                    }
+                }
             }
         }
 
@@ -123,6 +150,7 @@ namespace vsg
         std::size_t _indentationStep = 2;
         std::size_t _indentation = 0;
         std::size_t _maximumIndentation = 0;
+        std::size_t _maximumNumbersPerLine = 12;
         // 24 characters long enough for 12 levels of nesting
         const char* _indentationString = "                        ";
     };

--- a/include/vsg/io/BinaryOutput.h
+++ b/include/vsg/io/BinaryOutput.h
@@ -25,8 +25,11 @@ namespace vsg
     public:
         explicit BinaryOutput(std::ostream& output, ref_ptr<const Options> in_options = {});
 
-        // write property name if appropriate for format
+        /// write property name an non op for binary
         void writePropertyName(const char*) override {}
+
+        /// write end of line a non op for binary
+        void writeEndOfLine() override {}
 
         template<typename T>
         void _write(size_t num, const T* value)

--- a/include/vsg/io/Output.h
+++ b/include/vsg/io/Output.h
@@ -37,10 +37,13 @@ namespace vsg
 
         Options& operator=(const Options& rhs) = delete;
 
-        // write property name if appropriate for format
+        /// write property name if appropriate for format
         virtual void writePropertyName(const char* propertyName) = 0;
 
-        // write contiguous array of value(s)
+        /// write end of line character if required.
+        virtual void writeEndOfLine() = 0;
+
+        /// write contiguous array of value(s)
         virtual void write(size_t num, const int8_t* values) = 0;
         virtual void write(size_t num, const uint8_t* value) = 0;
         virtual void write(size_t num, const int16_t* value) = 0;
@@ -106,6 +109,8 @@ namespace vsg
 
             // use fold expression to expand arguments and map to appropriate write method
             (write(1, &(args)), ...);
+
+            writeEndOfLine();
         }
 
         void writeObject(const char* propertyName, const Object* object)

--- a/src/vsg/core/Data.cpp
+++ b/src/vsg/core/Data.cpp
@@ -21,10 +21,7 @@ void Data::read(Input& input)
     Object::read(input);
     _format = static_cast<VkFormat>(input.readValue<std::int32_t>("Format"));
 
-    if (input.matchPropertyName("Layout"))
-    {
-        input.read(4, &_layout.maxNumMipmaps);
-    }
+    input.read("Layout",  _layout.maxNumMipmaps, _layout.blockWidth, _layout.blockHeight, _layout.blockDepth);
 }
 
 void Data::write(Output& output) const
@@ -32,8 +29,7 @@ void Data::write(Output& output) const
     Object::write(output);
     output.writeValue<std::int32_t>("Format", _format);
 
-    output.writePropertyName("Layout");
-    output.write(4, &_layout.maxNumMipmaps);
+    output.write("Layout", _layout.maxNumMipmaps, _layout.blockWidth, _layout.blockHeight, _layout.blockDepth);
 }
 
 Data::MipmapOffsets Data::computeMipmapOffsets() const

--- a/src/vsg/io/AsciiOutput.cpp
+++ b/src/vsg/io/AsciiOutput.cpp
@@ -38,7 +38,6 @@ void AsciiOutput::write(size_t num, const std::string* value)
     {
         _output << ' ';
         _write(*value);
-        _output << '\n';
     }
     else
     {
@@ -47,7 +46,6 @@ void AsciiOutput::write(size_t num, const std::string* value)
             _output << ' ';
             _write(*value);
         }
-        _output << '\n';
     }
 }
 
@@ -56,7 +54,7 @@ void AsciiOutput::write(const vsg::Object* object)
     if (auto itr = objectIDMap.find(object); itr != objectIDMap.end())
     {
         // write out the objectID
-        _output << " id=" << itr->second << "\n";
+        _output << " id=" << itr->second <<"\n";
         return;
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Improved the formatting of ascii output by inserting newlines into the output of arrays of numbers.

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested with osg2vsg reading and writing files via the .vsgt format.