### PR TITLE
Introduced a dedicated vsg::PipelineBarrier class and support *Barrier classes.

### DIFF
--- a/include/vsg/vk/Image.h
+++ b/include/vsg/vk/Image.h
@@ -53,19 +53,4 @@ namespace vsg
         VkDeviceSize _memoryOffset;
     };
 
-    class VSG_DECLSPEC ImageMemoryBarrier : public Inherit<Object, ImageMemoryBarrier>, public VkImageMemoryBarrier
-    {
-    public:
-        ImageMemoryBarrier(VkAccessFlags in_srcAccessMask = 0, VkAccessFlags in_destAccessMask = 0,
-                           VkImageLayout in_oldLayout = VK_IMAGE_LAYOUT_UNDEFINED, VkImageLayout in_newLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-                           Image* in_image = nullptr);
-
-        void cmdPiplineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags sourceStage, VkPipelineStageFlags destinationStage);
-
-        virtual ~ImageMemoryBarrier();
-
-    protected:
-        ref_ptr<Image> _image;
-    };
-
 } // namespace vsg

--- a/include/vsg/vk/PipelineBarrier.h
+++ b/include/vsg/vk/PipelineBarrier.h
@@ -12,45 +12,45 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/vk/Command.h>
 #include <vsg/vk/Buffer.h>
+#include <vsg/vk/Command.h>
 
 namespace vsg
 {
 
     struct MemoryBarrier : public Inherit<Object, MemoryBarrier>
     {
-        ref_ptr<Object>    next;
-        VkAccessFlags      srcAccessMask = 0;
-        VkAccessFlags      dstAccessMask = 0;
+        ref_ptr<Object> next;
+        VkAccessFlags srcAccessMask = 0;
+        VkAccessFlags dstAccessMask = 0;
 
-        void assign(VkMemoryBarrier& info);
+        void assign(VkMemoryBarrier& info) const;
     };
 
     struct BufferMemoryBarrier : public Inherit<Object, BufferMemoryBarrier>
     {
-        ref_ptr<Object>    next;
-        VkAccessFlags      srcAccessMask = 0;
-        VkAccessFlags      dstAccessMask = 0;
-        uint32_t           srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
-        uint32_t           dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
-        ref_ptr<Buffer>    buffer;
-        VkDeviceSize       offset = 0;
-        VkDeviceSize       size = 0;
+        ref_ptr<Object> next;
+        VkAccessFlags srcAccessMask = 0;
+        VkAccessFlags dstAccessMask = 0;
+        uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
+        uint32_t dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
+        ref_ptr<Buffer> buffer;
+        VkDeviceSize offset = 0;
+        VkDeviceSize size = 0;
 
-        void assign(VkBufferMemoryBarrier& info);
+        void assign(VkBufferMemoryBarrier& info) const;
     };
 
     struct ImageMemoryBarrier : public Inherit<Object, ImageMemoryBarrier>
     {
         ImageMemoryBarrier(VkAccessFlags in_srcAccessMask = 0,
-                           VkAccessFlags              in_dstAccessMask = 0,
-                           VkImageLayout              in_oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-                           VkImageLayout              in_newLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-                           uint32_t                   in_srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-                           uint32_t                   in_dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-                           ref_ptr<Image>             in_image = {},
-                           VkImageSubresourceRange    in_subresourceRange = {0, 0, 0, 0, 0}) :
+                           VkAccessFlags in_dstAccessMask = 0,
+                           VkImageLayout in_oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+                           VkImageLayout in_newLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+                           uint32_t in_srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+                           uint32_t in_dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+                           ref_ptr<Image> in_image = {},
+                           VkImageSubresourceRange in_subresourceRange = {0, 0, 0, 0, 0}) :
             srcAccessMask(in_srcAccessMask),
             dstAccessMask(in_dstAccessMask),
             oldLayout(in_oldLayout),
@@ -60,26 +60,29 @@ namespace vsg
             image(in_image),
             subresourceRange(in_subresourceRange) {}
 
-        VkAccessFlags              srcAccessMask = 0;
-        VkAccessFlags              dstAccessMask = 0;
-        VkImageLayout              oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        VkImageLayout              newLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        uint32_t                   srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        uint32_t                   dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-        ref_ptr<Image>             image;
-        VkImageSubresourceRange    subresourceRange = {0, 0, 0, 0, 0};
+        ref_ptr<Object> next;
+        VkAccessFlags srcAccessMask = 0;
+        VkAccessFlags dstAccessMask = 0;
+        VkImageLayout oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        VkImageLayout newLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        uint32_t dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        ref_ptr<Image> image;
+        VkImageSubresourceRange subresourceRange = {0, 0, 0, 0, 0};
 
-        //ref_ptr<Object>            next;
 
-        void assign(VkImageMemoryBarrier& info);
+        void assign(VkImageMemoryBarrier& info) const;
     };
 
