### PR TITLE
Replace Command::dispatch(CommandBuffer&) with Command::record(CommandBuffer&)

### DIFF
--- a/include/vsg/commands/BindIndexBuffer.h
+++ b/include/vsg/commands/BindIndexBuffer.h
@@ -45,7 +45,7 @@ namespace vsg
 
         void compile(Context& context) override;
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
     protected:
         virtual ~BindIndexBuffer();

--- a/include/vsg/commands/BindVertexBuffers.h
+++ b/include/vsg/commands/BindVertexBuffers.h
@@ -52,7 +52,7 @@ namespace vsg
 
         void compile(Context& context) override;
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
     protected:
         virtual ~BindVertexBuffers();

--- a/include/vsg/commands/BlitImage.h
+++ b/include/vsg/commands/BlitImage.h
@@ -24,7 +24,7 @@ namespace vsg
     public:
         BlitImage();
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         using Regions = std::vector<VkImageBlit>;
 

--- a/include/vsg/commands/Command.h
+++ b/include/vsg/commands/Command.h
@@ -29,7 +29,7 @@ namespace vsg
 
         virtual void compile(Context& /*context*/) {}
 
-        virtual void dispatch(CommandBuffer& commandBuffer) const = 0;
+        virtual void record(CommandBuffer& commandBuffer) const = 0;
     };
     VSG_type_name(vsg::Command);
 

--- a/include/vsg/commands/Commands.h
+++ b/include/vsg/commands/Commands.h
@@ -62,7 +62,7 @@ namespace vsg
         const Children& getChildren() const noexcept { return _children; }
 
         void compile(Context& context) override;
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
     protected:
         virtual ~Commands();

--- a/include/vsg/commands/CopyImage.h
+++ b/include/vsg/commands/CopyImage.h
@@ -24,7 +24,7 @@ namespace vsg
     public:
         CopyImage();
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         using Regions = std::vector<VkImageCopy>;
 

--- a/include/vsg/commands/CopyImageToBuffer.h
+++ b/include/vsg/commands/CopyImageToBuffer.h
@@ -25,7 +25,7 @@ namespace vsg
     public:
         CopyImageToBuffer();
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         using Regions = std::vector<VkBufferImageCopy>;
 

--- a/include/vsg/commands/Dispatch.h
+++ b/include/vsg/commands/Dispatch.h
@@ -32,7 +32,7 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void dispatch(CommandBuffer& commandBuffer) const override
+        void record(CommandBuffer& commandBuffer) const override
         {
             vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
         }

--- a/include/vsg/commands/Draw.h
+++ b/include/vsg/commands/Draw.h
@@ -33,7 +33,7 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void dispatch(CommandBuffer& commandBuffer) const override
+        void record(CommandBuffer& commandBuffer) const override
         {
             vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
         }

--- a/include/vsg/commands/DrawIndexed.h
+++ b/include/vsg/commands/DrawIndexed.h
@@ -34,7 +34,7 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void dispatch(CommandBuffer& commandBuffer) const override
+        void record(CommandBuffer& commandBuffer) const override
         {
             vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
         }

--- a/include/vsg/commands/NextSubPass.h
+++ b/include/vsg/commands/NextSubPass.h
@@ -25,7 +25,7 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE;
 

--- a/include/vsg/commands/PipelineBarrier.h
+++ b/include/vsg/commands/PipelineBarrier.h
@@ -106,7 +106,7 @@ namespace vsg
             add(barrier);
         }
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         void add(ref_ptr<MemoryBarrier> mb) { memoryBarriers.emplace_back(mb); }
         void add(ref_ptr<BufferMemoryBarrier> bmb) { bufferMemoryBarriers.emplace_back(bmb); }

--- a/include/vsg/commands/PushConstants.h
+++ b/include/vsg/commands/PushConstants.h
@@ -32,7 +32,7 @@ namespace vsg
         Data* getData() noexcept { return _data; }
         const Data* getData() const noexcept { return _data; }
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
     protected:
         virtual ~PushConstants();

