### PR TITLE
Refactor window initialization

### DIFF
--- a/include/vsg/platform/android/Android_Window.h
+++ b/include/vsg/platform/android/Android_Window.h
@@ -68,13 +68,13 @@ namespace vsgAndroid
 
         const char* instanceExtensionSurfaceName() const override { return "VK_KHR_android_surface"; }
 
-        virtual bool valid() const { return _window; }
+        bool valid() const override { return _window; }
 
-        virtual bool pollEvents(vsg::Events& events);
+        bool pollEvents(vsg::Events& events) override;
 
-        virtual bool resized() const;
+        bool resized() const override;
 
-        virtual void resize();
+        void resize() override;
 
         bool handleAndroidInputEvent(AInputEvent* anEvent);
 

--- a/include/vsg/platform/android/Android_Window.h
+++ b/include/vsg/platform/android/Android_Window.h
@@ -61,10 +61,12 @@ namespace vsgAndroid
     {
     public:
 
-        Android_Window(vsg::ref_ptr<vsg::WindowTraits> traits, vsg::AllocationCallbacks* allocator = nullptr);
+        Android_Window(vsg::ref_ptr<vsg::WindowTraits> traits);
         Android_Window() = delete;
         Android_Window(const Android_Window&) = delete;
         Android_Window operator = (const Android_Window&) = delete;
+
+        const char* instanceExtensionSurfaceName() const override { return "VK_KHR_android_surface"; }
 
         virtual bool valid() const { return _window; }
 
@@ -78,6 +80,8 @@ namespace vsgAndroid
 
     protected:
         virtual ~Android_Window();
+
+        void _initSurface() override;
 
         ANativeWindow* _window;
 

--- a/include/vsg/platform/macos/MacOS_Window.h
+++ b/include/vsg/platform/macos/MacOS_Window.h
@@ -44,10 +44,12 @@ namespace vsgMacOS
     {
     public:
 
-        MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits, vsg::AllocationCallbacks* allocator = nullptr);
+        MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits);
         MacOS_Window() = delete;
         MacOS_Window(const MacOS_Window&) = delete;
         MacOS_Window operator = (const MacOS_Window&) = delete;
+
+        const char* instanceExtensionSurfaceName() const override { return "VK_MVK_macos_surface"; }
 
         virtual bool valid() const { return _window; }
 
@@ -74,6 +76,8 @@ namespace vsgMacOS
 
     protected:
         virtual ~MacOS_Window();
+
+        void _initSurface() override;
 
         vsg_MacOS_NSWindow* _window;
         vsg_MacOS_NSView* _view;

--- a/include/vsg/platform/macos/MacOS_Window.h
+++ b/include/vsg/platform/macos/MacOS_Window.h
@@ -51,13 +51,13 @@ namespace vsgMacOS
 
         const char* instanceExtensionSurfaceName() const override { return "VK_MVK_macos_surface"; }
 
-        virtual bool valid() const { return _window; }
+        bool valid() const override { return _window; }
 
-        virtual bool pollEvents(vsg::Events& events);
+        bool pollEvents(vsg::Events& events) override;
 
-        virtual bool resized() const;
+        bool resized() const override;
 
-        virtual void resize();
+        void resize() override;
 
         bool handleNSEvent(NSEvent* anEvent);
 

--- a/include/vsg/platform/unix/Xcb_Window.h
+++ b/include/vsg/platform/unix/Xcb_Window.h
@@ -16,6 +16,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/ui/KeyEvent.h>
 
 #include <xcb/xcb.h>
+#include <vulkan/vulkan_xcb.h>
+
 
 #include <iostream>
 
