### PR TITLE
add a DAG to manage SubPasses and Dependencies

### DIFF
--- a/include/vsg/vk/PassGraph.h
+++ b/include/vsg/vk/PassGraph.h
@@ -1,0 +1,361 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+Copyright(c) 2020 Julien Valentin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/vk/Device.h>
+
+namespace vsg
+{   
+    class SubPass;
+    class Dependency;
+    ///
+    /// @brief Directed Acyclic Graph managing SubPasses and Dependencies
+    ///
+    class VSG_DECLSPEC PassGraph : public Inherit<Object, PassGraph>
+    {
+    public:
+        PassGraph() {}
+        friend class SubPass;
+        using Dependencies = std::vector< ref_ptr<Dependency> >;
+        using SubPasses = std::vector< ref_ptr<SubPass> >;
+
+        struct AttachmentDescription : public VkAttachmentDescription
+        {
+            AttachmentDescription()
+            {
+                samples= VK_SAMPLE_COUNT_1_BIT;
+                loadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+                storeOp  = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+                stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+                stencilStoreOp  = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+                initialLayout= VK_IMAGE_LAYOUT_UNDEFINED;
+                finalLayout= VK_IMAGE_LAYOUT_UNDEFINED;
+            }
+            bool operator ==(const AttachmentDescription& other) const
+            {
+                return(flags==other.flags
+                       && format==other.format
+                       && samples==other.samples
+                       && loadOp==other.loadOp
+                       && storeOp==other.storeOp
+                       && stencilLoadOp==other.stencilLoadOp
+                       && stencilStoreOp==other.stencilStoreOp
+                       && initialLayout==other.initialLayout
+                       && finalLayout==other.finalLayout);
+            }
+        };
+        using AttachmentDescriptions = std::vector< AttachmentDescription >;
+
+        void setDepthFormat(VkFormat d) { _depthFormat = d;  }
+        void setColorFormat(VkFormat d) { _imageFormat = d;  }
+
+        inline void addSubPass(SubPass* v);
+        inline void removeSubPass(SubPass* v);
+
+        const SubPass* getSubPass(int i) const { return _subpasses[i]; }
+        SubPass* getSubPass(int i) { return _subpasses[i]; }
+        uint getNumSubPasses() const { return _subpasses.size(); }
+        inline int getSubPassIndex(SubPass* v) const;
+
+        inline void addDependency(Dependency* v) { _depends.push_back(vsg::ref_ptr<Dependency> (v)); }
+        inline void removeDependency(Dependency* v);
+
+        const Dependency* getDependency(int i) const { return _depends[i]; }
+        Dependency* getDependency(int i) { return _depends[i]; }
+        uint getNumDependencies() const {  return _depends.size(); }
+
+        inline void addAttachmentDescription(AttachmentDescription &v) { _attachments.push_back(v); }
+        inline void removeAttachmentDescription(AttachmentDescription &v);
+
+        const AttachmentDescription& getAttachmentDescription(int i) const { return _attachments[i]; }
+        AttachmentDescription& getAttachmentDescription(int i) { return _attachments[i]; }
+        inline int getAttachmentIndex(AttachmentDescription& v) const;
+
+        uint getNumAttachmentDescriptions() const { return _attachments.size(); }
+        AttachmentDescriptions & getAttachmentDescriptions() { return _attachments; }
+
+    protected:
+        inline bool addInputAttachment(SubPass* sub, AttachmentDescription& ad, VkImageLayout l);
+        inline bool addColorAttachment(SubPass* sub, AttachmentDescription& ad, VkImageLayout l);
+        inline bool addDepthStencilAttachment(SubPass* sub, AttachmentDescription& ad, VkImageLayout l);
+        inline bool addResolveAttachment(SubPass* sub, AttachmentDescription& ad, VkImageLayout l);
+
+        AttachmentDescriptions _attachments;
+        ref_ptr<Device> _device;
+        ref_ptr<AllocationCallbacks> _allocator;
+        VkFormat _depthFormat, _imageFormat;
+        SubPasses _subpasses;
+        Dependencies _depends;
+
+    };
+
+    ///Render pass composite
+    class VSG_DECLSPEC SubPass : public Inherit<Object, SubPass> {
+    public:
+        friend class PassGraph;
+        using AttachmentRef = std::pair< PassGraph::AttachmentDescription, VkImageLayout>;
+        using Dependencies = std::vector< ref_ptr<Dependency> >;
+        struct AttachmentReference : public VkAttachmentReference
+        {
+            AttachmentReference() { attachment = 0; layout = VK_IMAGE_LAYOUT_UNDEFINED; }
+
+            bool operator ==(const AttachmentReference& other) const
+            {
+                return(attachment == other.attachment && layout == other.layout);
+            }
+        };
+
+        ///constructor
+        SubPass(PassGraph * graph) : _graph(graph) {}
+
+        void setBindPoint(VkPipelineBindPoint b = VK_PIPELINE_BIND_POINT_GRAPHICS)
+        {
+            if(b == _desc.pipelineBindPoint) return;
+            _desc.pipelineBindPoint = b;
+        }
+
+        inline const PassGraph * getPassGraph() const { return _graph; }
+        inline PassGraph * getPassGraph() { return _graph; }
+
+        bool addInputAttachmentRef(PassGraph::AttachmentDescription & ad, VkImageLayout l)
+        {
+            if(_graph) return _graph->addInputAttachment(this, ad, l);
+            return false;
+        }
+        bool addDepthStencilAttachmentRef(PassGraph::AttachmentDescription & ad, VkImageLayout l)
+        {
+            if(_graph) return _graph->addDepthStencilAttachment(this, ad, l);
+            return false;
+        }
+        bool addResolvAttachmentRef(PassGraph::AttachmentDescription & ad, VkImageLayout l)
+        {
+            if(_graph) return _graph->addResolveAttachment(this, ad, l);
+            return false;
+        }
+        bool addColorAttachmentRef(PassGraph::AttachmentDescription & ad, VkImageLayout l)
+        {
+            if(_graph) return _graph->addColorAttachment(this, ad, l);
+            return false;
+        }
+        inline void removeColorAttachmentRef(AttachmentReference &v)
+        {
+            for (auto item =_colorattachmentrefs.begin(); item != _colorattachmentrefs.end(); ++item ) if(*item==v) { _colorattachmentrefs.erase(item); return; }
+        }
+
+        const AttachmentReference& getColorAttachmentRef(int i) const { return _colorattachmentrefs[i]; }
+        AttachmentReference& getColorAttachmentRef(int i) { return _colorattachmentrefs[i]; }
+        uint getNumColorAttachmentRefs() const { return _colorattachmentrefs.size(); }
+        uint getNumInputAttachmentRefs() const { return _inputattachmentrefs.size(); }
+
+        ///Dependencies management
+        inline Dependency * createForwardDependency();
+        inline Dependency * createBackwardDependency();
+        inline void getForwardDependencies(Dependencies&);
+        inline void getBackWardDependencies(Dependencies&);
+
+        //validate Attachment Refs and return it
+        operator VkSubpassDescription ()
+        {
+            _desc.colorAttachmentCount=_colorattachmentrefs.size();
+            _desc.pColorAttachments=_colorattachmentrefs.data();
+            _desc.inputAttachmentCount=_inputattachmentrefs.size();
+            _desc.pInputAttachments=_colorattachmentrefs.data();
+            _desc.inputAttachmentCount=_inputattachmentrefs.size();
+            _desc.pInputAttachments=_colorattachmentrefs.data();
+            return _desc;
+        }
+
+    protected:
+        VkSubpassDescription _desc = {};
+        std::vector<AttachmentReference> _inputattachmentrefs;
+        std::vector<AttachmentReference> _colorattachmentrefs;
+        std::vector<AttachmentReference> _pResolveAttachments;
+        std::vector<AttachmentReference> _pDepthStencilAttachment;
+        std::vector<uint> _pPreserveAttachments;
+        ref_ptr<PassGraph> _graph;
+    };
+
+    class VSG_DECLSPEC Dependency : public Inherit<Object, Dependency> {
+    public:
+        Dependency(SubPass* src = nullptr, SubPass* dst = nullptr): _src(src), _dst(dst)
+        {
+            _desc.srcSubpass = VK_SUBPASS_EXTERNAL;
+            _desc.dstSubpass = VK_SUBPASS_EXTERNAL;
+            _desc.srcAccessMask = 0;
+            _desc.srcAccessMask = 0;
+            _desc.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            _desc.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            _desc.dependencyFlags = 0;
+        }
+        inline void setDstAccessMask(VkAccessFlags d) { _desc.dstAccessMask = d; }
+        inline void setSrcAccessMask(VkAccessFlags d) { _desc.srcAccessMask = d; }
+        inline void setSrcStageMask(VkPipelineStageFlags d) { _desc.srcStageMask = d; }
+        inline void setDstStageMask(VkPipelineStageFlags d) { _desc.dstStageMask = d; }
+        inline void setDependencyFlags(VkDependencyFlags d) { _desc.dependencyFlags = d; }
+
+        //validate Attachment Refs and return it
+        operator VkSubpassDependency ()
+        {
+            int isrc = -1, idst = -1;
+            if(_src)
+            {
+                isrc = _src->getPassGraph()->getSubPassIndex(_src);
+                _desc.srcSubpass = isrc;
+            }
+            if(_dst)
+            {
+                idst = _dst->getPassGraph()->getSubPassIndex(_dst);
+                //TODO ERROR if(isrc<0||idst<0)
+                _desc.dstSubpass = idst;
+            }
+            return _desc;
+        }
+        ref_ptr<SubPass> _src,  _dst;
+        VkSubpassDependency _desc = {};
+    };
+
+    bool PassGraph::addInputAttachment(SubPass* sub, AttachmentDescription & ad, VkImageLayout l)
+    {
+        SubPass::AttachmentReference attachref;
+        attachref.layout=l; int attindex;
+        if((attindex = getAttachmentIndex(ad)) < 0)
+        {
+            attachref.attachment = _attachments.size();
+            addAttachmentDescription(ad);
+        }
+        else attachref.attachment = attindex;
+        sub->_inputattachmentrefs.push_back(attachref);
+        return true;
+    }
+
+    bool PassGraph::addColorAttachment(SubPass* sub, AttachmentDescription & ad, VkImageLayout l)
+    {
+        SubPass::AttachmentReference attachref = {};
+        attachref.layout=l; int attindex;
+        if((attindex = getAttachmentIndex(ad)) < 0)
+        {
+            attachref.attachment = _attachments.size();
+            addAttachmentDescription(ad);
+        }
+        else attachref.attachment = attindex;
+        sub->_colorattachmentrefs.push_back(attachref);
+        return true;
+    }
+
+    bool PassGraph::addDepthStencilAttachment(SubPass* sub, AttachmentDescription & ad, VkImageLayout l)
+    {
+        SubPass::AttachmentReference attachref = {};
+        attachref.layout=l; int attindex;
+        if((attindex=getAttachmentIndex(ad)) < 0)
+        {
+            attachref.attachment = _attachments.size();
+            addAttachmentDescription(ad);
+        }
+        else attachref.attachment = attindex;
+        sub->_pDepthStencilAttachment.push_back(attachref);
+        return true;
+    }
+
+    bool PassGraph::addResolveAttachment(SubPass* sub, AttachmentDescription & ad, VkImageLayout l)
+    {
+        SubPass::AttachmentReference attachref = {};
+        attachref.layout=l; int attindex;
+        if((attindex=getAttachmentIndex(ad)) < 0)
+        {
+            attachref.attachment = _attachments.size();
+            addAttachmentDescription(ad);
+        }
+        else attachref.attachment = attindex;
+        sub->_pResolveAttachments.push_back(attachref);
+        return true;
+    }
+
+    void SubPass::getForwardDependencies(SubPass::Dependencies& ret)
+    {
+        if(_graph)
+        {
+            for(uint i=0; i<_graph->getNumDependencies(); ++i)
+                if(_graph->getDependency(i)->_src == this) ret.push_back(ref_ptr<Dependency>(_graph->getDependency(i)));
+        }
+    }
+
+    void SubPass::getBackWardDependencies(SubPass::Dependencies& ret)
+    {
+        if(_graph)
+        {
+            for(uint i=0; i<_graph->getNumDependencies(); ++i)
+                if(_graph->getDependency(i)->_dst == this) ret.push_back(ref_ptr<Dependency>(_graph->getDependency(i)));
+        }
+    }
+
+    Dependency * SubPass::createForwardDependency()
+    {
+        if(_graph)
+        {
+            Dependency *dep = new Dependency(this, 0);
+            _graph->addDependency(dep);
+            return dep;
+        }
+        return nullptr;
+    }
+
+    Dependency * SubPass::createBackwardDependency()
+    {
+        if(_graph)
+        {
+            Dependency *dep = new Dependency(0, this);
+            _graph->addDependency(dep);
+            return dep;
+        }
+        return nullptr;
+    }
+
+    int PassGraph::getSubPassIndex(SubPass* v) const
+    {
+        int cpt = 0;
+        for (auto item =_subpasses.begin(); item != _subpasses.end(); ++item, ++cpt) if(*item == v) return cpt;
+        return -1;
+    }
+
+    void PassGraph::addSubPass(SubPass* v)
+    {
+        if(!v) return;
+        _subpasses.push_back(vsg::ref_ptr<SubPass> (v));
+
+    }
+    void PassGraph::removeSubPass(SubPass* v)
+    {
+        for (auto item =_subpasses.begin(); item != _subpasses.end(); ++item) if(*item==v)
+        {
+                _subpasses.erase(item);
+
+        }
+    }
+    void  PassGraph::removeAttachmentDescription(AttachmentDescription &v)
+    {
+        for (auto item =_attachments.begin(); item != _attachments.end(); ++item ) if(*item==v) _attachments.erase(item);
+    }
+
+    void PassGraph::removeDependency(Dependency* v)
+    {
+        for (auto item =_depends.begin(); item != _depends.end(); ++item) if(*item == v) { _depends.erase(item); return;}
+    }
+
+    int PassGraph::getAttachmentIndex( AttachmentDescription&v) const
+    {
+        uint cpt=0;
+        for (auto item =_attachments.begin(); item != _attachments.end(); ++item,++cpt) if(*item==v) return cpt;
+        return -1;
+    }
+} // namespace vsg

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SOURCES
     vk/ImageView.cpp
     vk/Instance.cpp
     vk/MemoryManager.cpp
