### PR TITLE
Multisampling support

### DIFF
--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -53,6 +53,8 @@ namespace vsg
         VkClearColorValue& clearColor() { return _clearColor; }
         const VkClearColorValue& clearColor() const { return _clearColor; }
 
+        VkSampleCountFlagBits framebufferSamples() const { return _framebufferSamples; }
+
         Instance* getInstance() { return _instance; }
         Instance* getOrCreateInstance()
         {
@@ -147,6 +149,8 @@ namespace vsg
 
         VkExtent2D _extent2D;
         VkClearColorValue _clearColor;
+
+        VkSampleCountFlagBits _framebufferSamples;
 
         ref_ptr<Instance> _instance;
         ref_ptr<PhysicalDevice> _physicalDevice;

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -149,6 +149,8 @@ namespace vsg
 
         VkExtent2D _extent2D;
         VkClearColorValue _clearColor;
+        VkSurfaceFormatKHR _imageFormat;
+        VkFormat _depthFormat;
 
         VkSampleCountFlagBits _framebufferSamples;
 
@@ -161,6 +163,10 @@ namespace vsg
         ref_ptr<Image> _depthImage;
         ref_ptr<DeviceMemory> _depthImageMemory;
         ref_ptr<ImageView> _depthImageView;
+
+        // only required when multisampling is required
+        ref_ptr<Image> _multisampleImage;
+        ref_ptr<ImageView> _multisampleImageView;
 
         Frames _frames;
         uint32_t _nextImageIndex;

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -164,7 +164,7 @@ namespace vsg
         ref_ptr<DeviceMemory> _depthImageMemory;
         ref_ptr<ImageView> _depthImageView;
 
-        // only required when multisampling is required
+        // only used when multisampling is required
         ref_ptr<Image> _multisampleImage;
         ref_ptr<ImageView> _multisampleImageView;
 

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -146,6 +146,7 @@ CompileTraversal::CompileTraversal(Window* window, ViewportState* viewport, Buff
     context.graphicsQueue = device->getQueue(queueFamily);
 
     if (viewport) context.defaultPipelineStates.emplace_back(viewport);
+    if (window->framebufferSamples() != VK_SAMPLE_COUNT_1_BIT) context.overridePipelineStates.emplace_back(vsg::MultisampleState::create(window->framebufferSamples()));
 }
 
 CompileTraversal::CompileTraversal(const CompileTraversal& ct) :
@@ -204,6 +205,12 @@ void CompileTraversal::apply(RenderGraph& renderGraph)
     else
     {
         context.defaultPipelineStates.push_back( vsg::ViewportState::create(renderGraph.window->extent2D()) );
+    }
+
+    if (renderGraph.window)
+    {
+        ref_ptr<MultisampleState> defaultMsState = MultisampleState::create(renderGraph.window->framebufferSamples());
+        context.overridePipelineStates.push_back(defaultMsState);
     }
 
     renderGraph.traverse(*this);

--- a/src/vsg/viewer/RenderGraph.cpp
+++ b/src/vsg/viewer/RenderGraph.cpp
@@ -176,9 +176,19 @@ ref_ptr<RenderGraph> vsg::createRenderGraphForView(Window* window, Camera* camer
     renderGraph->renderArea.offset = {0, 0};
     renderGraph->renderArea.extent = window->extent2D();
 
-    renderGraph->clearValues.resize(2);
-    renderGraph->clearValues[0].color = window->clearColor();
-    renderGraph->clearValues[1].depthStencil = VkClearDepthStencilValue{1.0f, 0};
+    if (window->framebufferSamples() != VK_SAMPLE_COUNT_1_BIT)
+    {
+        renderGraph->clearValues.resize(3);
+        renderGraph->clearValues[0].color = window->clearColor();
+        renderGraph->clearValues[1].color = window->clearColor();
+        renderGraph->clearValues[2].depthStencil = VkClearDepthStencilValue{1.0f, 0};
+    }
+    else
+    {
+        renderGraph->clearValues.resize(2);
+        renderGraph->clearValues[0].color = window->clearColor();
+        renderGraph->clearValues[1].depthStencil = VkClearDepthStencilValue{1.0f, 0};
+    }
 
     return renderGraph;
 }

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -129,10 +129,10 @@ void Window::_initDevice()
     {
         VkSampleCountFlags deviceColorSamples = _physicalDevice->getProperties().limits.framebufferColorSampleCounts;
         VkSampleCountFlags deviceDepthSamples = _physicalDevice->getProperties().limits.framebufferDepthSampleCounts;
-        unsigned satisfied = deviceColorSamples & deviceDepthSamples & _traits->samples;
+        VkSampleCountFlags satisfied = deviceColorSamples & deviceDepthSamples & _traits->samples;
         if (satisfied != 0)
         {
-            unsigned highest = 1 << static_cast<unsigned>(floor(log2(satisfied)));
+            uint32_t highest = 1 << static_cast<uint32_t>(floor(log2(satisfied)));
             _framebufferSamples = static_cast<VkSampleCountFlagBits>(highest);
         }
         else

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -146,15 +146,25 @@ void Window::_initDevice()
     }
 }
 