--- a/include/vsg/commands/README.md
+++ b/include/vsg/commands/README.md
@@ -3,7 +3,7 @@ The **include/vsg/commands** [header directory contains the scene graph level Vk
 
 ## Vulkan command integration classes
 
-Vulkan commands have a specific role in Vulkan so to encapsulate this the [vsg::Command](Command.h) pure virtual base class provides **virtual void dispatch(CommandBuffer&) const** [is overridden in the subclasses to provide specific Vulkan command calls.
+Vulkan commands have a specific role in Vulkan so to encapsulate this the [vsg::Command](Command.h) pure virtual base class provides **virtual void record(CommandBuffer&) const** [is overridden in the subclasses to provide specific Vulkan command calls.
 
 * [include/vsg/commands/BindIndexBuffer.h](BindIndexBuffer.h) - node class encapsulating vkCmdBindIndexBuffer
 * [[include/vsg/commands/BindVertexBuffers.h](BindVertexBuffers.h) - node class encapsulating vkCmdBindVertexBuffers

--- a/include/vsg/nodes/Geometry.h
+++ b/include/vsg/nodes/Geometry.h
@@ -30,7 +30,7 @@ namespace vsg
         void write(Output& output) const override;
 
         void compile(Context& context) override;
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         using DrawCommands = std::vector<ref_ptr<Command>>;
 

--- a/include/vsg/nodes/LOD.h
+++ b/include/vsg/nodes/LOD.h
@@ -26,9 +26,9 @@ namespace vsg
      *  Children should be ordered with the highest resolution Child first, thought to lowest resolution LOD child last.
      *  The Child struct stores the visibleHeightRatio and child that it's associated with.
      *  During culling tHe visibleHeightRatio is used as a ratio of screen height that Bound sphere occupies on screen needs to be at least in order for the associated child to be traversed.
-     *  Once on child passes this test no more children are checked, so that no more than on child will ever being traversed in a cull or dispatch traversal.
+     *  Once on child passes this test no more children are checked, so that no more than on child will ever being traversed in a record traversal.
      *  If no Child pass the visible height test then none of the LOD's children will be visible.
-     *  During the cull or dispatch traversals the Bound sphere is also checked against the view frustum so that LOD's also enable view frustum culling for subgraphs so there is no need for a separate CullNode/CullGroup to decorate it. */
+     *  During the record traversals the Bound sphere is also checked against the view frustum so that LOD's also enable view frustum culling for subgraphs so there is no need for a separate CullNode/CullGroup to decorate it. */
     class VSG_DECLSPEC LOD : public Inherit<Node, LOD>
     {
     public:

--- a/include/vsg/nodes/PagedLOD.h
+++ b/include/vsg/nodes/PagedLOD.h
@@ -31,9 +31,9 @@ namespace vsg
      *  Children should be ordered with the highest resolution PagedLODChild first, thought to lowest resolution PagedLOD child last.
      *  The PagedLODChild struct stores the visibleHeightRatio and child that it's associated with.
      *  During culling tHe visibleHeightRatio is used as a ratio of screen height that Bound sphere occupies on screen needs to be at least in order for the associated child to be traversed.
-     *  Once on child passes this test no more children are checked, so that no more than on child will ever being traversed in a cull or dispatch traversal.
+     *  Once on child passes this test no more children are checked, so that no more than on child will ever being traversed in a record traversal.
      *  If no PagedLODChild pass the visible height test then none of the PagedLOD's children will be visible.
-     *  During the cull or dispatch traversals the Bound sphere is also checked against the view frustum so that PagedLOD's also enable view frustum culling for subgraphs so there is no need for a separate CullNode/CullGroup to decorate it. */
+     *  During the record traversals the Bound sphere is also checked against the view frustum so that PagedLOD's also enable view frustum culling for subgraphs so there is no need for a separate CullNode/CullGroup to decorate it. */
     class VSG_DECLSPEC PagedLOD : public Inherit<Node, PagedLOD>
     {
     public:
@@ -49,7 +49,7 @@ namespace vsg
         // external file to load when child 0 is null.
         Path filename;
 
-        // priority value assigned by cull/dispatch traversal as a guide to how important the external child is for loading.
+        // priority value assigned by record traversal as a guide to how important the external child is for loading.
         mutable std::atomic<double> priority{0.0};
 
         // TODO need status of external file load

--- a/include/vsg/nodes/VertexIndexDraw.h
+++ b/include/vsg/nodes/VertexIndexDraw.h
@@ -29,7 +29,7 @@ namespace vsg
         void write(Output& output) const override;
 
         void compile(Context& context) override;
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         // vkCmdDrawIndexed settings
         // vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);

--- a/include/vsg/raytracing/RayTracingPipeline.h
+++ b/include/vsg/raytracing/RayTracingPipeline.h
@@ -95,7 +95,7 @@ namespace vsg
         RayTracingPipeline* getPipeline() { return _pipeline; }
         const RayTracingPipeline* getPipeline() const { return _pipeline; }
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         // compile the Vulkan object, context parameter used for Device
         void compile(Context& context) override;

--- a/include/vsg/raytracing/TraceRays.h
+++ b/include/vsg/raytracing/TraceRays.h
@@ -23,7 +23,7 @@ namespace vsg
     public:
         TraceRays();
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         ref_ptr<RayTracingShaderGroup> raygen;
         ref_ptr<RayTracingShaderGroup> missShader;

--- a/include/vsg/state/ComputePipeline.h
+++ b/include/vsg/state/ComputePipeline.h
@@ -79,7 +79,7 @@ namespace vsg
         ComputePipeline* getPipeline() { return _pipeline; }
         const ComputePipeline* getPipeline() const { return _pipeline; }
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         // compile the Vulkan object, context parameter used for Device
         void compile(Context& context) override;

--- a/include/vsg/state/DescriptorSet.h
+++ b/include/vsg/state/DescriptorSet.h
@@ -124,7 +124,7 @@ namespace vsg
         // compile the Vulkan object, context parameter used for Device
         void compile(Context& context) override;
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
     protected:
         virtual ~BindDescriptorSets() {}
@@ -191,7 +191,7 @@ namespace vsg
         // compile the Vulkan object, context parameter used for Device
         void compile(Context& context) override;
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
     protected:
         virtual ~BindDescriptorSet() {}

--- a/include/vsg/state/GraphicsPipeline.h
+++ b/include/vsg/state/GraphicsPipeline.h
@@ -110,7 +110,7 @@ namespace vsg
         GraphicsPipeline* getPipeline() { return _pipeline; }
         const GraphicsPipeline* getPipeline() const { return _pipeline; }
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         // compile the Vulkan object, context parameter used for Device
         void compile(Context& context) override;

--- a/include/vsg/viewer/CopyImageViewToWindow.h
+++ b/include/vsg/viewer/CopyImageViewToWindow.h
@@ -33,7 +33,7 @@ namespace vsg
             _extent2D = window->extent2D();
         }
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
     };
 
 } // namespace vsg

--- a/include/vsg/viewer/ExecuteCommands.h
+++ b/include/vsg/viewer/ExecuteCommands.h
@@ -34,7 +34,7 @@ namespace vsg
         void completed(ref_ptr<CommandBuffer> commandBuffer);
 
         /// call vkCmdExecuteCommands with all the CommandBuffer that have been recorded with this ExecuteCommands
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
     protected:
         virtual ~ExecuteCommands();

--- a/include/vsg/viewer/README.md
+++ b/include/vsg/viewer/README.md
@@ -2,6 +2,5 @@
 
 The include/vsg/viewer header directory contains the Windowing  and Viewer classes required to create a Vulkan window(s) and viewer to render to it/then.
 
-* [include/vsg/viewer/GraphicsStage.h](GraphicsStage.h) - class for managing the dispatch of Vulkan state and geometry data into the Vulkan graphics queue.
-* [include/vsg/viewer/Window.h](Window.h) - base class for creation of Windows with Vulkan support.  Subclasses from vsg::Window provide the implementation for the different target platforms.  Currently a GLFW based Window is provided internally by libvsg to server the role as cross platform Window implementation.  Plan is to replace the GLFW version with native Windowing implementations.
-* [include/vsg/viewer/Viewer.h](Viewer.h) - high level viewer class for managing vsg::Window(s) and rendering of graphics to them.
+* [include/vsg/viewer/Window.h](Window.h) - base class for creation of Windows with Vulkan support.  Subclasses from vsg::Window provide the implementation for the different target platforms, these can be found in include/vsg/platform directory
+* [include/vsg/viewer/Viewer.h](Viewer.h) - high level viewer class for managing vsg::Window(s) and rendering graphics to them.

--- a/include/vsg/vk/Context.h
+++ b/include/vsg/vk/Context.h
@@ -80,7 +80,7 @@ namespace vsg
         BufferData source;
         BufferData destination;
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
     protected:
         virtual ~CopyAndReleaseBufferDataCommand();
@@ -94,7 +94,7 @@ namespace vsg
             destination(dest),
             mipLevels(numMipMapLevels) {}
 
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         BufferData source;
         ImageData destination;
@@ -110,14 +110,14 @@ namespace vsg
         BuildAccelerationStructureCommand(Device* device, VkAccelerationStructureInfoNV* info, const VkAccelerationStructureNV& structure, Buffer* instanceBuffer, Allocator* allocator = nullptr);
 
         void compile(Context&) override {}
-        void dispatch(CommandBuffer& commandBuffer) const override;
+        void record(CommandBuffer& commandBuffer) const override;
 
         ref_ptr<Device> _device;
         VkAccelerationStructureInfoNV* _accelerationStructureInfo;
         VkAccelerationStructureNV _accelerationStructure;
         ref_ptr<Buffer> _instanceBuffer;
 
-        // scratch buffer set after compile traversal before dispatch of build commands
+        // scratch buffer set after compile traversal before record of build commands
         ref_ptr<Buffer> _scratchBuffer;
     };
 
@@ -165,7 +165,7 @@ namespace vsg
         std::vector<ref_ptr<CopyAndReleaseImageDataCommand>> copyImageDataCommands;
         std::vector<ref_ptr<Command>> commands;
 
-        void dispatch();
+        void record();
         void waitForCompletion();
 
         ref_ptr<CommandBuffer> getOrCreateCommandBuffer();

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -55,11 +55,11 @@ namespace vsg
         T& top() { return stack.top(); }
         const T& top() const { return stack.top(); }
 
-        inline void dispatch(CommandBuffer& commandBuffer)
+        inline void record(CommandBuffer& commandBuffer)
         {
             if (dirty)
             {
-                stack.top()->dispatch(commandBuffer);
+                stack.top()->record(commandBuffer);
                 dirty = false;
             }
         }
@@ -149,7 +149,7 @@ namespace vsg
             dirty = true;
         }
 
-        inline void dispatch(CommandBuffer& commandBuffer)
+        inline void record(CommandBuffer& commandBuffer)
         {
             if (dirty)
             {
@@ -247,17 +247,17 @@ namespace vsg
             pushFrustum();
         }
 
-        inline void dispatch()
+        inline void record()
         {
             if (dirty)
             {
                 for (auto& stateStack : stateStacks)
                 {
-                    stateStack.dispatch(*_commandBuffer);
+                    stateStack.record(*_commandBuffer);
                 }
 
-                projectionMatrixStack.dispatch(*_commandBuffer);
-                modelviewMatrixStack.dispatch(*_commandBuffer);
+                projectionMatrixStack.record(*_commandBuffer);
+                modelviewMatrixStack.record(*_commandBuffer);
 
                 dirty = false;
             }

--- a/src/vsg/commands/BindIndexBuffer.cpp
+++ b/src/vsg/commands/BindIndexBuffer.cpp
@@ -107,7 +107,7 @@ void BindIndexBuffer::compile(Context& context)
     }
 }
 
-void BindIndexBuffer::dispatch(CommandBuffer& commandBuffer) const
+void BindIndexBuffer::record(CommandBuffer& commandBuffer) const
 {
     auto& vkd = _vulkanData[commandBuffer.deviceID];
     vkCmdBindIndexBuffer(commandBuffer, *vkd.bufferData._buffer, vkd.bufferData._offset, vkd.indexType);

--- a/src/vsg/commands/BindVertexBuffers.cpp
+++ b/src/vsg/commands/BindVertexBuffers.cpp
@@ -90,7 +90,7 @@ void BindVertexBuffers::compile(Context& context)
     }
 }
 
