### PR TITLE
declare default operator= for math types

### DIFF
--- a/include/vsg/maths/plane.h
+++ b/include/vsg/maths/plane.h
@@ -55,6 +55,8 @@ namespace vsg
         constexpr t_plane(const t_plane& pl) :
             value{pl[0], pl[1], pl[2], pl[3]} {}
 
+        constexpr t_plane& operator=(const t_plane&) = default;
+
         constexpr explicit t_plane(const t_vec4<T>& v) :
             value{v[0], v[1], v[2], v[3]} {}
 

--- a/include/vsg/maths/sphere.h
+++ b/include/vsg/maths/sphere.h
@@ -59,6 +59,8 @@ namespace vsg
         constexpr t_sphere(const t_sphere& s) :
             value{s[0], s[1], s[2], s[3]} {}
 
+        constexpr t_sphere& operator=(const t_sphere&) = default;
+
         template<typename R>
         constexpr t_sphere(const t_sphere<R>& s) :
             value{static_cast<value_type>(s[0]), static_cast<value_type>(s[1]), static_cast<value_type>(s[2]), static_cast<value_type>(s[3])} {}

--- a/include/vsg/maths/vec2.h
+++ b/include/vsg/maths/vec2.h
@@ -56,6 +56,7 @@ namespace vsg
             value{} {}
         constexpr t_vec2(const t_vec2& v) :
             value{v.x, v.y} {}
+        constexpr t_vec2& operator=(const t_vec2&) = default;
         constexpr t_vec2(value_type in_x, value_type in_y) :
             value{in_x, in_y} {}
 

--- a/include/vsg/maths/vec3.h
+++ b/include/vsg/maths/vec3.h
@@ -56,6 +56,7 @@ namespace vsg
             value{} {}
         constexpr t_vec3(const t_vec3& v) :
             value{v.x, v.y, v.z} {}
+        constexpr t_vec3& operator=(const t_vec3&) = default;
         constexpr t_vec3(value_type in_x, value_type in_y, value_type in_z) :
             value{in_x, in_y, in_z} {}
 

--- a/include/vsg/maths/vec4.h
+++ b/include/vsg/maths/vec4.h
@@ -56,6 +56,7 @@ namespace vsg
             value{} {}
         constexpr t_vec4(const t_vec4& v) :
             value{v.x, v.y, v.z, v.w} {}
+        constexpr t_vec4& operator=(const t_vec4&) = default;
         constexpr t_vec4(value_type in_x, value_type in_y, value_type in_z, value_type in_w) :
             value{in_x, in_y, in_z, in_w} {}
 


### PR DESCRIPTION
This silences a spew of gcc warnings (-Wdeprecated-copy).

# Pull Request Template

## Description

It is apparently deprecated to declare a copy constructor without declaring an assignment operator. -Wdeprecated-copy is part of -Wall in gcc 9

Fixes # (issue)

## Type of change

## How Has This Been Tested?

recompiled

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain: gcc 9
* SDK:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
