### PR TITLE
Moore/multisample

### DIFF
--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -120,10 +120,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/viewer/CommandGraph.h>
 #include <vsg/viewer/CopyImageViewToWindow.h>
 #include <vsg/viewer/EllipsoidModel.h>
+#include <vsg/viewer/FrameAssembly.h>
 #include <vsg/viewer/Presentation.h>
 #include <vsg/viewer/ProjectionMatrix.h>
 #include <vsg/viewer/RecordAndSubmitTask.h>
 #include <vsg/viewer/RenderGraph.h>
+#include <vsg/viewer/SingleFrameAssembly.h>
 #include <vsg/viewer/Trackball.h>
 #include <vsg/viewer/ViewMatrix.h>
 #include <vsg/viewer/Viewer.h>

--- a/include/vsg/viewer/FrameAssembly.h
+++ b/include/vsg/viewer/FrameAssembly.h
@@ -1,0 +1,41 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/vk/ImageView.h>
+#include <vsg/vk/RenderPass.h>
+#include <vsg/vk/Framebuffer.h>
+
+#include <utility>
+
+namespace vsg
+{
+    class VSG_DECLSPEC FrameAssembly : public Inherit<Object, FrameAssembly>
+    {
+    public:
+        FrameAssembly()
+        {
+        }
+        struct AttachmentImageView
+        {
+            ref_ptr<ImageView> imageView;
+        };
+        using AttachmentImageViews = std::vector<AttachmentImageView>;
+        using FrameRender = std::pair<ref_ptr<Framebuffer>, ref_ptr<RenderPass>>;
+        // Not clear yet what arguments getFrameRender should pass.
+        virtual FrameRender getFrameRender() = 0;
+        virtual ref_ptr<Device> getDevice() const = 0;
+        virtual const VkExtent2D& getExtent2D() const = 0;
+    protected:
+    };
+}

--- a/include/vsg/viewer/FrameAssembly.h
+++ b/include/vsg/viewer/FrameAssembly.h
@@ -31,7 +31,8 @@ namespace vsg
             ref_ptr<ImageView> imageView;
         };
         using AttachmentImageViews = std::vector<AttachmentImageView>;
-        using FrameRender = std::pair<ref_ptr<Framebuffer>, ref_ptr<RenderPass>>;
+        using ClearValues = std::vector<VkClearValue>;
+        using FrameRender = std::tuple<ref_ptr<Framebuffer>, ref_ptr<RenderPass>, const ClearValues&>;
         // Not clear yet what arguments getFrameRender should pass.
         virtual FrameRender getFrameRender() = 0;
         virtual ref_ptr<Device> getDevice() const = 0;

--- a/include/vsg/viewer/RenderGraph.h
+++ b/include/vsg/viewer/RenderGraph.h
@@ -36,11 +36,10 @@ namespace vsg
 
         RenderPass* getRenderPass()
         {
-            auto [frameBuffer, renderPass] = frameAssembly->getFrameRender();
+            auto [frameBuffer, renderPass, clearValues] = frameAssembly->getFrameRender();
             return renderPass.get();
         }
         using ClearValues = std::vector<VkClearValue>;
-        ClearValues clearValues; // initialize window colour and depth/stencil
 
         // windopw extent at previous frame
         const uint32_t invalid_dimension = std::numeric_limits<uint32_t>::max();