+#include <iostream>
+
 void Window::_initRenderPass()
 {
     if (!_device) _initDevice();
 
     vsg::SwapChainSupportDetails supportDetails = vsg::querySwapChainSupport(*_physicalDevice, *_surface);
-    VkSurfaceFormatKHR imageFormat = vsg::selectSwapSurfaceFormat(supportDetails);
-    VkFormat depthFormat = VK_FORMAT_D24_UNORM_S8_UINT; //VK_FORMAT_D32_SFLOAT; // VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_SFLOAT_S8_UINT
 
-    _renderPass = vsg::createRenderPass(_device, imageFormat.format, depthFormat, _traits->allocator);
+    _imageFormat = vsg::selectSwapSurfaceFormat(supportDetails);
+    _depthFormat = VK_FORMAT_D24_UNORM_S8_UINT; //VK_FORMAT_D32_SFLOAT; // VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_SFLOAT_S8_UINT
+
+    if (_framebufferSamples == VK_SAMPLE_COUNT_1_BIT)
+    {
+        _renderPass = vsg::createRenderPass(_device, _imageFormat.format, _depthFormat, _traits->allocator);
+    }
+    else
+    {
+        _renderPass = vsg::createMultisampledRenderPass(_device, _imageFormat.format, _depthFormat, _framebufferSamples, _traits->allocator);
+    }
 }
 
 void Window::_initSwapchain()
@@ -179,6 +189,9 @@ void Window::buildSwapchain()
         _depthImage = 0;
         _depthImageMemory = 0;
 
+        _multisampleImage = 0;
+        _multisampleImageView = 0;
+
         _swapchain = 0;
     }
 
@@ -188,9 +201,35 @@ void Window::buildSwapchain()
     // pass back the extents used by the swap chain.
     _extent2D = _swapchain->getExtent();
 