-void BindVertexBuffers::dispatch(CommandBuffer& commandBuffer) const
+void BindVertexBuffers::record(CommandBuffer& commandBuffer) const
 {
     auto& vkd = _vulkanData[commandBuffer.deviceID];
     vkCmdBindVertexBuffers(commandBuffer, _firstBinding, static_cast<uint32_t>(vkd.vkBuffers.size()), vkd.vkBuffers.data(), vkd.offsets.data());

--- a/src/vsg/commands/BlitImage.cpp
+++ b/src/vsg/commands/BlitImage.cpp
@@ -19,7 +19,7 @@ BlitImage::BlitImage()
 {
 }
 
-void BlitImage::dispatch(CommandBuffer& commandBuffer) const
+void BlitImage::record(CommandBuffer& commandBuffer) const
 {
     vkCmdBlitImage(
         commandBuffer,

--- a/src/vsg/commands/Commands.cpp
+++ b/src/vsg/commands/Commands.cpp
@@ -62,10 +62,10 @@ void Commands::compile(Context& context)
     }
 }
 
-void Commands::dispatch(CommandBuffer& commandBuffer) const
+void Commands::record(CommandBuffer& commandBuffer) const
 {
     for (auto& command : _children)
     {
-        command->dispatch(commandBuffer);
+        command->record(commandBuffer);
     }
 }

--- a/src/vsg/commands/CopyImage.cpp
+++ b/src/vsg/commands/CopyImage.cpp
@@ -19,7 +19,7 @@ CopyImage::CopyImage()
 {
 }
 
-void CopyImage::dispatch(CommandBuffer& commandBuffer) const
+void CopyImage::record(CommandBuffer& commandBuffer) const
 {
     vkCmdCopyImage(
         commandBuffer,

--- a/src/vsg/commands/CopyImageToBuffer.cpp
+++ b/src/vsg/commands/CopyImageToBuffer.cpp
@@ -19,7 +19,7 @@ CopyImageToBuffer::CopyImageToBuffer()
 {
 }
 
-void CopyImageToBuffer::dispatch(CommandBuffer& commandBuffer) const
+void CopyImageToBuffer::record(CommandBuffer& commandBuffer) const
 {
     vkCmdCopyImageToBuffer(
         commandBuffer,

--- a/src/vsg/commands/NextSubPass.cpp
+++ b/src/vsg/commands/NextSubPass.cpp
@@ -33,7 +33,7 @@ void NextSubPass::write(Output& output) const
     output.writeValue<uint32_t>("contents", contents);
 }
 
-void NextSubPass::dispatch(CommandBuffer& commandBuffer) const
+void NextSubPass::record(CommandBuffer& commandBuffer) const
 {
     vkCmdNextSubpass(commandBuffer, contents);
 }

--- a/src/vsg/commands/PipelineBarrier.cpp
+++ b/src/vsg/commands/PipelineBarrier.cpp
@@ -92,7 +92,7 @@ PipelineBarrier::~PipelineBarrier()
 {
 }
 
-void PipelineBarrier::dispatch(CommandBuffer& commandBuffer) const
+void PipelineBarrier::record(CommandBuffer& commandBuffer) const
 {
     auto& scratchMemory = *(commandBuffer.scratchMemory);
 

--- a/src/vsg/commands/PushConstants.cpp
+++ b/src/vsg/commands/PushConstants.cpp
@@ -52,7 +52,7 @@ void PushConstants::write(Output& output) const
     output.writeObject("data", _data.get());
 }
 
-void PushConstants::dispatch(CommandBuffer& commandBuffer) const
+void PushConstants::record(CommandBuffer& commandBuffer) const
 {
     vkCmdPushConstants(commandBuffer, commandBuffer.getCurrentPipelineLayout(), _stageFlags, _offset, static_cast<uint32_t>(_data->dataSize()), _data->dataPointer());
 }

--- a/src/vsg/io/DatabasePager.cpp
+++ b/src/vsg/io/DatabasePager.cpp
@@ -399,7 +399,7 @@ void DatabasePager::start()
 #endif
                 if (!nodesCompiled.empty())
                 {
-                    ct->context.dispatch();
+                    ct->context.record();
 
                     for (auto& plod : nodesCompiled)
                     {

--- a/src/vsg/nodes/Geometry.cpp
+++ b/src/vsg/nodes/Geometry.cpp
@@ -141,7 +141,7 @@ void Geometry::compile(Context& context)
     }
 }
 
-void Geometry::dispatch(CommandBuffer& commandBuffer) const
+void Geometry::record(CommandBuffer& commandBuffer) const
 {
     auto& vkd = _vulkanData[commandBuffer.deviceID];
 
@@ -156,6 +156,6 @@ void Geometry::dispatch(CommandBuffer& commandBuffer) const
 
     for (auto& command : commands)
     {
-        command->dispatch(commandBuffer);
+        command->record(commandBuffer);
     }
 }

--- a/src/vsg/nodes/VertexIndexDraw.cpp
+++ b/src/vsg/nodes/VertexIndexDraw.cpp
@@ -139,7 +139,7 @@ void VertexIndexDraw::compile(Context& context)
     }
 }
 
-void VertexIndexDraw::dispatch(CommandBuffer& commandBuffer) const
+void VertexIndexDraw::record(CommandBuffer& commandBuffer) const
 {
     auto& vkd = _vulkanData[commandBuffer.deviceID];
 

--- a/src/vsg/raytracing/RayTracingPipeline.cpp
+++ b/src/vsg/raytracing/RayTracingPipeline.cpp
@@ -195,7 +195,7 @@ void BindRayTracingPipeline::write(Output& output) const
     output.writeObject("RayTracingPipeline", _pipeline.get());
 }
 
-void BindRayTracingPipeline::dispatch(CommandBuffer& commandBuffer) const
+void BindRayTracingPipeline::record(CommandBuffer& commandBuffer) const
 {
     vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_NV, _pipeline->vk(commandBuffer.deviceID));
     commandBuffer.setCurrentPipelineLayout(_pipeline->getPipelineLayout()->vk(commandBuffer.deviceID));

--- a/src/vsg/raytracing/TraceRays.cpp
+++ b/src/vsg/raytracing/TraceRays.cpp
@@ -20,7 +20,7 @@ TraceRays::TraceRays()
 {
 }
 
-void TraceRays::dispatch(CommandBuffer& commandBuffer) const
+void TraceRays::record(CommandBuffer& commandBuffer) const
 {
     Device* device = commandBuffer.getDevice();
     Extensions* extensions = Extensions::Get(device, true);

--- a/src/vsg/state/ComputePipeline.cpp
+++ b/src/vsg/state/ComputePipeline.cpp
@@ -122,7 +122,7 @@ void BindComputePipeline::write(Output& output) const
     output.writeObject("ComputePipeline", _pipeline.get());
 }
 
-void BindComputePipeline::dispatch(CommandBuffer& commandBuffer) const
+void BindComputePipeline::record(CommandBuffer& commandBuffer) const
 {
     vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, _pipeline->vk(commandBuffer.deviceID));
     commandBuffer.setCurrentPipelineLayout(_pipeline->getPipelineLayout()->vk(commandBuffer.deviceID));

--- a/src/vsg/state/DescriptorSet.cpp
+++ b/src/vsg/state/DescriptorSet.cpp
@@ -187,7 +187,7 @@ void BindDescriptorSets::compile(Context& context)
     }
 }
 