--- a/include/vsg/viewer/SingleFrameAssembly.h
+++ b/include/vsg/viewer/SingleFrameAssembly.h
@@ -12,42 +12,29 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/nodes/Group.h>
-
-#include <vsg/viewer/Camera.h>
-#include <vsg/viewer/Window.h>
 #include <vsg/viewer/FrameAssembly.h>
 
 namespace vsg
 {
-    class RenderGraph : public Inherit<Group, RenderGraph>
+    class VSG_DECLSPEC SingleFrameAssembly : public Inherit<FrameAssembly, SingleFrameAssembly>
     {
     public:
-        RenderGraph();
-
-        using Group::accept;
-
-        void accept(RecordTraversal& dispatchTraversal) const override;
-
-        ref_ptr<Camera> camera; // camera that the trackball controls
-
-        ref_ptr<FrameAssembly> frameAssembly;
-        VkRect2D renderArea; // viewport dimensions
-
-        RenderPass* getRenderPass()
+        SingleFrameAssembly(ref_ptr<Framebuffer> frameBuffer, ref_ptr<RenderPass> renderPass,
+                            const VkExtent2D& extent2D = VkExtent2D{})
+            : _frameBuffer(std::move(frameBuffer)), _renderPass(std::move(renderPass)),
+              _extent2D(extent2D)
         {
-            auto [frameBuffer, renderPass] = frameAssembly->getFrameRender();
-            return renderPass.get();
         }
-        using ClearValues = std::vector<VkClearValue>;
-        ClearValues clearValues; // initialize window colour and depth/stencil
-
-        // windopw extent at previous frame
-        const uint32_t invalid_dimension = std::numeric_limits<uint32_t>::max();
-        mutable VkExtent2D previous_extent = VkExtent2D{invalid_dimension, invalid_dimension};
+        FrameRender getFrameRender() override;
+        ref_ptr<Device> getDevice() const override;
+        const VkExtent2D& getExtent2D() const override;
+        void setExtent2D(VkExtent2D extent2D)
+        {
+            _extent2D = std::move(extent2D);
+        }
+    protected:
+        ref_ptr<Framebuffer> _frameBuffer;
+        ref_ptr<RenderPass> _renderPass;
+        VkExtent2D _extent2D;
     };
-
-    /// convience function that sets up RenderGraph to render the specified scene graph from the speified Camera view
-    ref_ptr<RenderGraph> createRenderGraphForView(Window* window, Camera* camera, Node* scenegraph);
-
-} // namespace vsg
+}

--- a/include/vsg/viewer/SingleFrameAssembly.h
+++ b/include/vsg/viewer/SingleFrameAssembly.h
@@ -20,8 +20,10 @@ namespace vsg
     {
     public:
         SingleFrameAssembly(ref_ptr<Framebuffer> frameBuffer, ref_ptr<RenderPass> renderPass,
+                            const ClearValues clearValues,
                             const VkExtent2D& extent2D = VkExtent2D{})
             : _frameBuffer(std::move(frameBuffer)), _renderPass(std::move(renderPass)),
+              _clearValues(clearValues),
               _extent2D(extent2D)
         {
         }
@@ -35,6 +37,7 @@ namespace vsg
     protected:
         ref_ptr<Framebuffer> _frameBuffer;
         ref_ptr<RenderPass> _renderPass;
+        ClearValues _clearValues;
         VkExtent2D _extent2D;
     };
 }

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -23,10 +23,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/Semaphore.h>
 
 #include <vsg/viewer/WindowTraits.h>
+#include <vsg/viewer/FrameAssembly.h>
 
 namespace vsg
 {
-    class VSG_DECLSPEC Window : public Inherit<Object, Window>
+    class VSG_DECLSPEC Window : public Inherit<FrameAssembly, Window>
     {
     public:
         Window(const Window&) = delete;
@@ -127,6 +128,10 @@ namespace vsg
 
         Frame& frame(uint32_t i) { return _frames[i]; }
         Frames& frames() { return _frames; }
+
+        FrameAssembly::FrameRender getFrameRender() override;
+        ref_ptr<Device> getDevice() const override;
+        const VkExtent2D& getExtent2D() const override;
 
     protected:
         Window(ref_ptr<WindowTraits> traits);

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -13,6 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <any>
+#include <optional>
 
 #include <vsg/ui/UIEvent.h>
 
@@ -133,6 +134,8 @@ namespace vsg
         ref_ptr<Device> getDevice() const override;
         const VkExtent2D& getExtent2D() const override;
 
+        VkSampleCountFlagBits getFramebufferSamples();
+
     protected:
         Window(ref_ptr<WindowTraits> traits);
 
@@ -152,6 +155,8 @@ namespace vsg
 
         VkExtent2D _extent2D;
         VkClearColorValue _clearColor;
+        FrameAssembly::ClearValues _clearValues;
+        VkSurfaceFormatKHR _imageFormat;
 
         ref_ptr<Instance> _instance;
         ref_ptr<PhysicalDevice> _physicalDevice;
@@ -162,6 +167,9 @@ namespace vsg
         ref_ptr<Image> _depthImage;
         ref_ptr<DeviceMemory> _depthImageMemory;
         ref_ptr<ImageView> _depthImageView;
+        std::optional<VkSampleCountFlagBits> _framebufferSamples;
+        ref_ptr<Image> _multisampleImage;
+        ref_ptr<ImageView> _multisampleImageView;
 
         Frames _frames;
         uint32_t _nextImageIndex;

--- a/include/vsg/viewer/WindowTraits.h
+++ b/include/vsg/viewer/WindowTraits.h
@@ -68,6 +68,11 @@ namespace vsg
         vsg::Names instanceExtensionNames;
         vsg::Names deviceExtensionNames;
 
+        // Multisampling
+        // A bitmask of sample counts. The window's framebuffer will
+        // be configured with the maxium requested value that is
+        // supported by the device.
+        VkSampleCountFlags samples = VK_SAMPLE_COUNT_1_BIT;
         ref_ptr<Device> device;
 
         Window* shareWindow = nullptr;

--- a/include/vsg/vk/ImageView.h
+++ b/include/vsg/vk/ImageView.h
@@ -16,6 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
+    class Context;
 
     class VSG_DECLSPEC ImageView : public Inherit<Object, ImageView>
     {
@@ -42,5 +43,10 @@ namespace vsg
         ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::ImageView);
+
+    extern ref_ptr<ImageView> createImageView(Context& context, const VkImageCreateInfo& imageCreateInfo,
+                                              VkImageAspectFlags aspectFlags, VkImageLayout targetImageLayout);
+    extern ref_ptr<ImageView> createImageView(Device* device, const VkImageCreateInfo& imageCreateInfo,
+                                              VkImageAspectFlags aspectFlags, VkImageLayout targetImageLayout);
 
 } // namespace vsg

--- a/include/vsg/vk/RenderPass.h
+++ b/include/vsg/vk/RenderPass.h
@@ -41,5 +41,7 @@ namespace vsg
     VSG_type_name(vsg::RenderPass);
 
     extern ref_ptr<RenderPass> createRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat, AllocationCallbacks* allocator = nullptr);