+    bool multisampling = _framebufferSamples != VK_SAMPLE_COUNT_1_BIT;
+    if (multisampling)
+    {
+        VkImageCreateInfo colorImageCreateInfo = {};
+        colorImageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        colorImageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+        colorImageCreateInfo.format = _imageFormat.format;
+        colorImageCreateInfo.extent.width = _extent2D.width;
+        colorImageCreateInfo.extent.height = _extent2D.height;
+        colorImageCreateInfo.extent.depth = 1;
+        colorImageCreateInfo.mipLevels = 1;
+        colorImageCreateInfo.arrayLayers = 1;
+        colorImageCreateInfo.samples = _framebufferSamples;
+        colorImageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+        colorImageCreateInfo.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        colorImageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        colorImageCreateInfo.flags = 0;
+        colorImageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        colorImageCreateInfo.queueFamilyIndexCount = 0;
+        colorImageCreateInfo.pNext = nullptr;
+        _multisampleImage = Image::create(_device, colorImageCreateInfo);
+
+        auto colorMemory = DeviceMemory::create(_device, _multisampleImage->getMemoryRequirements(), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        _multisampleImage->bind(colorMemory, 0);
+
+        _multisampleImageView = ImageView::create(_device, _multisampleImage, VK_IMAGE_VIEW_TYPE_2D, _imageFormat.format, VK_IMAGE_ASPECT_COLOR_BIT);
+    }
+
     // create depth buffer
-    //VkFormat depthFormat = VK_FORMAT_D32_SFLOAT; // VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT
-    VkFormat depthFormat = VK_FORMAT_D24_UNORM_S8_UINT;
     VkImageCreateInfo depthImageCreateInfo = {};
     depthImageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     depthImageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
@@ -199,11 +238,11 @@ void Window::buildSwapchain()
     depthImageCreateInfo.extent.depth = 1;
     depthImageCreateInfo.mipLevels = 1;
     depthImageCreateInfo.arrayLayers = 1;
-    depthImageCreateInfo.format = depthFormat;
+    depthImageCreateInfo.format = _depthFormat;
     depthImageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     depthImageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     depthImageCreateInfo.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-    depthImageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+    depthImageCreateInfo.samples = _framebufferSamples;
     depthImageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     depthImageCreateInfo.pNext = nullptr;
 
@@ -213,7 +252,7 @@ void Window::buildSwapchain()
 
     vkBindImageMemory(*_device, *_depthImage, *_depthImageMemory, 0);
 
-    _depthImageView = ImageView::create(_device, _depthImage, VK_IMAGE_VIEW_TYPE_2D, depthFormat, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
+    _depthImageView = ImageView::create(_device, _depthImage, VK_IMAGE_VIEW_TYPE_2D, _depthFormat, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     int graphicsFamily = -1;
     std::tie(graphicsFamily, std::ignore) = _physicalDevice->getQueueFamily(VK_QUEUE_GRAPHICS_BIT, _surface);
@@ -223,11 +262,17 @@ void Window::buildSwapchain()
 
     for (size_t i = 0; i < imageViews.size(); ++i)
     {
-        std::array<VkImageView, 2> attachments = {{*imageViews[i], *_depthImageView}};
+        std::vector<VkImageView> attachments;
 
         VkFramebufferCreateInfo framebufferInfo = {};
         framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
         framebufferInfo.renderPass = *_renderPass;
+        if (multisampling)
+        {
+            attachments.push_back(*_multisampleImageView);
+        }
+        attachments.push_back(*imageViews[i]);
+        attachments.push_back(*_depthImageView);
         framebufferInfo.attachmentCount = static_cast<uint32_t>(attachments.size());
         framebufferInfo.pAttachments = attachments.data();
         framebufferInfo.width = _extent2D.width;
@@ -237,7 +282,7 @@ void Window::buildSwapchain()
         ref_ptr<Semaphore> ias = vsg::Semaphore::create(_device, _traits->imageAvailableSemaphoreWaitFlag);
         ref_ptr<Framebuffer> fb = Framebuffer::create(_device, framebufferInfo);
 
-        _frames.push_back({imageViews[i], fb, ias});
+        _frames.push_back({multisampling ? _multisampleImageView : imageViews[i], fb, ias});
     }
 
     {
@@ -254,8 +299,23 @@ void Window::buildSwapchain()
             auto pipelineBarrier = PipelineBarrier::create(
                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
                 0, depthImageBarrier);
-
             pipelineBarrier->dispatch(commandBuffer);
+
+            if (multisampling)
+            {
+                std::cout<<"Setting up Multisample barrier"<<std::endl;
+
+                auto msImageBarrier = ImageMemoryBarrier::create(
+                    0, VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                    VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                    VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
+                    _multisampleImage,
+                    VkImageSubresourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
+                auto msPipelineBarrier = PipelineBarrier::create(
+                    VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                    0, msImageBarrier);
+                msPipelineBarrier->dispatch(commandBuffer);
+            }
         });
     }
 

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -146,8 +146,6 @@ void Window::_initDevice()
     }
 }
 
-#include <iostream>
-
 void Window::_initRenderPass()
 {
     if (!_device) _initDevice();
@@ -303,8 +301,6 @@ void Window::buildSwapchain()
 
             if (multisampling)
             {
-                std::cout<<"Setting up Multisample barrier"<<std::endl;
-
                 auto msImageBarrier = ImageMemoryBarrier::create(
                     0, VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
                     VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,


### PR DESCRIPTION
Using @timoore's multisample branch as a building block and reference implemented mulitsampling support.  To enable multisampling simply set the WindowTraits.samples to the preferred number of samples such as 2, 4, 8.