### PR TITLE
Fix getQueueFamily crash on macOS

### DIFF
--- a/src/vsg/vk/PhysicalDevice.cpp
+++ b/src/vsg/vk/PhysicalDevice.cpp
@@ -46,7 +46,7 @@ int PhysicalDevice::getQueueFamily(VkQueueFlags queueFlags) const
                 return i;
             }
 
-            bestFamily = i;
+            if (bestFamily < 0) bestFamily = i;
         }
     }
 


### PR DESCRIPTION

## Description

on macOS, the last `bestFamily` result of PhysicalDevice::getQueueFamily(), the queueFamily with `queueFlags=VK_QUEUE_GRAPHICS_BIT`  contains 0 queue, thus cause crashes. it's solved by using the first best match.

Fixes #157

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Examples in vsgExamples/Desktop no longer crashes.

**Test Configuration**:
* Firmware version: macOS 10.15.4
* Hardware: MacBook Pro (Retina, 13-inch, Early 2015) Intel Iris Graphics 6100 1536 MB
* Toolchain: XCode
* SDK: MoltenVK 1.2.135

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