@@ -52,10 +54,12 @@ namespace vsgXcb
     {
     public:
 
-        Xcb_Window(vsg::ref_ptr<vsg::WindowTraits> traits, vsg::AllocationCallbacks* allocator = nullptr);
+        Xcb_Window(vsg::ref_ptr<vsg::WindowTraits> traits);
         Xcb_Window() = delete;
         Xcb_Window(const Xcb_Window&) = delete;
         Xcb_Window& operator = (const Xcb_Window&) = delete;
+
+        const char* instanceExtensionSurfaceName() const override { return VK_KHR_XCB_SURFACE_EXTENSION_NAME; }
 
         bool valid() const override;
 
@@ -67,9 +71,12 @@ namespace vsgXcb
 
         void resize() override;
 
+
     protected:
 
         ~Xcb_Window();
+
+        void _initSurface() override;
 
         xcb_connection_t* _connection = nullptr;
         xcb_screen_t* _screen = nullptr;

--- a/include/vsg/platform/unix/Xcb_Window.h
+++ b/include/vsg/platform/unix/Xcb_Window.h
@@ -18,9 +18,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <xcb/xcb.h>
 #include <vulkan/vulkan_xcb.h>
 
-
-#include <iostream>
-
 namespace vsgXcb
 {
 

--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -25,8 +25,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <windows.h>
 #include <windowsx.h>
 
-#include <iostream>
-
 namespace vsgWin32
 {
     class KeyboardMap : public vsg::Object
@@ -109,10 +107,12 @@ namespace vsgWin32
     {
     public:
 
-        Win32_Window(vsg::ref_ptr<vsg::WindowTraits> traits, vsg::AllocationCallbacks* allocator = nullptr);
+        Win32_Window(vsg::ref_ptr<vsg::WindowTraits> traits);
         Win32_Window() = delete;
         Win32_Window(const Win32_Window&) = delete;
         Win32_Window operator=(const Win32_Window&) = delete;
+
+        const char* instanceExtensionSurfaceName() const override { return VK_KHR_WIN32_SURFACE_EXTENSION_NAME; }
 
         bool valid() const override { return _window; }
 
@@ -129,6 +129,8 @@ namespace vsgWin32
 
     protected:
         virtual ~Win32_Window();
+
+        void _initSurface() override;
 
         HWND _window;
 

--- a/include/vsg/traversals/CompileTraversal.h
+++ b/include/vsg/traversals/CompileTraversal.h
@@ -16,12 +16,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/nodes/Group.h>
 #include <vsg/state/Descriptor.h>
 #include <vsg/state/ResourceHints.h>
+#include <vsg/viewer/Window.h>
 #include <vsg/vk/BufferData.h>
 #include <vsg/vk/CommandPool.h>
 #include <vsg/vk/Context.h>
 #include <vsg/vk/DescriptorPool.h>
 #include <vsg/vk/Fence.h>
-#include <vsg/viewer/Window.h>
 
 #include <map>
 #include <set>

--- a/include/vsg/traversals/CompileTraversal.h
+++ b/include/vsg/traversals/CompileTraversal.h
@@ -21,6 +21,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/Context.h>
 #include <vsg/vk/DescriptorPool.h>
 #include <vsg/vk/Fence.h>
+#include <vsg/viewer/Window.h>
 
 #include <map>
 #include <set>
@@ -62,6 +63,7 @@ namespace vsg
     {
     public:
         explicit CompileTraversal(Device* in_device, BufferPreferences bufferPreferences = {});
+        explicit CompileTraversal(Window* window, BufferPreferences bufferPreferences = {});
         CompileTraversal(const CompileTraversal& ct);
         ~CompileTraversal();
 

--- a/include/vsg/viewer/RenderGraph.h
+++ b/include/vsg/viewer/RenderGraph.h
@@ -44,7 +44,7 @@ namespace vsg
             }
             else
             {
-                return window->renderPass();
+                return window->getOrCreateRenderPass();
             }
         }
         using ClearValues = std::vector<VkClearValue>;

--- a/include/vsg/viewer/Viewer.h
+++ b/include/vsg/viewer/Viewer.h
@@ -30,21 +30,6 @@ namespace vsg
     public:
         Viewer();
 
-        struct PerDeviceObjects
-        {
-            Windows windows;
-            ref_ptr<Queue> graphicsQueue;
-            ref_ptr<Queue> presentQueue;
-            ref_ptr<Semaphore> renderFinishedSemaphore;
-
-            // cache data to be used each frame
-            std::vector<uint32_t> imageIndices;
-            std::vector<VkSemaphore> signalSemaphores;
-            std::vector<VkCommandBuffer> commandBuffers;
-            std::vector<VkSwapchainKHR> swapchains;
-        };
-
-        using DeviceMap = std::map<ref_ptr<Device>, PerDeviceObjects>;
 
         /// add Window to Viewer
         virtual void addWindow(ref_ptr<Window> window);
@@ -95,8 +80,6 @@ namespace vsg
         /// pass the Events into the any register EventHandlers
         virtual void handleEvents();
 
-        virtual void reassignFrameCache();
-
         virtual void compile(BufferPreferences bufferPreferences = {});
 
         virtual bool acquireNextFrame();
@@ -117,6 +100,9 @@ namespace vsg
 
         virtual void present();
 
+        /// Call vkDeviceWaitIdle on all the devices associated with this Viewer
+        void deviceWaitIdle() const;
+
     protected:
         virtual ~Viewer();
 
@@ -125,8 +111,6 @@ namespace vsg
         ref_ptr<FrameStamp> _frameStamp;
 
         Windows _windows;
-
-        DeviceMap _deviceMap;
 
         clock::time_point _start_point;
         Events _events;

--- a/include/vsg/viewer/Viewer.h
+++ b/include/vsg/viewer/Viewer.h
@@ -30,7 +30,6 @@ namespace vsg
     public:
         Viewer();
 
-
         /// add Window to Viewer
         virtual void addWindow(ref_ptr<Window> window);
 

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -54,23 +54,47 @@ namespace vsg
         const VkClearColorValue& clearColor() const { return _clearColor; }
 
         Instance* getInstance() { return _instance; }
-        Instance* getOrCreateInstance() { if (!_instance) _initInstance(); return _instance; }
+        Instance* getOrCreateInstance()
+        {
+            if (!_instance) _initInstance();
+            return _instance;
+        }
 
         Surface* getSurface() { return _surface; }
-        Surface* getOrCreateSurface() { if (!_surface) _initSurface(); return _surface; }
+        Surface* getOrCreateSurface()
+        {
+            if (!_surface) _initSurface();
+            return _surface;
+        }
 
         Device* getDevice() { return _device; }
-        Device* getOrCreateDevice() { if (!_device) _initDevice(); return _device; }
+        Device* getOrCreateDevice()
+        {
+            if (!_device) _initDevice();
+            return _device;
+        }
 
         PhysicalDevice* getPhysicalDevice() { return _physicalDevice; }
-        PhysicalDevice* getOrCreatePhysicalDevice() { if (!_physicalDevice) _initDevice(); return _physicalDevice; }
+        PhysicalDevice* getOrCreatePhysicalDevice()
+        {
+            if (!_physicalDevice) _initDevice();
+            return _physicalDevice;
+        }
 
         void setRenderPass(RenderPass* renderPass) { _renderPass = renderPass; }
         RenderPass* getRenderPass() { return _renderPass; }
-        RenderPass* getOrCreateRenderPass() { if (!_renderPass) _initRenderPass(); return _renderPass; }
+        RenderPass* getOrCreateRenderPass()
+        {
+            if (!_renderPass) _initRenderPass();
+            return _renderPass;
+        }
 
         Swapchain* getSwapchain() { return _swapchain; }
-        Swapchain* getOrCreateSwapchain() { if (!_swapchain) _initSwapchain(); return _swapchain; }
+        Swapchain* getOrCreateSwapchain()
+        {
+            if (!_swapchain) _initSwapchain();
+            return _swapchain;
+        }
 
         size_t numFrames() const { return _frames.size(); }
 

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -34,6 +34,8 @@ namespace vsg
 
         static ref_ptr<Window> create(vsg::ref_ptr<WindowTraits> traits);
 
+        virtual const char* instanceExtensionSurfaceName() const = 0;
+
         virtual bool valid() const { return false; }
 
         virtual bool visible() const { return valid(); }
@@ -51,23 +53,24 @@ namespace vsg
         VkClearColorValue& clearColor() { return _clearColor; }
         const VkClearColorValue& clearColor() const { return _clearColor; }
 
-        Instance* instance() { return _instance; }
-        const Instance* instance() const { return _instance; }
+        Instance* getInstance() { return _instance; }
+        Instance* getOrCreateInstance() { if (!_instance) _initInstance(); return _instance; }
 
-        PhysicalDevice* physicalDevice() { return _physicalDevice; }
-        const PhysicalDevice* physicalDevice() const { return _physicalDevice; }
+        Surface* getSurface() { return _surface; }
+        Surface* getOrCreateSurface() { if (!_surface) _initSurface(); return _surface; }
 
-        Device* device() { return _device; }
-        const Device* device() const { return _device; }
+        Device* getDevice() { return _device; }
+        Device* getOrCreateDevice() { if (!_device) _initDevice(); return _device; }
 
-        Surface* surface() { return _surface; }
-        const Surface* surface() const { return _surface; }
+        PhysicalDevice* getPhysicalDevice() { return _physicalDevice; }
+        PhysicalDevice* getOrCreatePhysicalDevice() { if (!_physicalDevice) _initDevice(); return _physicalDevice; }
 
-        RenderPass* renderPass() { return _renderPass; }
-        const RenderPass* renderPass() const { return _renderPass; }
+        void setRenderPass(RenderPass* renderPass) { _renderPass = renderPass; }
+        RenderPass* getRenderPass() { return _renderPass; }
+        RenderPass* getOrCreateRenderPass() { if (!_renderPass) _initRenderPass(); return _renderPass; }
 
-        Swapchain* swapchain() { return _swapchain; }
-        const Swapchain* swapchain() const { return _swapchain; }
+        Swapchain* getSwapchain() { return _swapchain; }
+        Swapchain* getOrCreateSwapchain() { if (!_swapchain) _initSwapchain(); return _swapchain; }
 
         size_t numFrames() const { return _frames.size(); }
 
@@ -79,6 +82,7 @@ namespace vsg
 
         VkResult acquireNextImage(uint64_t timeout = std::numeric_limits<uint64_t>::max())
         {
+            if (!_swapchain) _initSwapchain();
             return vkAcquireNextImageKHR(*_device, *_swapchain, timeout, *(_frames[_nextImageIndex].imageAvailableSemaphore), VK_NULL_HANDLE, &_nextImageIndex);
         }
 
@@ -101,14 +105,19 @@ namespace vsg
         Frames& frames() { return _frames; }
 
     protected:
-        Window(ref_ptr<WindowTraits> traits, AllocationCallbacks* allocator);
+        Window(ref_ptr<WindowTraits> traits);
 
         virtual ~Window();
 
+        virtual void _initSurface() = 0;
+        void _initInstance();
+        void _initDevice();
+        void _initRenderPass();
+        void _initSwapchain();
+
         virtual void clear();
         void share(const Window& window);
-        void initaliseDevice();
-        void buildSwapchain(uint32_t width, uint32_t height);
+        void buildSwapchain();
 
         ref_ptr<WindowTraits> _traits;
 

--- a/include/vsg/viewer/WindowTraits.h
+++ b/include/vsg/viewer/WindowTraits.h
@@ -84,12 +84,4 @@ namespace vsg
     };
     VSG_type_name(vsg::WindowTraits);
 
-    /// convinience function used by Window implementations to set the required instanceExtensionNames
-    inline ref_ptr<WindowTraits> assignSurfaceExtension(ref_ptr<WindowTraits> traits, const char* name)
-    {
-        traits->instanceExtensionNames.push_back("VK_KHR_surface");
-        traits->instanceExtensionNames.push_back(name);
-        return traits;
-    }
-
 } // namespace vsg

--- a/include/vsg/viewer/WindowTraits.h
+++ b/include/vsg/viewer/WindowTraits.h
@@ -14,7 +14,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <any>
 
-#include <vsg/vk/RenderPass.h>
 #include <vsg/vk/Swapchain.h>
 
 namespace vsg
@@ -70,7 +69,6 @@ namespace vsg
         vsg::Names deviceExtensionNames;
 
         ref_ptr<Device> device;
-        ref_ptr<RenderPass> renderPass;
 
         Window* shareWindow = nullptr;
 

--- a/include/vsg/vk/Device.h
+++ b/include/vsg/vk/Device.h
@@ -65,6 +65,4 @@ namespace vsg
     };
     VSG_type_name(vsg::Device);
 