+    extern ref_ptr<RenderPass> createMultisampledRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat,
+                                                            VkSampleCountFlagBits samples, AllocationCallbacks* allocator = nullptr);
 
 } // namespace vsg

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SOURCES
     viewer/RenderGraph.cpp
     viewer/Presentation.cpp
     viewer/RecordAndSubmitTask.cpp
+    viewer/SingleFrameAssembly.cpp
 
     raytracing/AccelerationGeometry.cpp
     raytracing/AccelerationStructure.cpp

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -197,7 +197,7 @@ void CompileTraversal::apply(RenderGraph& renderGraph)
     }
     else
     {
-        context.viewport = vsg::ViewportState::create(renderGraph.window->extent2D());
+        context.viewport = vsg::ViewportState::create(renderGraph.frameAssembly->getExtent2D());
     }
 
     renderGraph.traverse(*this);

--- a/src/vsg/viewer/FrameAssembly.cpp
+++ b/src/vsg/viewer/FrameAssembly.cpp
@@ -1,0 +1,1 @@
+#include <vsg/viewer/FrameAssembly.h>

--- a/src/vsg/viewer/SingleFrameAssembly.cpp
+++ b/src/vsg/viewer/SingleFrameAssembly.cpp
@@ -11,12 +11,13 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/viewer/SingleFrameAssembly.h>
+#include <vsg/vk/Context.h>
 
 using namespace vsg;
 
 FrameAssembly::FrameRender SingleFrameAssembly::getFrameRender()
 {
-    return FrameRender(_frameBuffer, _renderPass);
+    return FrameRender(_frameBuffer, _renderPass, _clearValues);
 }
 
 ref_ptr<Device> SingleFrameAssembly::getDevice() const

--- a/src/vsg/viewer/SingleFrameAssembly.cpp
+++ b/src/vsg/viewer/SingleFrameAssembly.cpp
@@ -1,0 +1,30 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/viewer/SingleFrameAssembly.h>
+
+using namespace vsg;
+
+FrameAssembly::FrameRender SingleFrameAssembly::getFrameRender()
+{
+    return FrameRender(_frameBuffer, _renderPass);
+}
+
+ref_ptr<Device> SingleFrameAssembly::getDevice() const
+{
+    return ref_ptr<Device>(_frameBuffer->getDevice());
+}
+
+const VkExtent2D& SingleFrameAssembly::getExtent2D() const
+{
+    return _extent2D;
+}

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -239,3 +239,22 @@ void Window::buildSwapchain()
 
     _nextImageIndex = 0;
 }
