### PR TITLE
fixed warning for forward declaration

### DIFF
--- a/include/vsg/traversals/DispatchTraversal.h
+++ b/include/vsg/traversals/DispatchTraversal.h
@@ -35,7 +35,7 @@ namespace vsg
     class State;
     class DatabasePager;
     class FrameStamp;
-    class CulledPagedLODs;
+    struct CulledPagedLODs;
 
     class VSG_DECLSPEC DispatchTraversal : public Object
     {


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes warning about first seeing a class forward declaration and then using a struct
## Type of change

Forward declaration change

## How Has This Been Tested?

Compiled in-house project

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