-    struct SampleLocationsInfo : public Inherit<Object, SampleLocationsInfo>
+    // TODO : need to implement a scheme for assign to ImageMemoryBarrier and creating/destryoung VkSampleLocationsInfoEXT
+    struct SampleLocations : public Inherit<Object, SampleLocations>
     {
-        ref_ptr<Object>                     next;
-        VkSampleCountFlagBits               sampleLocationsPerPixel = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;
-        VkExtent2D                          sampleLocationGridSize = {0, 0};
-        std::vector<vec2>                   sampleLocations;
+        ref_ptr<Object> next;
+        VkSampleCountFlagBits sampleLocationsPerPixel = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;
+        VkExtent2D sampleLocationGridSize = {0, 0};
+        std::vector<vec2> sampleLocations;
+
+        void apply(VkSampleLocationsInfoEXT& info) const;
     };
 
     class VSG_DECLSPEC PipelineBarrier : public Inherit<Command, PipelineBarrier>
@@ -106,13 +109,13 @@ namespace vsg
         using BufferMemoryBarriers = std::vector<ref_ptr<BufferMemoryBarrier>>;
         using ImageMemoryBarriers = std::vector<ref_ptr<ImageMemoryBarrier>>;
 
-        VkPipelineStageFlags    srcStageMask;
-        VkPipelineStageFlags    dstStageMask;
-        VkDependencyFlags       dependencyFlags;
+        VkPipelineStageFlags srcStageMask;
+        VkPipelineStageFlags dstStageMask;
+        VkDependencyFlags dependencyFlags;
 
-        MemoryBarriers          memoryBarriers;
-        BufferMemoryBarriers    bufferMemoryBarriers;
-        ImageMemoryBarriers     imageMemoryBarriers;
+        MemoryBarriers memoryBarriers;
+        BufferMemoryBarriers bufferMemoryBarriers;
+        ImageMemoryBarriers imageMemoryBarriers;
 
     protected:
         virtual ~PipelineBarrier();

--- a/include/vsg/vk/PipelineBarrier.h
+++ b/include/vsg/vk/PipelineBarrier.h
@@ -30,7 +30,7 @@ namespace vsg
         template<typename T>
         T* allocate(uint32_t count = 1)
         {
-            if (count==0) return nullptr;
+            if (count == 0) return nullptr;
 
             T* ptr = reinterpret_cast<T*>(base_ptr);
             base_ptr += sizeof(T) * count;
@@ -105,7 +105,6 @@ namespace vsg
         ref_ptr<Image> image;
         VkImageSubresourceRange subresourceRange = {0, 0, 0, 0, 0};
 
-
         uint32_t infoSize() const { return sizeof(VkImageMemoryBarrier) + (next ? next->infoSize() : 0); }
         void assign(VkImageMemoryBarrier& info, ScratchBuffer& buffer) const;
     };
@@ -117,7 +116,7 @@ namespace vsg
         VkExtent2D sampleLocationGridSize = {0, 0};
         std::vector<vec2> sampleLocations;
 
