### PR TITLE
Add changeExtent function to ProjectionMatrix

### DIFF
--- a/include/vsg/viewer/ProjectionMatrix.h
+++ b/include/vsg/viewer/ProjectionMatrix.h
@@ -35,6 +35,9 @@ namespace vsg
             get(matrix);
             matrix = inverse(matrix);
         }
+        virtual void changeExtent(const VkExtent2D& /*prevExtent*/, const VkExtent2D& /*newExtent*/)
+        {
+        }
     };
     VSG_type_name(vsg::ProjectionMatrix);
 
@@ -59,7 +62,10 @@ namespace vsg
 
         void get(mat4& matrix) const override { matrix = perspective(radians(fieldOfViewY), aspectRatio, nearDistance, farDistance); }
         void get(dmat4& matrix) const override { matrix = perspective(radians(fieldOfViewY), aspectRatio, nearDistance, farDistance); }
-
+        void changeExtent(const VkExtent2D&, const VkExtent2D& newExtent) override
+        {
+            aspectRatio = static_cast<double>(newExtent.width) / static_cast<double>(newExtent.height);
+        }
         double fieldOfViewY;
         double aspectRatio;
         double nearDistance;
@@ -92,7 +98,16 @@ namespace vsg
 
         void get(mat4& matrix) const override { matrix = orthographic(left, right, bottom, top, nearDistance, farDistance); }
         void get(dmat4& matrix) const override { matrix = orthographic(left, right, bottom, top, nearDistance, farDistance); }
-
+        void changeExtent(const VkExtent2D& prevExtent, const VkExtent2D& newExtent) override
+        {
+            double oldRatio
+                = static_cast<double>(prevExtent.width) / static_cast<double>(prevExtent.height);
+            double newRatio
+                = static_cast<double>(newExtent.width) / static_cast<double>(newExtent.height);
+            left *= newRatio / oldRatio;
+            right *= newRatio / oldRatio;
+        }
+        
         double left;
         double right;
         double bottom;
@@ -123,6 +138,14 @@ namespace vsg
             in_matrix = matrix * in_matrix;
         }
 
+        void changeExtent(const VkExtent2D& prevExtent, const VkExtent2D& newExtent) override
+        {
+            double oldRatio
+                = static_cast<double>(prevExtent.width) / static_cast<double>(prevExtent.height);
+            double newRatio
+                = static_cast<double>(newExtent.width) / static_cast<double>(newExtent.height);
+            matrix = scale(oldRatio / newRatio, 1.0, 1.0) * matrix;
+        }
         ref_ptr<ProjectionMatrix> projectionMatrix;
         dmat4 matrix;
     };
@@ -181,6 +204,11 @@ namespace vsg
             //std::cout<<"H = "<<H<<", l = "<<l<<", theta = "<<vsg::degrees(theta)<<", fd = "<<farDistance<<std::endl;
 
             matrix = perspective(radians(fieldOfViewY), aspectRatio, nearDistance, farDistance);
+        }
+
+        void changeExtent(const VkExtent2D&, const VkExtent2D& newExtent) override
+        {
+            aspectRatio = static_cast<double>(newExtent.width) / static_cast<double>(newExtent.height);
         }
 
         ref_ptr<LookAt> lookAt;

--- a/src/vsg/viewer/RenderGraph.cpp
+++ b/src/vsg/viewer/RenderGraph.cpp
@@ -109,14 +109,7 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
 
             if (camera)
             {
-                if (auto perspective = dynamic_cast<Perspective*>(camera->getProjectionMatrix()))
-                {
-                    perspective->aspectRatio = static_cast<double>(extent.width) / static_cast<double>(extent.height);
-                }
-                else if (auto ep = dynamic_cast<EllipsoidPerspective*>(camera->getProjectionMatrix()))
-                {
-                    ep->aspectRatio = static_cast<double>(extent.width) / static_cast<double>(extent.height);
-                }
+                camera->getProjectionMatrix()->changeExtent(previous_extent, extent);
 
                 auto viewport = camera->getViewportState();
                 updatePipeline.context.defaultPipelineStates.emplace_back(viewport);


### PR DESCRIPTION
Remove special-case window size handling from RenderGraph and support
resize of orthographic projections.

# Pull Request Template

## Description

Implementation of changes discussed on vsg-users. This simplifies RenderGraph.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added an --ortho option to vsgviewer.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain: gcc
* SDK:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