-    extern VSG_DECLSPEC ref_ptr<Device> createDevice(WindowTraits* traits);
-
 } // namespace vsg

--- a/include/vsg/vk/Surface.h
+++ b/include/vsg/vk/Surface.h
@@ -34,4 +34,6 @@ namespace vsg
         ref_ptr<Instance> _instance;
         ref_ptr<AllocationCallbacks> _allocator;
     };
+    VSG_type_name(vsg::Surface);
+
 } // namespace vsg

--- a/src/vsg/platform/android/Android_Window.cpp
+++ b/src/vsg/platform/android/Android_Window.cpp
@@ -389,12 +389,12 @@ bool Android_Window::resized() const
 
 void Android_Window::resize()
 {
-    auto width = ANativeWindow_getWidth(_window);
-    auto height = ANativeWindow_getHeight(_window);
+    _extent2D.width = ANativeWindow_getWidth(_window);
+    _extent2D.height = ANativeWindow_getHeight(_window);
 
     LOG("resize event = wh: %d, %d", width, height);
 
-    buildSwapchain(width, height);
+    buildSwapchain();
 }
 
 bool Android_Window::handleAndroidInputEvent(AInputEvent* anEvent)

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -819,8 +819,8 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
         share(*traits->shareWindow);
     }
 
-    _extent2D.width = finalWidth;
-    _extent2D.height = finalHeight;
+    _extent2D.width = finalwidth;
+    _extent2D.height = finalheight;
 
     _first_macos_timestamp = [[NSProcessInfo processInfo] systemUptime];
     _first_macos_time_point = vsg::clock::now();

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -890,10 +890,10 @@ void MacOS_Window::resize()
     auto devicePixelScale = _traits->hdpi ? [_window backingScaleFactor] : 1.0f;
     //[_metalLayer setContentsScale:devicePixelScale];
 
