### PR TITLE
Replaced T const& usage with const T& for consistency with rest of VSG

### DIFF
--- a/include/vsg/core/Array.h
+++ b/include/vsg/core/Array.h
@@ -55,7 +55,7 @@ namespace vsg
             _data(new value_type[l.size()])
         {
             value_type* ptr = _data;
-            for (value_type const& v : l) { (*ptr++) = v; }
+            for (const value_type& v : l) { (*ptr++) = v; }
         }
 
         explicit Array(std::uint32_t numElements) :

--- a/include/vsg/io/stream.h
+++ b/include/vsg/io/stream.h
@@ -119,7 +119,7 @@ namespace vsg
     }
 
     template<typename... Args>
-    std::string make_string(Args const&... args)
+    std::string make_string(const Args&... args)
     {
         std::ostringstream stream;
         (stream << ... << args);

--- a/include/vsg/maths/mat3.h
+++ b/include/vsg/maths/mat3.h
@@ -64,7 +64,7 @@ namespace vsg
         constexpr std::size_t rows() const { return 3; }
 
         column_type& operator[](std::size_t c) { return value[c]; }
-        column_type const& operator[](std::size_t c) const { return value[c]; }
+        const column_type& operator[](std::size_t c) const { return value[c]; }
 
         value_type& operator()(std::size_t c, std::size_t r) { return value[c][r]; }
         value_type operator()(std::size_t c, std::size_t r) const { return value[c][r]; }
@@ -113,7 +113,7 @@ namespace vsg
     }
 
     template<typename T>
-    t_mat3<T> operator*(t_mat3<T> const& lhs, t_mat3<T> const& rhs)
+    t_mat3<T> operator*(const t_mat3<T>& lhs, const t_mat3<T>& rhs)
     {
         return t_mat3<T>(dot(lhs, rhs, 0, 0), dot(lhs, rhs, 0, 1), dot(lhs, rhs, 0, 2),
                          dot(lhs, rhs, 1, 0), dot(lhs, rhs, 1, 1), dot(lhs, rhs, 1, 2),
@@ -121,7 +121,7 @@ namespace vsg
     }
 
     template<typename T>
-    t_vec3<T> operator*(t_mat3<T> const& lhs, t_vec3<T> const& rhs)
+    t_vec3<T> operator*(const t_mat3<T>& lhs, const t_vec3<T>& rhs)
     {
         return t_vec3<T>((lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2]),
                          (lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1] + lhs[2][1] * rhs[2]),

--- a/include/vsg/maths/mat4.h
+++ b/include/vsg/maths/mat4.h
@@ -71,7 +71,7 @@ namespace vsg
         constexpr std::size_t rows() const { return 4; }
 
         column_type& operator[](std::size_t c) { return value[c]; }
-        column_type const& operator[](std::size_t c) const { return value[c]; }
+        const column_type& operator[](std::size_t c) const { return value[c]; }
 
         value_type& operator()(std::size_t c, std::size_t r) { return value[c][r]; }
         value_type operator()(std::size_t c, std::size_t r) const { return value[c][r]; }
@@ -124,7 +124,7 @@ namespace vsg
     }
 
     template<typename T>
-    t_mat4<T> operator*(t_mat4<T> const& lhs, t_mat4<T> const& rhs)
+    t_mat4<T> operator*(const t_mat4<T>& lhs, const t_mat4<T>& rhs)
     {
         return t_mat4<T>(dot(lhs, rhs, 0, 0), dot(lhs, rhs, 0, 1), dot(lhs, rhs, 0, 2), dot(lhs, rhs, 0, 3),
                          dot(lhs, rhs, 1, 0), dot(lhs, rhs, 1, 1), dot(lhs, rhs, 1, 2), dot(lhs, rhs, 1, 3),
@@ -133,7 +133,7 @@ namespace vsg
     }
 
     template<typename T>
-    t_vec4<T> operator*(t_mat4<T> const& lhs, t_vec4<T> const& rhs)
+    t_vec4<T> operator*(const t_mat4<T>& lhs, const t_vec4<T>& rhs)
     {
         return t_vec4<T>(lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2] + lhs[3][0] * rhs[3],
                          lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1] + lhs[2][1] * rhs[2] + lhs[3][1] * rhs[3],
@@ -142,7 +142,7 @@ namespace vsg
     }
 
     template<typename T, typename R>