-        uint32_t infoSize() const override { return sizeof(VkSampleLocationsInfoEXT) + (next ? next->infoSize() : 0); ; }
+        uint32_t infoSize() const override { return sizeof(VkSampleLocationsInfoEXT) + (next ? next->infoSize() : 0); }
         void* assign(ScratchBuffer& buffer) const override;
     };
 
@@ -157,8 +156,5 @@ namespace vsg
         virtual ~PipelineBarrier();
     };
     VSG_type_name(vsg::PipelineBarrier);
-
-
-
 
 } // namespace vsg

--- a/include/vsg/vk/PipelineBarrier.h
+++ b/include/vsg/vk/PipelineBarrier.h
@@ -1,0 +1,122 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/vk/Command.h>
+#include <vsg/vk/Buffer.h>
+
+namespace vsg
+{
+
+    struct MemoryBarrier : public Inherit<Object, MemoryBarrier>
+    {
+        ref_ptr<Object>    next;
+        VkAccessFlags      srcAccessMask = 0;
+        VkAccessFlags      dstAccessMask = 0;
+
+        void assign(VkMemoryBarrier& info);
+    };
+
+    struct BufferMemoryBarrier : public Inherit<Object, BufferMemoryBarrier>
+    {
+        ref_ptr<Object>    next;
+        VkAccessFlags      srcAccessMask = 0;
+        VkAccessFlags      dstAccessMask = 0;
+        uint32_t           srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
+        uint32_t           dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
+        ref_ptr<Buffer>    buffer;
+        VkDeviceSize       offset = 0;
+        VkDeviceSize       size = 0;
+
+        void assign(VkBufferMemoryBarrier& info);
+    };
+
+    struct ImageMemoryBarrier : public Inherit<Object, ImageMemoryBarrier>
+    {
+        ImageMemoryBarrier(VkAccessFlags in_srcAccessMask = 0,
+                           VkAccessFlags              in_dstAccessMask = 0,
+                           VkImageLayout              in_oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+                           VkImageLayout              in_newLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+                           uint32_t                   in_srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+                           uint32_t                   in_dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+                           ref_ptr<Image>             in_image = {},
+                           VkImageSubresourceRange    in_subresourceRange = {0, 0, 0, 0, 0}) :
+            srcAccessMask(in_srcAccessMask),
+            dstAccessMask(in_dstAccessMask),
+            oldLayout(in_oldLayout),
+            newLayout(in_newLayout),
+            srcQueueFamilyIndex(in_srcQueueFamilyIndex),
+            dstQueueFamilyIndex(in_dstQueueFamilyIndex),
+            image(in_image),
+            subresourceRange(in_subresourceRange) {}
+
+        VkAccessFlags              srcAccessMask = 0;
+        VkAccessFlags              dstAccessMask = 0;
+        VkImageLayout              oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        VkImageLayout              newLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        uint32_t                   srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        uint32_t                   dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        ref_ptr<Image>             image;
+        VkImageSubresourceRange    subresourceRange = {0, 0, 0, 0, 0};
+
+        //ref_ptr<Object>            next;
+
+        void assign(VkImageMemoryBarrier& info);
+    };
+
+    struct SampleLocationsInfo : public Inherit<Object, SampleLocationsInfo>
+    {
+        ref_ptr<Object>                     next;
+        VkSampleCountFlagBits               sampleLocationsPerPixel = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;
+        VkExtent2D                          sampleLocationGridSize = {0, 0};
+        std::vector<vec2>                   sampleLocations;
+    };
+
+    class VSG_DECLSPEC PipelineBarrier : public Inherit<Command, PipelineBarrier>
+    {
+    public:
+        PipelineBarrier();
+
+        template<class T>
+        PipelineBarrier(VkPipelineStageFlags in_srcStageMask, VkPipelineStageFlags in_destStageMask, VkDependencyFlags in_dependencyFlags, T barrier) :
+            srcStageMask(in_srcStageMask),
+            dstStageMask(in_destStageMask),
+            dependencyFlags(in_dependencyFlags)
+        {
+            add(barrier);
+        }
+
+        void dispatch(CommandBuffer& commandBuffer) const override;
+
+        void add(ref_ptr<MemoryBarrier> mb) { memoryBarriers.emplace_back(mb); }
+        void add(ref_ptr<BufferMemoryBarrier> bmb) { bufferMemoryBarriers.emplace_back(bmb); }
+        void add(ref_ptr<ImageMemoryBarrier> imb) { imageMemoryBarriers.emplace_back(imb); }
+
+        using MemoryBarriers = std::vector<ref_ptr<MemoryBarrier>>;
+        using BufferMemoryBarriers = std::vector<ref_ptr<BufferMemoryBarrier>>;
+        using ImageMemoryBarriers = std::vector<ref_ptr<ImageMemoryBarrier>>;
+
+        VkPipelineStageFlags    srcStageMask;
+        VkPipelineStageFlags    dstStageMask;
+        VkDependencyFlags       dependencyFlags;
+
+        MemoryBarriers          memoryBarriers;
+        BufferMemoryBarriers    bufferMemoryBarriers;
+        ImageMemoryBarriers     imageMemoryBarriers;
+
+    protected:
+        virtual ~PipelineBarrier();
+    };
+    VSG_type_name(vsg::PipelineBarrier);
+
+} // namespace vsg

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -101,6 +101,7 @@ set(SOURCES
     vk/MemoryManager.cpp
     vk/PhysicalDevice.cpp
     vk/PipelineLayout.cpp
+    vk/PipelineBarrier.cpp
     vk/PushConstants.cpp
     vk/Queue.cpp
     vk/RenderPass.cpp

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -13,6 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/ui/ApplicationEvent.h>
 #include <vsg/viewer/Window.h>
 #include <vsg/vk/SubmitCommands.h>
+#include <vsg/vk/PipelineBarrier.h>
 
 #include <array>
 #include <chrono>
@@ -186,16 +187,20 @@ void Window::buildSwapchain(uint32_t width, uint32_t height)
         _frames.push_back({ias, imageViews[i], fb, cp, cb, false, fence});
     }
 
