### PR TITLE
prevent the image class deleting the vkimages owned by the swapchain

### DIFF
--- a/include/vsg/vk/Image.h
+++ b/include/vsg/vk/Image.h
@@ -31,6 +31,8 @@ namespace vsg
         Device* getDevice() { return _device; }
         const Device* getDevice() const { return _device; }
 
+        void releaseImage() { _image = VK_NULL_HANDLE; }
+
         VkResult bind(DeviceMemory* deviceMemory, VkDeviceSize memoryOffset)
         {
             VkResult result = vkBindImageMemory(*_device, _image, *deviceMemory, memoryOffset);

--- a/src/vsg/vk/Swapchain.cpp
+++ b/src/vsg/vk/Swapchain.cpp
@@ -136,6 +136,10 @@ Swapchain::Swapchain(VkSwapchainKHR swapchain, Device* device, Surface* surface,
 
 Swapchain::~Swapchain()
 {
+    for (auto& imgview : _imageViews)
+    {
+        imgview->getImage()->releaseImage();
+    }
     _imageViews.clear();
 
     if (_swapchain)


### PR DESCRIPTION
So the issue is that if we want to use a vsg Image with the swap chain ImageViews the vsg Image
class will delete the VkImage which is owned by the swap chain and seemingly deleted by vkDestroySwapchainKHR.

Previously around line 230 ish of SwapChain.cpp the swapchain image was wrapped in an image view by directly passing the VkImage to the ImageView create function.

However doing that there is no way to get hold of the image and on top on that things like ImageMemoryBarrier expect a vsg Image.

So for now this release function seems like the simplest solution. Otherwise I think we'd need ImageView to be able to optionally store a raw VkImage and create different functions for ImageMemoryBarrier  etc etc