### PR TITLE
RenderGraph support for rendering to an explicit FrameBuffer

### DIFF
--- a/include/vsg/viewer/RenderGraph.h
+++ b/include/vsg/viewer/RenderGraph.h
@@ -33,6 +33,20 @@ namespace vsg
         ref_ptr<Window> window;
         VkRect2D renderArea; // viewport dimensions
 
+        ref_ptr<RenderPass> renderPass; // If not set, use window's.
+        ref_ptr<Framebuffer> framebuffer; // If not set, use window's.
+
+        RenderPass* getRenderPass()
+        {
+            if (renderPass)
+            {
+                return renderPass;
+            }
+            else
+            {
+                return window->renderPass();
+            }
+        }
         using ClearValues = std::vector<VkClearValue>;
         ClearValues clearValues; // initialize window colour and depth/stencil
 

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -179,7 +179,7 @@ void CompileTraversal::apply(CommandGraph& commandGraph)
 }
 void CompileTraversal::apply(RenderGraph& renderGraph)
 {
-    context.renderPass = renderGraph.window->renderPass();
+    context.renderPass = renderGraph.getRenderPass();
 
     if (renderGraph.camera)
     {

--- a/src/vsg/viewer/RenderGraph.cpp
+++ b/src/vsg/viewer/RenderGraph.cpp
@@ -140,8 +140,22 @@ void RenderGraph::accept(RecordTraversal& dispatchTraversal) const
 
     VkRenderPassBeginInfo renderPassInfo = {};
     renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-    renderPassInfo.renderPass = *(window->renderPass());
-    renderPassInfo.framebuffer = *(window->framebuffer(window->nextImageIndex()));
+    if (renderPass)
+    {
+        renderPassInfo.renderPass = *renderPass;
+    }
+    else if (window)
+    {
+        renderPassInfo.renderPass = *(window->renderPass());
+    }
+    if (framebuffer)
+    {
+        renderPassInfo.framebuffer = *framebuffer;
+    }
+    else if (window)
+    {
+        renderPassInfo.framebuffer = *(window->framebuffer(window->nextImageIndex()));
+    }
     renderPassInfo.renderArea = renderArea;
 
     renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());


### PR DESCRIPTION
This provides minimal support for rendering to off-screen buffers by
allowing the VSG objects normally provided by Window to be stored
directly in the RenderGraph object.

# Pull Request Template

## Description

This is early, yet hopefully useful, work in supporting offscreen rendering for a variety of purposes.

Fixes # (issue)
New functionality
## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested with an example that will soon be submitted to vsgExamples

**Test Configuration**:
* Firmware version:
* Hardware: NVidia GTX 1070
* Toolchain: Linux Fedora 31
* SDK: 1.2.131.2

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
Submission to vsgExamples will follow
- [ ] New and existing unit tests pass locally with my changes
Don't know. vsgExamples Desktop apps work.
- [ ] Any dependent changes have been merged and published in downstream modules