-    submitCommandsToQueue(_device, _frames[0].commandPool, _device->getQueue(_physicalDevice->getGraphicsFamily()), [&](VkCommandBuffer commandBuffer) {
-        vsg::ImageMemoryBarrier depthImageMemoryBarrier(
+    submitCommandsToQueue(_device, _frames[0].commandPool, _device->getQueue(_physicalDevice->getGraphicsFamily()), [&](CommandBuffer& commandBuffer) {
+
+        auto depthImageBarrier = ImageMemoryBarrier::create(
             0, VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
             VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-            _depthImage);
+            VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
+            _depthImage,
+            VkImageSubresourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
 
-        depthImageMemoryBarrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+        auto pipelineBarrier = PipelineBarrier::create(
+            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+            0, depthImageBarrier);
 
-        depthImageMemoryBarrier.cmdPiplineBarrier(commandBuffer,
-                                                  VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT);
+        pipelineBarrier->dispatch(commandBuffer);
     });
 
     _nextImageIndex = 0;

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -193,7 +193,7 @@ void Window::buildSwapchain(uint32_t width, uint32_t height)
             VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
             VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
             _depthImage,
-            VkImageSubresourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
+            VkImageSubresourceRange{VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1});
 
         auto pipelineBarrier = PipelineBarrier::create(
             VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -12,8 +12,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/ui/ApplicationEvent.h>
 #include <vsg/viewer/Window.h>
-#include <vsg/vk/SubmitCommands.h>
 #include <vsg/vk/PipelineBarrier.h>
+#include <vsg/vk/SubmitCommands.h>
 
 #include <array>
 #include <chrono>
@@ -188,7 +188,6 @@ void Window::buildSwapchain(uint32_t width, uint32_t height)
     }
 
     submitCommandsToQueue(_device, _frames[0].commandPool, _device->getQueue(_physicalDevice->getGraphicsFamily()), [&](CommandBuffer& commandBuffer) {
-
         auto depthImageBarrier = ImageMemoryBarrier::create(
             0, VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
             VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,

--- a/src/vsg/vk/Context.cpp
+++ b/src/vsg/vk/Context.cpp
@@ -21,8 +21,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/vk/Command.h>
 #include <vsg/vk/CommandBuffer.h>
-#include <vsg/vk/RenderPass.h>
 #include <vsg/vk/PipelineBarrier.h>
+#include <vsg/vk/RenderPass.h>
 #include <vsg/vk/State.h>
 
 #include <iostream>
@@ -535,7 +535,6 @@ void CopyAndReleaseImageDataCommand::dispatch(CommandBuffer& commandBuffer) cons
             0, postCopyImageBarrier);
 
         postPipelineBarrier->dispatch(commandBuffer);
-
     }
 }
 

--- a/src/vsg/vk/Image.cpp
+++ b/src/vsg/vk/Image.cpp
@@ -52,38 +52,3 @@ Image::Result Image::create(Device* device, const VkImageCreateInfo& createImage
         return Result("Error: Failed to create vkImage.", result);
     }
 }
-
-ImageMemoryBarrier::ImageMemoryBarrier(VkAccessFlags in_srcAccessMask, VkAccessFlags in_destAccessMask,
-                                       VkImageLayout in_oldLayout, VkImageLayout in_newLayout,
-                                       Image* in_image) :
-    VkImageMemoryBarrier{},
-    _image(in_image)
-{
-    sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-    oldLayout = in_oldLayout;
-    newLayout = in_newLayout;
-    srcAccessMask = in_srcAccessMask;
-    dstAccessMask = in_destAccessMask;
-    srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    image = *in_image;
-    subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    subresourceRange.baseMipLevel = 0;
-    subresourceRange.levelCount = 1;
-    subresourceRange.baseArrayLayer = 0;
-    subresourceRange.layerCount = 1;
-}
-
-ImageMemoryBarrier::~ImageMemoryBarrier()
-{
-}
-
-void ImageMemoryBarrier::cmdPiplineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags sourceStage, VkPipelineStageFlags destinationStage)
-{
-    vkCmdPipelineBarrier(commandBuffer,
-                         sourceStage, destinationStage,
-                         0,
-                         0, nullptr,
-                         0, nullptr,
-                         1, static_cast<VkImageMemoryBarrier*>(this));
-}