+    vk/PassGraph.cpp
     vk/PhysicalDevice.cpp
     vk/PipelineLayout.cpp
     vk/PipelineBarrier.cpp

--- a/src/vsg/vk/PassGraph.cpp
+++ b/src/vsg/vk/PassGraph.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 /* <editor-fold desc="MIT License">
 
 Copyright(c) 2018 Robert Osfield
@@ -12,30 +10,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/vk/Device.h>
+#include <vsg/vk/PassGraph.h>
 
-namespace vsg
-{
-    class PassGraph;
-    class VSG_DECLSPEC RenderPass : public Inherit<Object, RenderPass>
-    {
-    public:
-        RenderPass(VkRenderPass renderPass, Device* device, AllocationCallbacks* allocator = nullptr);
+#include <array>
 
-        using Result = vsg::Result<RenderPass, VkResult, VK_SUCCESS>;
-        static Result create(Device* device, VkFormat imageFormat, VkFormat depthFormat, AllocationCallbacks* allocator = nullptr);
-        static Result create(Device* device, PassGraph*  passgraph, AllocationCallbacks* allocator = nullptr);
-
-        operator VkRenderPass() const { return _renderPass; }
-
-        Device* getDevice() { return _device; }
-        const Device* getDevice() const { return _device; }
-    protected:
-        virtual ~RenderPass();
-
-        VkRenderPass _renderPass;
-        ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
-    };
-
-} // namespace vsg
+using namespace vsg;

--- a/src/vsg/vk/RenderPass.cpp
+++ b/src/vsg/vk/RenderPass.cpp
@@ -1,6 +1,7 @@
 /* <editor-fold desc="MIT License">
 
 Copyright(c) 2018 Robert Osfield
+Copyright(c) 2020 Julien Valentin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -11,7 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/vk/RenderPass.h>
-
+#include <vsg/vk/PassGraph.h>
 #include <array>
 
 using namespace vsg;
@@ -37,77 +38,58 @@ RenderPass::Result RenderPass::create(Device* device, VkFormat imageFormat, VkFo
     {
         return Result("Error: vsg::RenderPass::create(...) failed to create RenderPass, undefined Device.", VK_ERROR_INVALID_EXTERNAL_HANDLE);
     }
-
-    Attachments attachments;
-
-    VkAttachmentDescription colorAttachment = {};
+    ref_ptr<PassGraph> graph(PassGraph::create());
+    //create  default render pass
+    vsg::PassGraph::AttachmentDescription colorAttachment;
     colorAttachment.format = imageFormat;
-    colorAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
     colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     colorAttachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    attachments.push_back(colorAttachment);
 
-    VkAttachmentDescription depthAttachment = {};
+    vsg::PassGraph::AttachmentDescription depthAttachment;
     depthAttachment.format = depthFormat;
-    depthAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
     depthAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    depthAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    depthAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    depthAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     depthAttachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    attachments.push_back(depthAttachment);
 
-    VkAttachmentReference colorAttachmentRef = {};
-    colorAttachmentRef.attachment = 0;
-    colorAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    graph->addAttachmentDescription(colorAttachment);
+    graph->addAttachmentDescription(depthAttachment);
 
-    VkAttachmentReference depthAttachmentRef = {};
-    depthAttachmentRef.attachment = 1;
-    depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    vsg::ref_ptr<vsg::SubPass > classicpass(SubPass::create(graph));
+    classicpass->addColorAttachmentRef(colorAttachment, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    classicpass->addDepthStencilAttachmentRef(depthAttachment, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+    classicpass->setBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
 
-    Subpasses subpasses;
+    graph->addSubPass(classicpass);
 
-    VkSubpassDescription subpass = {};
-    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpass.colorAttachmentCount = 1;
-    subpass.pColorAttachments = &colorAttachmentRef;
-    subpass.pDepthStencilAttachment = &depthAttachmentRef;
-    subpasses.push_back(subpass);
+    vsg::ref_ptr<vsg::Dependency > classicdep(classicpass->createForwardDependency());
+    classicdep->setDstAccessMask(VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
 
-    Dependancies dependancies;
-
-    VkSubpassDependency dependency = {};
-    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependency.dstSubpass = 0;
-    dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependency.srcAccessMask = 0;
-    dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    dependancies.push_back(dependency);
-
-    return create(device, attachments, subpasses, dependancies, allocator);
+    return create(device, graph, allocator);
 }
 
-RenderPass::Result RenderPass::create(Device* device, const Attachments& attachments, const Subpasses& subpasses, const Dependancies& dependancies, AllocationCallbacks* allocator)
+RenderPass::Result RenderPass::create(Device* device, PassGraph* graph, AllocationCallbacks* allocator)
 {
     if (!device)
     {
         return Result("Error: vsg::RenderPass::create(...) failed to create RenderPass, undefined Device.", VK_ERROR_INVALID_EXTERNAL_HANDLE);
     }
+    std::vector<VkSubpassDescription> subpasses;
+    std::vector<VkSubpassDependency> dependencies;
 
+    if(graph->getNumSubPasses()>0)
+    {
+        if(graph->getNumDependencies() == 0) graph->getSubPass(0)->createForwardDependency();
+        for(uint i=0; i<graph->getNumSubPasses(); ++i) subpasses.push_back(*graph->getSubPass(i));
+        for(uint i=0; i<graph->getNumDependencies(); ++i) dependencies.push_back(*graph->getDependency(i));
+    }
     VkRenderPassCreateInfo renderPassInfo = {};
     renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-    renderPassInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
-    renderPassInfo.pAttachments = attachments.data();
-    renderPassInfo.subpassCount = static_cast<uint32_t>(subpasses.size());
+    renderPassInfo.attachmentCount =  static_cast<uint32_t>(graph->getAttachmentDescriptions().size());
+    renderPassInfo.pAttachments = graph->getAttachmentDescriptions().data();
+    renderPassInfo.subpassCount = subpasses.size();
     renderPassInfo.pSubpasses = subpasses.data();
-    renderPassInfo.dependencyCount = static_cast<uint32_t>(dependancies.size());
-    renderPassInfo.pDependencies = dependancies.data();
+    renderPassInfo.dependencyCount = dependencies.size();
+    renderPassInfo.pDependencies = dependencies.data();
 
     VkRenderPass renderPass;
     VkResult result = vkCreateRenderPass(*device, &renderPassInfo, allocator, &renderPass);
@@ -120,4 +102,5 @@ RenderPass::Result RenderPass::create(Device* device, const Attachments& attachm
     {
         return Result("Error: vsg::RenderPass::create(...) Failed to create VkRenderPass.", result);
     }
+
 }


### PR DESCRIPTION
## Add a graph abstraction for RenderPass preparation
cool feature not to have to maintain syntaxic coherence in renderpass design 
but Not hardy tested and very inlined