-    uint32_t width = contentRect.size.width * devicePixelScale;
-    uint32_t height = contentRect.size.height * devicePixelScale;
+    _extent2D.width = contentRect.size.width * devicePixelScale;
+    _extent2D.height = contentRect.size.height * devicePixelScale;
 
-    buildSwapchain(width, height);
+    buildSwapchain();
 }
 
 bool MacOS_Window::handleNSEvent(NSEvent* anEvent)

--- a/src/vsg/platform/unix/Xcb_Window.cpp
+++ b/src/vsg/platform/unix/Xcb_Window.cpp
@@ -641,10 +641,9 @@ void Xcb_Window::resize()
     {
         _extent2D.width = geometry_reply->width;
         _extent2D.height = geometry_reply->height;
+        free(geometry_reply);
 
         buildSwapchain();
-
-        free(geometry_reply);
     }
     _windowResized = false;
 }

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -421,12 +421,10 @@ Win32_Window::Win32_Window(vsg::ref_ptr<WindowTraits> traits, vsg::AllocationCal
     uint32_t finalWidth = clientRect.right - clientRect.left;
     uint32_t finalHeight = clientRect.bottom - clientRect.top;
 
-    vsg::ref_ptr<Win32_Window> window;
-
     if (traits->shareWindow)
     {
         // share the _instance, _physicalDevice and _device;
-        window->share(*traits->shareWindow);
+        share(*traits->shareWindow);
 
         // create surface
         _surface = new vsgWin32::Win32Surface(traits->shareWindow->instance(), _window, allocator);

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -458,7 +458,7 @@ void Win32_Window::_initSurface()
 {
     if (!_instance) _initInstance();
 
-    _surface = new vsgWin32::Win32Surface(_instance, _window, _traits->allocator)
+    _surface = new vsgWin32::Win32Surface(_instance, _window, _traits->allocator);
 }
 
 bool Win32_Window::pollEvents(vsg::Events& events)
@@ -508,10 +508,10 @@ void Win32_Window::resize()
     RECT windowRect;
     GetClientRect(_window, &windowRect);
 
-    int width = windowRect.right - windowRect.left;
-    int height = windowRect.bottom - windowRect.top;
+    _extent2D.width = windowRect.right - windowRect.left;
+    _extent2D.height = windowRect.bottom - windowRect.top;
 
-    buildSwapchain(width, height);
+    buildSwapchain();
 }
 
 LRESULT Win32_Window::handleWin32Messages(UINT msg, WPARAM wParam, LPARAM lParam)

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -136,6 +136,16 @@ CompileTraversal::CompileTraversal(Device* in_device, BufferPreferences bufferPr
 {
 }
 
+CompileTraversal::CompileTraversal(Window* window, BufferPreferences bufferPreferences) :
+    context(window->getOrCreateDevice(), bufferPreferences)
+{
+    auto device = window->getDevice();
+    auto queueFamily = device->getPhysicalDevice()->getQueueFamily(VK_QUEUE_GRAPHICS_BIT);
+    context.renderPass = window->getOrCreateRenderPass();
+    context.commandPool = vsg::CommandPool::create(device, queueFamily);
+    context.graphicsQueue = device->getQueue(queueFamily);
+}
+
 CompileTraversal::CompileTraversal(const CompileTraversal& ct) :
     Inherit(ct),
     context(ct.context)

--- a/src/vsg/viewer/CommandGraph.cpp
+++ b/src/vsg/viewer/CommandGraph.cpp
@@ -32,12 +32,12 @@ CommandGraph::CommandGraph(Window* in_window)
     {
         window = in_window;
 
-        _device = window->device();
+        _device = window->getOrCreateDevice();
 
         VkQueueFlags queueFlags = VK_QUEUE_GRAPHICS_BIT;
         if (window->traits()) queueFlags = window->traits()->queueFlags;
 
-        std::tie(_queueFamily, _presentFamily) = window->physicalDevice()->getQueueFamily(queueFlags, window->surface());
+        std::tie(_queueFamily, _presentFamily) = _device->getPhysicalDevice()->getQueueFamily(queueFlags, window->getOrCreateSurface());
 
         for (size_t i = 0; i < window->numFrames(); ++i)
         {

--- a/src/vsg/viewer/Presentation.cpp
+++ b/src/vsg/viewer/Presentation.cpp
@@ -35,7 +35,7 @@ VkResult Presentation::present()
         //vk_semaphores.push_back(*(window->frame(window->nextImageIndex()).imageAvailableSemaphore));
         if (window->visible())
         {
-            vk_swapchains.emplace_back(*(window->swapchain()));
+            vk_swapchains.emplace_back(*(window->getOrCreateSwapchain()));
             indices.emplace_back(window->nextImageIndex());
         }
     }

--- a/src/vsg/viewer/RecordAndSubmitTask.cpp
+++ b/src/vsg/viewer/RecordAndSubmitTask.cpp
@@ -54,7 +54,7 @@ VkResult RecordAndSubmitTask::submit(ref_ptr<FrameStamp> frameStamp)
     if (recordedCommandBuffers.empty())
     {
         // nothing to do so return early
-        std::this_thread::sleep_for(std::chrono::milliseconds(16));  // sleep for 1/60th of a second
+        std::this_thread::sleep_for(std::chrono::milliseconds(16)); // sleep for 1/60th of a second
         return VK_SUCCESS;
     }
 

--- a/src/vsg/viewer/RenderGraph.cpp
+++ b/src/vsg/viewer/RenderGraph.cpp
@@ -94,10 +94,10 @@ void RenderGraph::accept(RecordTraversal& dispatchTraversal) const
         {
             // crude handling of window resize...TODO, come up with a user controllable way to handle resize.
 
-            vsg::UpdatePipeline updatePipeline(window->device());
+            vsg::UpdatePipeline updatePipeline(window->getDevice());
 
             updatePipeline.context.commandPool = dispatchTraversal.state->_commandBuffer->getCommandPool();
-            updatePipeline.context.renderPass = window->renderPass();
+            updatePipeline.context.renderPass = window->getRenderPass();
 
             if (camera)
             {
@@ -146,7 +146,7 @@ void RenderGraph::accept(RecordTraversal& dispatchTraversal) const
     }
     else if (window)
     {
-        renderPassInfo.renderPass = *(window->renderPass());
+        renderPassInfo.renderPass = *(window->getRenderPass());
     }
     if (framebuffer)
     {

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -41,7 +41,7 @@ void Viewer::deviceWaitIdle() const
         if (window->getDevice()) devices.insert(*(window->getDevice()));
     }
 
-    for(auto& device : devices)
+    for (auto& device : devices)
     {
         vkDeviceWaitIdle(device);
     }
@@ -130,7 +130,7 @@ bool Viewer::acquireNextFrame()
     {
         if (!window->visible()) continue;
 
-        while((result = window->acquireNextImage()) != VK_SUCCESS)
+        while ((result = window->acquireNextImage()) != VK_SUCCESS)
         {
             if (result == VK_ERROR_SURFACE_LOST_KHR ||
                 result == VK_ERROR_DEVICE_LOST ||
@@ -142,7 +142,7 @@ bool Viewer::acquireNextFrame()
             }
             else
             {
-                std::cout<<"Warning : window->acquireNextImage() VkResult = "<<result<<std::endl;
+                std::cout << "Warning : window->acquireNextImage() VkResult = " << result << std::endl;
                 break;
             }
         }

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -18,7 +18,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <array>
 #include <chrono>
-#include <iostream>
 
 using namespace vsg;
 

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -163,6 +163,9 @@ void Window::buildSwapchain()
     // is width and height even required here as the surface appear to control it.
     _swapchain = Swapchain::create(_physicalDevice, _device, _surface, _extent2D.width, _extent2D.height, _traits->swapchainPreferences);
 
+    // pass back the extents used by the swap chain.
+    _extent2D = _swapchain->getExtent();
+
     // create depth buffer
     //VkFormat depthFormat = VK_FORMAT_D32_SFLOAT; // VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT
     VkFormat depthFormat = VK_FORMAT_D24_UNORM_S8_UINT;

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -128,18 +128,11 @@ void Window::_initRenderPass()
 {
     if (!_device) _initDevice();
 
-    if (_traits->renderPass)
-    {
-        _renderPass = _traits->renderPass;
-    }
-    else
-    {
-        vsg::SwapChainSupportDetails supportDetails = vsg::querySwapChainSupport(*_physicalDevice, *_surface);
-        VkSurfaceFormatKHR imageFormat = vsg::selectSwapSurfaceFormat(supportDetails);
-        VkFormat depthFormat = VK_FORMAT_D24_UNORM_S8_UINT; //VK_FORMAT_D32_SFLOAT; // VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_SFLOAT_S8_UINT
+    vsg::SwapChainSupportDetails supportDetails = vsg::querySwapChainSupport(*_physicalDevice, *_surface);
+    VkSurfaceFormatKHR imageFormat = vsg::selectSwapSurfaceFormat(supportDetails);
+    VkFormat depthFormat = VK_FORMAT_D24_UNORM_S8_UINT; //VK_FORMAT_D32_SFLOAT; // VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_SFLOAT_S8_UINT
 
-        _renderPass = vsg::createRenderPass(_device, imageFormat.format, depthFormat, _traits->allocator);
-    }
+    _renderPass = vsg::createRenderPass(_device, imageFormat.format, depthFormat, _traits->allocator);
 }
 
 void Window::_initSwapchain()

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -18,34 +18,15 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <array>
 #include <chrono>
+#include <iostream>
 
 using namespace vsg;
 
-Window::Window(ref_ptr<WindowTraits> traits, vsg::AllocationCallbacks* allocator) :
+Window::Window(ref_ptr<WindowTraits> traits) :
     _traits(traits),
     _clearColor{{0.2f, 0.2f, 0.4f, 1.0f}},
     _nextImageIndex(0)
 {
-    if (_traits->device)
-    {
-        _instance = _traits->device->getInstance();
-    }
-    else
-    {
-        // create the vkInstance
-        vsg::Names instanceExtensions = traits->instanceExtensionNames;
-
-        vsg::Names requestedLayers;
-        if (traits && traits->debugLayer)
-        {
-            instanceExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-            requestedLayers.push_back("VK_LAYER_LUNARG_standard_validation");
-            if (traits->apiDumpLayer) requestedLayers.push_back("VK_LAYER_LUNARG_api_dump");
-        }
-
-        vsg::Names validatedNames = vsg::validateInstancelayerNames(requestedLayers);
-        _instance = vsg::Instance::create(instanceExtensions, validatedNames, allocator);
-    }
 }
 
 Window::~Window()
@@ -76,8 +57,42 @@ void Window::share(const Window& window)
     _renderPass = window._renderPass;
 }
 
-void Window::initaliseDevice()
+void Window::_initInstance()
 {
+    if (_traits->device)
+    {
+        _instance = _traits->device->getInstance();
+    }
+    else
+    {
+        // create the vkInstance
+        vsg::Names instanceExtensions = _traits->instanceExtensionNames;
+
+        instanceExtensions.push_back("VK_KHR_surface");
+        instanceExtensions.push_back(instanceExtensionSurfaceName());
+
+        vsg::Names requestedLayers;
+        if (_traits->debugLayer)
+        {
+            instanceExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+            requestedLayers.push_back("VK_LAYER_LUNARG_standard_validation");
+            if (_traits->apiDumpLayer) requestedLayers.push_back("VK_LAYER_LUNARG_api_dump");
+        }
+
+        // TODO need to decide whether we need to have a Window::_allocator or traits member.
+        vsg::AllocationCallbacks* allocator = nullptr;
+
+        vsg::Names validatedNames = vsg::validateInstancelayerNames(requestedLayers);
+        _instance = vsg::Instance::create(instanceExtensions, validatedNames, allocator);
+    }
+}
+
+void Window::_initDevice()
+{
+    if (!_instance) _initInstance();
+    if (!_surface) _initSurface();
+
+    // Device
     if (_traits->device)
     {
         _device = _traits->device;
@@ -107,8 +122,12 @@ void Window::initaliseDevice()
         _device = vsg::Device::create(physicalDevice, queueSettings, validatedNames, deviceExtensions, _traits->allocator);
         _physicalDevice = physicalDevice;
     }
+}
 
-    // set up renderpass with the imageFormat that the swap chain will use
+void Window::_initRenderPass()
+{
+    if (!_device) _initDevice();
+
     if (_traits->renderPass)
     {
         _renderPass = _traits->renderPass;
@@ -123,7 +142,15 @@ void Window::initaliseDevice()
     }
 }
 
-void Window::buildSwapchain(uint32_t width, uint32_t height)
+void Window::_initSwapchain()
+{
+    if (!_device) _initDevice();
+    if (!_renderPass) _initRenderPass();
+
+    buildSwapchain();
+}
+
+void Window::buildSwapchain()
 {
     if (_swapchain)
     {
@@ -141,11 +168,7 @@ void Window::buildSwapchain(uint32_t width, uint32_t height)
     }
 
     // is width and height even required here as the surface appear to control it.
-
-    _swapchain = Swapchain::create(_physicalDevice, _device, _surface, width, height, _traits->swapchainPreferences);
-
-    // pass back the extents used by the swap chain.
-    _extent2D = _swapchain->getExtent();
+    _swapchain = Swapchain::create(_physicalDevice, _device, _surface, _extent2D.width, _extent2D.height, _traits->swapchainPreferences);
 
     // create depth buffer
     //VkFormat depthFormat = VK_FORMAT_D32_SFLOAT; // VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT

--- a/src/vsg/vk/Device.cpp
+++ b/src/vsg/vk/Device.cpp
@@ -134,35 +134,6 @@ Device::~Device()
     releaseDeiviceID(deviceID);
 }
 
-ref_ptr<Device> vsg::createDevice(WindowTraits* windowTraits)
-{
-    vsg::Names instanceExtensions = windowTraits->instanceExtensionNames;
-
-    vsg::Names requestedLayers;
-    if (windowTraits && windowTraits->debugLayer)
-    {
-        instanceExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-        requestedLayers.push_back("VK_LAYER_LUNARG_standard_validation");
-        if (windowTraits->apiDumpLayer) requestedLayers.push_back("VK_LAYER_LUNARG_api_dump");
-    }
-
-    vsg::Names validatedNames = vsg::validateInstancelayerNames(requestedLayers);
-
-    auto instance = vsg::Instance::create(instanceExtensions, validatedNames, windowTraits->allocator);
-
-    // set up device
-    auto [physicalDevice, queueFamily] = instance->getPhysicalDeviceAndQueueFamily(windowTraits->queueFlags);
-    if (!physicalDevice || queueFamily < 0) throw Exception{"Error: vsg::Device::create(...) failed to create logical device.", VK_ERROR_INITIALIZATION_FAILED};
-
-    vsg::Names deviceExtensions;
-    deviceExtensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
-
-    deviceExtensions.insert(deviceExtensions.end(), windowTraits->deviceExtensionNames.begin(), windowTraits->deviceExtensionNames.end());
-
-    vsg::QueueSettings queueSettings{vsg::QueueSetting{queueFamily, {1.0}}};
-    return vsg::Device::create(physicalDevice, queueSettings, validatedNames, deviceExtensions, windowTraits->allocator);
-}
-
 ref_ptr<Queue> Device::getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex)
 {
     for (auto& queue : _queues)


### PR DESCRIPTION
Changed vsg::Window Vulkan object setup so that rather it all being done in the constructors that Vulkan objects are initialized just in time/on demand.  This approach allow users to inject their own Vulkan objects when required to customized setup.