--- a/src/vsg/vk/PipelineBarrier.cpp
+++ b/src/vsg/vk/PipelineBarrier.cpp
@@ -1,0 +1,94 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/vk/CommandBuffer.h>
+#include <vsg/vk/PipelineBarrier.h>
+
+using namespace vsg;
+
+
+void MemoryBarrier::assign(VkMemoryBarrier& info)
+{
+    info.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    info.pNext = nullptr;
+    info.srcAccessMask = srcAccessMask;
+    info.dstAccessMask = dstAccessMask;
+}
+
+void BufferMemoryBarrier::assign(VkBufferMemoryBarrier& info)
+{
+    info.sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER;
+    info.pNext = nullptr;
+    info.srcAccessMask = srcAccessMask;
+    info.dstAccessMask = dstAccessMask;
+    info.srcQueueFamilyIndex = srcQueueFamilyIndex; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
+    info.dstQueueFamilyIndex = dstQueueFamilyIndex; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
+    info.buffer = buffer.valid() ? VkBuffer(*buffer) : VK_NULL_HANDLE;
+    info.offset = offset;
+    info.size = size;
+}
+
+void ImageMemoryBarrier::assign(VkImageMemoryBarrier& info)
+{
+    info.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    info.pNext = nullptr;
+    info.srcAccessMask = srcAccessMask;
+    info.dstAccessMask = dstAccessMask = 0;
+    info.oldLayout = oldLayout;
+    info.newLayout = newLayout;
+    info.srcQueueFamilyIndex = srcQueueFamilyIndex; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
+    info.dstQueueFamilyIndex = dstQueueFamilyIndex; // Queue::queueFamilyIndex() or VK_QUEUE_FAMILY_IGNORED
+    info.image = image.valid() ? VkImage(*image) : VK_NULL_HANDLE;
+    info.subresourceRange = subresourceRange;
+}
+
+
+PipelineBarrier::PipelineBarrier()
+{
+}
+
+PipelineBarrier::~PipelineBarrier()
+{
+}
+
+void PipelineBarrier::dispatch(CommandBuffer& commandBuffer) const
+{
+    std::vector<VkMemoryBarrier> vk_memoryBarriers(memoryBarriers.size());
+    for(size_t i = 0; i<memoryBarriers.size(); ++i)
+    {
+        memoryBarriers[i]->assign(vk_memoryBarriers[i]);
+    }
+
+    std::vector<VkBufferMemoryBarrier> vk_bufferMemoryBarriers(bufferMemoryBarriers.size());
+    for(size_t i = 0; i<bufferMemoryBarriers.size(); ++i)
+    {
+        bufferMemoryBarriers[i]->assign(vk_bufferMemoryBarriers[i]);
+    }
+
+    std::vector<VkImageMemoryBarrier> vk_imageMemoryBarriers(imageMemoryBarriers.size());
+    for(size_t i = 0; i<imageMemoryBarriers.size(); ++i)
+    {
+        imageMemoryBarriers[i]->assign(vk_imageMemoryBarriers[i]);
+    }
+
+    vkCmdPipelineBarrier(
+        commandBuffer,
+        srcStageMask,
+        dstStageMask,
+        dependencyFlags,
+        vk_memoryBarriers.size(),
+        vk_memoryBarriers.data(),
+        vk_bufferMemoryBarriers.size(),
+        vk_bufferMemoryBarriers.data(),
+        vk_imageMemoryBarriers.size(),
+        vk_imageMemoryBarriers.data());
+}