-void BindDescriptorSets::dispatch(CommandBuffer& commandBuffer) const
+void BindDescriptorSets::record(CommandBuffer& commandBuffer) const
 {
     auto& vkd = _vulkanData[commandBuffer.deviceID];
     vkCmdBindDescriptorSets(commandBuffer, _bindPoint, vkd._vkPipelineLayout, _firstSet, static_cast<uint32_t>(vkd._vkDescriptorSets.size()), vkd._vkDescriptorSets.data(), 0, nullptr);
@@ -241,7 +241,7 @@ void BindDescriptorSet::compile(Context& context)
     vkd._vkDescriptorSet = _descriptorSet->vk(context.deviceID);
 }
 
-void BindDescriptorSet::dispatch(CommandBuffer& commandBuffer) const
+void BindDescriptorSet::record(CommandBuffer& commandBuffer) const
 {
     auto& vkd = _vulkanData[commandBuffer.deviceID];
 

--- a/src/vsg/state/GraphicsPipeline.cpp
+++ b/src/vsg/state/GraphicsPipeline.cpp
@@ -176,7 +176,7 @@ void BindGraphicsPipeline::write(Output& output) const
     output.writeObject("GraphicsPipeline", _pipeline.get());
 }
 
-void BindGraphicsPipeline::dispatch(CommandBuffer& commandBuffer) const
+void BindGraphicsPipeline::record(CommandBuffer& commandBuffer) const
 {
     vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, _pipeline->vk(commandBuffer.deviceID));
     commandBuffer.setCurrentPipelineLayout(_pipeline->getPipelineLayout()->vk(commandBuffer.deviceID));