-    t_plane<R> operator*(t_mat4<T> const& lhs, t_plane<R> const& rhs)
+    t_plane<R> operator*(const t_mat4<T>& lhs, const t_plane<R>& rhs)
     {
         t_plane<R> transformed(lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2] + lhs[3][0] * rhs[3],
                                lhs[0][1] * rhs[0] + lhs[1][1] * rhs[1] + lhs[2][1] * rhs[2] + lhs[3][1] * rhs[3],
@@ -153,7 +153,7 @@ namespace vsg
     }
 
     template<typename T>
-    t_vec4<T> operator*(t_vec4<T> const& lhs, t_mat4<T> const& rhs)
+    t_vec4<T> operator*(const t_vec4<T>& lhs, const t_mat4<T>& rhs)
     {
         return t_vec4<T>(lhs[0] * rhs[0][0] + lhs[1] * rhs[0][1] + lhs[2] * rhs[0][2] + lhs[3] * rhs[0][3],
                          lhs[0] * rhs[1][0] + lhs[1] * rhs[1][1] + lhs[2] * rhs[1][2] + lhs[3] * rhs[1][3],
@@ -162,7 +162,7 @@ namespace vsg
     }
 
     template<typename T, typename R>
-    t_plane<T> operator*(t_plane<T> const& lhs, t_mat4<R> const& rhs)
+    t_plane<T> operator*(const t_plane<T>& lhs, const t_mat4<R>& rhs)
     {
         t_plane<T> transformed(lhs[0] * rhs[0][0] + lhs[1] * rhs[0][1] + lhs[2] * rhs[0][2] + lhs[3] * rhs[0][3],
                                lhs[0] * rhs[1][0] + lhs[1] * rhs[1][1] + lhs[2] * rhs[1][2] + lhs[3] * rhs[1][3],
@@ -173,7 +173,7 @@ namespace vsg
     }
 
     template<typename T>
-    t_vec3<T> operator*(t_mat4<T> const& lhs, t_vec3<T> const& rhs)
+    t_vec3<T> operator*(const t_mat4<T>& lhs, const t_vec3<T>& rhs)
     {
         T inv = static_cast<T>(1.0) / (lhs[0][3] * rhs[0] + lhs[1][3] * rhs[1] + lhs[2][3] * rhs[2] + lhs[3][3]);
         return t_vec3<T>((lhs[0][0] * rhs[0] + lhs[1][0] * rhs[1] + lhs[2][0] * rhs[2] + lhs[3][0]) * inv,
@@ -182,7 +182,7 @@ namespace vsg
     }
 
     template<typename T>
-    t_vec3<T> operator*(t_vec3<T> const& lhs, t_mat4<T> const& rhs)
+    t_vec3<T> operator*(const t_vec3<T>& lhs, const t_mat4<T>& rhs)
     {
         T inv = static_cast<T>(1.0) / (lhs[0] * rhs[3][0] + lhs[1] * rhs[3][1] + lhs[2] * rhs[3][2] + rhs[3][3]);
         return t_vec3<T>(lhs[0] * rhs[0][0] + lhs[1] * rhs[0][1] + lhs[2] * rhs[0][2] + rhs[0][3] * inv,

--- a/include/vsg/maths/plane.h
+++ b/include/vsg/maths/plane.h
@@ -103,13 +103,13 @@ namespace vsg
     VSG_type_name(vsg::dplane);
 
     template<typename T>
-    constexpr T distance(t_plane<T> const& pl, t_vec3<T> const& v)
+    constexpr T distance(const t_plane<T>& pl, const t_vec3<T>& v)
     {
         return dot(pl.n, v) + pl.p;
     }
 
     template<typename T, typename R>
-    constexpr T distance(t_plane<T> const& pl, t_vec3<R> const& v)
+    constexpr T distance(const t_plane<T>& pl, const t_vec3<R>& v)
     {
         using normal_type = typename t_plane<T>::normal_type;
         return dot(pl.n, normal_type(v)) + pl.p;
@@ -117,7 +117,7 @@ namespace vsg
 
     /** return true if bounding sphere is wholly or partially intersects with convex polytope defined by a list of planes with normals pointing inwards towards center of the polytope. */
     template<class PlaneItr, typename T>
-    constexpr bool intersect(PlaneItr first, PlaneItr last, t_sphere<T> const& s)
+    constexpr bool intersect(PlaneItr first, PlaneItr last, const t_sphere<T>& s)
     {
         auto negative_radius = -s.radius;
         for (auto itr = first; itr != last; ++itr)
@@ -128,7 +128,7 @@ namespace vsg
     }
 
     template<class Polytope, typename T>
-    constexpr bool intersect(Polytope const& polytope, t_sphere<T> const& s)
+    constexpr bool intersect(const Polytope& polytope, const t_sphere<T>& s)
     {
         return intersect(polytope.begin(), polytope.end(), s);
     }

--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -84,63 +84,63 @@ namespace vsg
     VSG_type_name(vsg::dquat);
 
     template<typename T>
-    constexpr t_quat<T> operator-(t_quat<T> const& lhs, t_quat<T> const& rhs)
+    constexpr t_quat<T> operator-(const t_quat<T>& lhs, const t_quat<T>& rhs)
     {
         return t_quat<T>(lhs[0] - rhs[0], lhs[1] - rhs[1], lhs[2] - rhs[2], lhs[3] - rhs[3]);
     }
 
     template<typename T>
-    constexpr t_quat<T> conjugate(t_quat<T> const& v)
+    constexpr t_quat<T> conjugate(const t_quat<T>& v)
     {
         return t_quat<T>(-v[0], -v[1], -v[2], -v[3]);
     }
 
     template<typename T>
-    constexpr t_quat<T> operator-(t_quat<T> const& v)
+    constexpr t_quat<T> operator-(const t_quat<T>& v)
     {
         return conjugate(v);
     }
 
     template<typename T>
-    constexpr t_quat<T> operator+(t_quat<T> const& lhs, t_quat<T> const& rhs)
+    constexpr t_quat<T> operator+(const t_quat<T>& lhs, const t_quat<T>& rhs)
     {
         return t_quat<T>(lhs[0] + rhs[0], lhs[1] + rhs[1], lhs[2] + rhs[2], lhs[3] + rhs[3]);
     }
 
     template<typename T>
-    constexpr t_quat<T> operator*(t_quat<T> const& lhs, T rhs)
+    constexpr t_quat<T> operator*(const t_quat<T>& lhs, T rhs)
     {
         return t_quat<T>(lhs[0] * rhs, lhs[1] * rhs, lhs[2] * rhs, lhs[3] * rhs);
     }
 
     template<typename T>
-    constexpr t_quat<T> operator/(t_quat<T> const& lhs, T rhs)
+    constexpr t_quat<T> operator/(const t_quat<T>& lhs, T rhs)
     {
         T inv = static_cast<T>(1.0) / rhs;
         return t_quat<T>(lhs[0] * inv, lhs[1] * inv, lhs[2] * inv, lhs[3] * inv);
     }
 
     template<typename T>
-    constexpr T length(t_quat<T> const& v)
+    constexpr T length(const t_quat<T>& v)
     {
         return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3]);
     }
 
     template<typename T>
-    constexpr t_quat<T> normalize(t_quat<T> const& v)
+    constexpr t_quat<T> normalize(const t_quat<T>& v)
     {
         T inverse_len = static_cast<T>(1.0) / length(v);
         return t_quat<T>(v[0] * inverse_len, v[1] * inverse_len, v[2] * inverse_len, v[3] * inverse_len);
     }
 
     template<typename T>
-    constexpr T dot(t_quat<T> const& lhs, t_quat<T> const& rhs)
+    constexpr T dot(const t_quat<T>& lhs, const t_quat<T>& rhs)
     {
         return lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2] + lhs[3] * rhs[3];
     }
 
     template<typename T>
-    constexpr t_quat<T> inverse(t_quat<T> const& v)
+    constexpr t_quat<T> inverse(const t_quat<T>& v)
     {
         t_quat<T> c = conj(v);
         T inverse_len = static_cast<T>(1.0) / length(v);
@@ -148,7 +148,7 @@ namespace vsg
     }
 
     template<typename T>
-    constexpr t_quat<T> mix(t_quat<T> const& from, t_quat<T> to, T r)
+    constexpr t_quat<T> mix(const t_quat<T>& from, t_quat<T> to, T r)
     {
         T epsilon = std::numeric_limits<T>::epsilon();
         T one(1.0);
@@ -176,7 +176,7 @@ namespace vsg
     }
 
     template<typename T>
-    constexpr t_mat4<T> mat4_cast(t_quat<T> const& q)
+    constexpr t_mat4<T> mat4_cast(const t_quat<T>& q)
     {
         T qxx(q.x * q.x);
         T qyy(q.y * q.y);

--- a/include/vsg/maths/transform.h
+++ b/include/vsg/maths/transform.h
@@ -111,7 +111,7 @@ namespace vsg
     }
 
     template<typename T>
-    constexpr t_mat4<T> lookAt(t_vec3<T> const& eye, t_vec3<T> const& center, t_vec3<T> const& up)
+    constexpr t_mat4<T> lookAt(const t_vec3<T>& eye, const t_vec3<T>& center, const t_vec3<T>& up)
     {
         using vec_type = t_vec3<T>;
 

--- a/include/vsg/maths/vec2.h
+++ b/include/vsg/maths/vec2.h
@@ -124,19 +124,19 @@ namespace vsg
     VSG_type_name(vsg::uivec2);
 
     template<typename T>
-    constexpr bool operator==(t_vec2<T> const& lhs, t_vec2<T> const& rhs)
+    constexpr bool operator==(const t_vec2<T>& lhs, const t_vec2<T>& rhs)
     {
         return lhs[0] == rhs[0] && lhs[1] == rhs[1];
     }
 
     template<typename T>
-    constexpr bool operator!=(t_vec2<T> const& lhs, t_vec2<T> const& rhs)
+    constexpr bool operator!=(const t_vec2<T>& lhs, const t_vec2<T>& rhs)
     {
         return lhs[0] == rhs[0] || lhs[1] != rhs[1];
     }
 
     template<typename T>
-    constexpr bool operator<(t_vec2<T> const& lhs, t_vec2<T> const& rhs)
+    constexpr bool operator<(const t_vec2<T>& lhs, const t_vec2<T>& rhs)
     {
         if (lhs[0] < rhs[0]) return true;
         if (lhs[0] > rhs[0]) return false;
@@ -144,57 +144,57 @@ namespace vsg
     }
 
     template<typename T>
-    constexpr t_vec2<T> operator-(t_vec2<T> const& lhs, t_vec2<T> const& rhs)
+    constexpr t_vec2<T> operator-(const t_vec2<T>& lhs, const t_vec2<T>& rhs)
     {
         return t_vec2<T>(lhs[0] - rhs[0], lhs[1] - rhs[1]);
     }
 
     template<typename T>
-    constexpr t_vec2<T> operator-(t_vec2<T> const& v)
+    constexpr t_vec2<T> operator-(const t_vec2<T>& v)
     {
         return t_vec2<T>(-v[0], -v[1]);
     }
 
     template<typename T>
-    constexpr t_vec2<T> operator+(t_vec2<T> const& lhs, t_vec2<T> const& rhs)
+    constexpr t_vec2<T> operator+(const t_vec2<T>& lhs, const t_vec2<T>& rhs)
     {
         return t_vec2<T>(lhs[0] + rhs[0], lhs[1] + rhs[1]);
     }
 
     template<typename T>
-    constexpr t_vec2<T> operator*(t_vec2<T> const& lhs, T rhs)
+    constexpr t_vec2<T> operator*(const t_vec2<T>& lhs, T rhs)
     {
         return t_vec2<T>(lhs[0] * rhs, lhs[1] * rhs);
     }
 
     template<typename T>
-    constexpr t_vec2<T> operator/(t_vec2<T> const& lhs, T rhs)
+    constexpr t_vec2<T> operator/(const t_vec2<T>& lhs, T rhs)
     {
         T inv = static_cast<T>(1.0) / rhs;
         return t_vec2<T>(lhs[0] * inv, lhs[1] * inv);
     }
 
     template<typename T>
-    constexpr T length(t_vec2<T> const& v)
+    constexpr T length(const t_vec2<T>& v)
     {
         return std::sqrt(v[0] * v[0] + v[1] * v[1]);
     }
 
     template<typename T>
-    constexpr T length2(t_vec2<T> const& v)
+    constexpr T length2(const t_vec2<T>& v)
     {
         return v[0] * v[0] + v[1] * v[1];
     }
 
     template<typename T>
-    constexpr t_vec2<T> normalize(t_vec2<T> const& v)
+    constexpr t_vec2<T> normalize(const t_vec2<T>& v)
     {
         T inverse_len = static_cast<T>(1.0) / length(v);
         return t_vec2<T>(v[0] * inverse_len, v[1] * inverse_len);
     }
 
     template<typename T>
-    constexpr T dot(t_vec2<T> const& lhs, t_vec2<T> const& rhs)
+    constexpr T dot(const t_vec2<T>& lhs, const t_vec2<T>& rhs)
     {
         return lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2];
     }

--- a/include/vsg/maths/vec3.h
+++ b/include/vsg/maths/vec3.h
@@ -134,19 +134,19 @@ namespace vsg
     VSG_type_name(vsg::uivec3);
 
     template<typename T>
-    constexpr bool operator==(t_vec3<T> const& lhs, t_vec3<T> const& rhs)
+    constexpr bool operator==(const t_vec3<T>& lhs, const t_vec3<T>& rhs)
     {
         return lhs[0] == rhs[0] && lhs[1] == rhs[1] && lhs[2] == rhs[2];
     }
 
     template<typename T>
-    constexpr bool operator!=(t_vec3<T> const& lhs, t_vec3<T> const& rhs)
+    constexpr bool operator!=(const t_vec3<T>& lhs, const t_vec3<T>& rhs)
     {
         return lhs[0] == rhs[0] || lhs[1] != rhs[1] || lhs[2] != rhs[2];
     }
 
     template<typename T>
-    constexpr bool operator<(t_vec3<T> const& lhs, t_vec3<T> const& rhs)
+    constexpr bool operator<(const t_vec3<T>& lhs, const t_vec3<T>& rhs)
     {
         if (lhs[0] < rhs[0]) return true;
         if (lhs[0] > rhs[0]) return false;
@@ -156,63 +156,63 @@ namespace vsg
     }
 
     template<typename T>
-    constexpr t_vec3<T> operator-(t_vec3<T> const& lhs, t_vec3<T> const& rhs)
+    constexpr t_vec3<T> operator-(const t_vec3<T>& lhs, const t_vec3<T>& rhs)
     {
         return t_vec3<T>(lhs[0] - rhs[0], lhs[1] - rhs[1], lhs[2] - rhs[2]);
     }
 
     template<typename T>
-    constexpr t_vec3<T> operator-(t_vec3<T> const& v)
+    constexpr t_vec3<T> operator-(const t_vec3<T>& v)
     {
         return t_vec3<T>(-v[0], -v[1], -v[2]);
     }
 
     template<typename T>
-    constexpr t_vec3<T> operator+(t_vec3<T> const& lhs, t_vec3<T> const& rhs)
+    constexpr t_vec3<T> operator+(const t_vec3<T>& lhs, const t_vec3<T>& rhs)
     {
         return t_vec3<T>(lhs[0] + rhs[0], lhs[1] + rhs[1], lhs[2] + rhs[2]);
     }
 
     template<typename T>
-    constexpr t_vec3<T> operator*(t_vec3<T> const& lhs, T rhs)
+    constexpr t_vec3<T> operator*(const t_vec3<T>& lhs, T rhs)
     {
         return t_vec3<T>(lhs[0] * rhs, lhs[1] * rhs, lhs[2] * rhs);
     }
 
     template<typename T>
-    constexpr t_vec3<T> operator/(t_vec3<T> const& lhs, T rhs)
+    constexpr t_vec3<T> operator/(const t_vec3<T>& lhs, T rhs)
     {
         T inv = static_cast<T>(1.0) / rhs;
         return t_vec3<T>(lhs[0] * inv, lhs[1] * inv, lhs[2] * inv);
     }
 
     template<typename T>
-    constexpr T length(t_vec3<T> const& v)
+    constexpr T length(const t_vec3<T>& v)
     {
         return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
     }
 
     template<typename T>
-    constexpr T length2(t_vec3<T> const& v)
+    constexpr T length2(const t_vec3<T>& v)
     {
         return v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
     }
 
     template<typename T>
-    constexpr t_vec3<T> normalize(t_vec3<T> const& v)
+    constexpr t_vec3<T> normalize(const t_vec3<T>& v)
     {
         T inverse_len = static_cast<T>(1.0) / length(v);
         return t_vec3<T>(v[0] * inverse_len, v[1] * inverse_len, v[2] * inverse_len);
     }
 
     template<typename T>
-    constexpr T dot(t_vec3<T> const& lhs, t_vec3<T> const& rhs)
+    constexpr T dot(const t_vec3<T>& lhs, const t_vec3<T>& rhs)
     {
         return lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2];
     }
 
     template<typename T>
-    constexpr t_vec3<T> cross(t_vec3<T> const& lhs, t_vec3<T> const& rhs)
+    constexpr t_vec3<T> cross(const t_vec3<T>& lhs, const t_vec3<T>& rhs)
     {
         return t_vec3<T>(lhs[1] * rhs[2] - rhs[1] * lhs[2],
                          lhs[2] * rhs[0] - rhs[2] * lhs[0],

--- a/include/vsg/maths/vec4.h
+++ b/include/vsg/maths/vec4.h
@@ -140,19 +140,19 @@ namespace vsg
     VSG_type_name(vsg::uivec4);
 
     template<typename T>
-    constexpr bool operator==(t_vec4<T> const& lhs, t_vec4<T> const& rhs)
+    constexpr bool operator==(const t_vec4<T>& lhs, const t_vec4<T>& rhs)
     {
         return lhs[0] == rhs[0] && lhs[1] == rhs[1] && lhs[2] == rhs[2] && lhs[3] == rhs[3];
     }
 
     template<typename T>
-    constexpr bool operator!=(t_vec4<T> const& lhs, t_vec4<T> const& rhs)
+    constexpr bool operator!=(const t_vec4<T>& lhs, const t_vec4<T>& rhs)
     {
         return lhs[0] == rhs[0] || lhs[1] != rhs[1] || lhs[2] != rhs[2] || lhs[3] != rhs[3];
     }
 
     template<typename T>
-    constexpr bool operator<(t_vec4<T> const& lhs, t_vec4<T> const& rhs)
+    constexpr bool operator<(const t_vec4<T>& lhs, const t_vec4<T>& rhs)
     {
         if (lhs[0] < rhs[0]) return true;
         if (lhs[0] > rhs[0]) return false;
@@ -164,50 +164,50 @@ namespace vsg
     }
 
     template<typename T>
-    constexpr t_vec4<T> operator-(t_vec4<T> const& lhs, t_vec4<T> const& rhs)
+    constexpr t_vec4<T> operator-(const t_vec4<T>& lhs, const t_vec4<T>& rhs)
     {
         return t_vec4<T>(lhs[0] - rhs[0], lhs[1] - rhs[1], lhs[2] - rhs[2], lhs[3] - rhs[3]);
     }
 
     template<typename T>
-    constexpr t_vec4<T> operator-(t_vec4<T> const& v)
+    constexpr t_vec4<T> operator-(const t_vec4<T>& v)
     {
         return t_vec4<T>(-v[0], -v[1], -v[2], -v[3]);
     }
 
     template<typename T>
-    constexpr t_vec4<T> operator+(t_vec4<T> const& lhs, t_vec4<T> const& rhs)
+    constexpr t_vec4<T> operator+(const t_vec4<T>& lhs, const t_vec4<T>& rhs)
     {
         return t_vec4<T>(lhs[0] + rhs[0], lhs[1] + rhs[1], lhs[2] + rhs[2], lhs[3] + rhs[3]);
     }
 
     template<typename T>
-    constexpr t_vec4<T> operator*(t_vec4<T> const& lhs, T rhs)
+    constexpr t_vec4<T> operator*(const t_vec4<T>& lhs, T rhs)
     {
         return t_vec4<T>(lhs[0] * rhs, lhs[1] * rhs, lhs[2] * rhs, lhs[3] * rhs);
     }
 
     template<typename T>
-    constexpr t_vec4<T> operator/(t_vec4<T> const& lhs, T rhs)
+    constexpr t_vec4<T> operator/(const t_vec4<T>& lhs, T rhs)
     {
         T inv = static_cast<T>(1.0) / rhs;
         return t_vec4<T>(lhs[0] * inv, lhs[1] * inv, lhs[2] * inv, lhs[3] * inv);
     }
 
     template<typename T>
-    constexpr T length(t_vec4<T> const& v)
+    constexpr T length(const t_vec4<T>& v)
     {
         return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3]);
     }
 
     template<typename T>
-    constexpr T length2(t_vec4<T> const& v)
+    constexpr T length2(const t_vec4<T>& v)
     {
         return v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3];
     }
 
     template<typename T>
-    constexpr t_vec4<T> normalize(t_vec4<T> const& v)
+    constexpr t_vec4<T> normalize(const t_vec4<T>& v)
     {
         T inverse_len = static_cast<T>(1.0) / length(v);
         return t_vec4<T>(v[0] * inverse_len, v[1] * inverse_len, v[2] * inverse_len, v[3] * inverse_len);

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -293,7 +293,7 @@ namespace vsg
         }
 
         template<typename T>
-        bool intersect(t_sphere<T> const& s)
+        bool intersect(const t_sphere<T>& s)
         {
             return vsg::intersect(_frustumStack.top(), s);
         }


### PR DESCRIPTION
Early in the project experimented with T const& usage to see how it natural it would be but have always found it awkward from a natural language perspective so have replaced with const T& usage to keep it consistent with the rest of the VSG.