--- a/src/vsg/vk/PipelineBarrier.cpp
+++ b/src/vsg/vk/PipelineBarrier.cpp
@@ -47,9 +47,8 @@ ScratchBuffer::ScratchBuffer(const ScratchBuffer& parent, uint32_t minimumSize)
 
 ScratchBuffer::~ScratchBuffer()
 {
-    if (requiresDelete) delete [] buffer_begin;
+    if (requiresDelete) delete[] buffer_begin;
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -131,14 +130,14 @@ PipelineBarrier::~PipelineBarrier()
 void PipelineBarrier::dispatch(CommandBuffer& commandBuffer) const
 {
     uint32_t total_size = 0;
-    for(auto& mb : memoryBarriers) total_size += mb->infoSize();
-    for(auto& bmb : bufferMemoryBarriers) total_size += bmb->infoSize();
-    for(auto& imb : imageMemoryBarriers) total_size += imb->infoSize();
+    for (auto& mb : memoryBarriers) total_size += mb->infoSize();
+    for (auto& bmb : bufferMemoryBarriers) total_size += bmb->infoSize();
+    for (auto& imb : imageMemoryBarriers) total_size += imb->infoSize();
 
     ScratchBuffer scratchBuffer(total_size);
 
     auto* vk_memoryBarriers = scratchBuffer.allocate<VkMemoryBarrier>(memoryBarriers.size());
-    for (size_t i=0; i < memoryBarriers.size(); ++i)
+    for (size_t i = 0; i < memoryBarriers.size(); ++i)
     {
         memoryBarriers[i]->assign(vk_memoryBarriers[i], scratchBuffer);
     }


### PR DESCRIPTION
Added vsg::PipelineBarrier Command wrapper of vkPipelineBarrier and associated MemoryBarrier, BufferMemoryBarrier and ImageMemoryBarrier classes.  The new scheme is more consistent with Vulkan.

The new ImageMemoryBarrier replaces the original class of this name, and works differently so original code won't compile and will need to be ported across to work with the new PipelineBarrier/ImageMemoryBarrier.