+
+FrameAssembly::FrameRender Window::getFrameRender()
+{
+    if (!_renderPass)
+    {
+        _initRenderPass();
+    }
+    return FrameRender(_frames[nextImageIndex()].framebuffer, _renderPass);
+}
+
+ref_ptr<Device> Window::getDevice() const
+{
+    return _device;
+}
+
+const VkExtent2D& Window::getExtent2D() const
+{
+    return _extent2D;
+}

--- a/src/vsg/vk/RenderPass.cpp
+++ b/src/vsg/vk/RenderPass.cpp
@@ -101,3 +101,95 @@ ref_ptr<RenderPass> vsg::createRenderPass(Device* device, VkFormat imageFormat, 
 
     return RenderPass::create(device, attachments, subpasses, dependencies, allocator);
 }
+
+ref_ptr<RenderPass> vsg::createMultisampledRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat,
+                                                      VkSampleCountFlagBits samples, AllocationCallbacks* allocator)
+{
+    if (samples == VK_SAMPLE_COUNT_1_BIT)
+    {
+        return createRenderPass(device, imageFormat, depthFormat, allocator);
+    }
+    RenderPass::Attachments attachments;
+
+    // First attachment is multisampled target.
+    VkAttachmentDescription colorAttachment = {};
+    colorAttachment.format = imageFormat;
+    colorAttachment.samples = samples;
+    colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    colorAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    colorAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    colorAttachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    attachments.push_back(colorAttachment);
+
+    // Second attachment is the resolved image which will be presented.
+    VkAttachmentDescription resolveAttachment = {};
+    resolveAttachment.format = imageFormat;
+    resolveAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    resolveAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    resolveAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    resolveAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    resolveAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    resolveAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    resolveAttachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    attachments.push_back(resolveAttachment);
+
+    // Multisampled depth attachment. It won't be resolved.
+    VkAttachmentDescription depthAttachment = {};
+    depthAttachment.format = depthFormat;
+    depthAttachment.samples = samples;
+    depthAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    depthAttachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depthAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    depthAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depthAttachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    depthAttachment.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    attachments.push_back(depthAttachment);
+
+    VkAttachmentReference colorAttachmentRef = {};
+    colorAttachmentRef.attachment = 0;
+    colorAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference resolveAttachmentRef = {};
+    resolveAttachmentRef.attachment = 1;
+    resolveAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference depthAttachmentRef = {};
+    depthAttachmentRef.attachment = 2;
+    depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+    RenderPass::Subpasses subpasses;
+
+    VkSubpassDescription subpass = {};
+    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &colorAttachmentRef;
+    subpass.pResolveAttachments = &resolveAttachmentRef;
+    subpass.pDepthStencilAttachment = &depthAttachmentRef;
+    subpasses.push_back(subpass);
+
+    RenderPass::Dependencies dependencies;
+
+    VkSubpassDependency dependency = {};
+    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+    dependency.dstSubpass = 0;
+    dependency.srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    dependency.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+    dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    dependency.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+    dependencies.push_back(dependency);
+
+    VkSubpassDependency dependency2 = {};
+    dependency2.srcSubpass = 0;
+    dependency2.dstSubpass = VK_SUBPASS_EXTERNAL;
+    dependency2.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency2.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    dependency2.dstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    dependency2.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+    dependency2.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+    dependencies.push_back(dependency2);
+
+    return RenderPass::create(device, attachments, subpasses, dependencies, allocator);    
+}


### PR DESCRIPTION
# Pull Request Template

## Description

This implements the creation of a multisampled frame buffer for vsg::Viewer. If the new WindowTraits::samples member requests more than 1 bit of sampling, then a render pass and frame buffer are created with a multisampled attachment that automatically resolves, via subpass flags, to the swapchain attachment.

A FrameAssembly class has been added to abstract the interaction between the RenderGraph and a window or render-to-texture frame buffer. If you like the approach, I might add more convenience functions to that class with the objective of supporting multisampling render-to-texture.

An update to vsgviewer in vsgExamples is being submitted as well.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

If multisampling is requested, then the scene graph needs to be modified with the proper multisampling state.

## How Has This Been Tested?

I ran vsgviewer, both with sampling and without

- [X] Test A
vsgviewer --samples 4 teapot.vsgt
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware: GTX 1070
* Toolchain: Linux
* SDK:1.2.131.2

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