--- a/src/vsg/traversals/RecordTraversal.cpp
+++ b/src/vsg/traversals/RecordTraversal.cpp
@@ -307,16 +307,16 @@ void RecordTraversal::apply(const MatrixTransform& mt)
 // Vulkan nodes
 void RecordTraversal::apply(const Commands& commands)
 {
-    _state->dispatch();
+    _state->record();
     for (auto& command : commands.getChildren())
     {
-        command->dispatch(*(_state->_commandBuffer));
+        command->record(*(_state->_commandBuffer));
     }
 }
 
 void RecordTraversal::apply(const Command& command)
 {
     //    std::cout<<"Visiting Command "<<std::endl;
-    _state->dispatch();
-    command.dispatch(*(_state->_commandBuffer));
+    _state->record();
+    command.record(*(_state->_commandBuffer));
 }

--- a/src/vsg/viewer/CopyImageViewToWindow.cpp
+++ b/src/vsg/viewer/CopyImageViewToWindow.cpp
@@ -19,6 +19,8 @@ using namespace vsg;
 
 void CopyImageViewToWindow::record(CommandBuffer& commandBuffer) const
 {
+    // TODO: replace this implementation with a list of commands rather than present create commands, record commands, delete commands
+
     auto imageView = window->imageView(window->nextImageIndex());
 
     //  transition image layouts for copy

--- a/src/vsg/viewer/CopyImageViewToWindow.cpp
+++ b/src/vsg/viewer/CopyImageViewToWindow.cpp
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-void CopyImageViewToWindow::dispatch(CommandBuffer& commandBuffer) const
+void CopyImageViewToWindow::record(CommandBuffer& commandBuffer) const
 {
     auto imageView = window->imageView(window->nextImageIndex());
 
@@ -33,7 +33,7 @@ void CopyImageViewToWindow::dispatch(CommandBuffer& commandBuffer) const
         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
         0, imb_transitionSwapChainToWriteDest);
 
-    pb_transitionSwapChainToWriteDest->dispatch(commandBuffer);
+    pb_transitionSwapChainToWriteDest->record(commandBuffer);
 
     auto ibm_transitionStorageImageToReadSrc = vsg::ImageMemoryBarrier::create(
         0, VK_ACCESS_TRANSFER_READ_BIT,
@@ -46,7 +46,7 @@ void CopyImageViewToWindow::dispatch(CommandBuffer& commandBuffer) const
         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
         0, ibm_transitionStorageImageToReadSrc);
 
-    pb_transitionStorageImageToReadSrc->dispatch(commandBuffer);
+    pb_transitionStorageImageToReadSrc->record(commandBuffer);
 
     // copy image
     VkImageCopy copyRegion{};
@@ -63,7 +63,7 @@ void CopyImageViewToWindow::dispatch(CommandBuffer& commandBuffer) const
     copyImage->dstImageLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     copyImage->regions.emplace_back(copyRegion);
 
-    copyImage->dispatch(commandBuffer);
+    copyImage->record(commandBuffer);
 
     // transition image layouts back
     auto imb_transitionSwapChainToOriginal = ImageMemoryBarrier::create(
@@ -77,7 +77,7 @@ void CopyImageViewToWindow::dispatch(CommandBuffer& commandBuffer) const
         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
         0, imb_transitionSwapChainToOriginal);
 
-    pb_transitionSwapChainToOriginal->dispatch(commandBuffer);
+    pb_transitionSwapChainToOriginal->record(commandBuffer);
 
     auto imb_transitionStorageImageToOriginal = ImageMemoryBarrier::create(
         VK_ACCESS_TRANSFER_READ_BIT, 0,
@@ -90,5 +90,5 @@ void CopyImageViewToWindow::dispatch(CommandBuffer& commandBuffer) const
         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
         0, imb_transitionStorageImageToOriginal);
 
-    pb_transitionStorageImageToOriginal->dispatch(commandBuffer);
+    pb_transitionStorageImageToOriginal->record(commandBuffer);
 }

--- a/src/vsg/viewer/ExecuteCommands.cpp
+++ b/src/vsg/viewer/ExecuteCommands.cpp
@@ -56,7 +56,7 @@ void ExecuteCommands::completed(ref_ptr<CommandBuffer> commandBuffer)
     _latch->count_down();
 }
 
-void ExecuteCommands::dispatch(CommandBuffer& commandBuffer) const
+void ExecuteCommands::record(CommandBuffer& commandBuffer) const
 {
     _latch->wait();
 

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -243,10 +243,10 @@ void Viewer::compile(BufferPreferences bufferPreferences)
         }
     }
 
-    // dispatch any transfer commands commands
+    // record any transfer commands commands
     for (auto& dp : deviceResourceMap)
     {
-        dp.second.compile->context.dispatch();
+        dp.second.compile->context.record();
     }
 
     // wait for the transfers to complete

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -305,7 +305,7 @@ void Window::buildSwapchain()
             auto pipelineBarrier = PipelineBarrier::create(
                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
                 0, depthImageBarrier);
-            pipelineBarrier->dispatch(commandBuffer);
+            pipelineBarrier->record(commandBuffer);
 
             if (multisampling)
             {
@@ -318,7 +318,7 @@ void Window::buildSwapchain()
                 auto msPipelineBarrier = PipelineBarrier::create(
                     VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                     0, msImageBarrier);
-                msPipelineBarrier->dispatch(commandBuffer);
+                msPipelineBarrier->record(commandBuffer);
             }
         });
     }


### PR DESCRIPTION
To complete the renaming of the DispatchTraversal -> RecordTraversal work replaced the Command::dispatch(CommandBuffer&) methods with Command::record(CommandBuffer&) to keep things consistent within the VSG and with language used in Vulkan.