### PR TITLE
Streamlining of RecordAndSubmitTask/Window/DatabasePager setup and usage

### DIFF
--- a/include/vsg/traversals/CompileTraversal.h
+++ b/include/vsg/traversals/CompileTraversal.h
@@ -46,6 +46,7 @@ namespace vsg
         void apply(const StateCommand& stateCommand) override;
         void apply(const DescriptorSet& descriptorSet) override;
         void apply(const Descriptor& descriptor) override;
+        void apply(const PagedLOD& plod) override;
 
         uint32_t computeNumDescriptorSets() const;
 
@@ -56,6 +57,10 @@ namespace vsg
         DescriptorTypeMap descriptorTypeMap;
         uint32_t maxSlot = 0;
         uint32_t externalNumDescriptorSets = 0;
+        bool containsPagedLOD = false;
+
+    protected:
+        uint32_t _numResourceHintsAbove = 0;
     };
     VSG_type_name(vsg::CollectDescriptorStats);
 

--- a/include/vsg/viewer/RecordAndSubmitTask.h
+++ b/include/vsg/viewer/RecordAndSubmitTask.h
@@ -41,12 +41,24 @@ namespace vsg
         CommandGraphs commandGraphs; // assign in application setup
         Semaphores signalSemaphores; // connect to Presentation.waitSemaphores
 
-        uint32_t index = 0; // current fence/buffer set to use, cycled through automatically in submit call.
-        std::vector<ref_ptr<Fence>> fences;
+        /// advance the currentFrameIndex
+        void advance();
+
+        /// return the fence index value for relativeFrameIndex where 0 is current frame, 1 is prevous frame etc.
+        size_t index(size_t relativeFrameIndex = 0) const { return relativeFrameIndex < _indices.size() ? _indices[relativeFrameIndex] : _indices.size(); }
+
+        /// fence() and fence(0) return the Fence for the frame currently being rendered, fence(1) return the previous frame's Fence etc.
+        Fence* fence(size_t relativeFrameIndex = 0) { size_t i = index(relativeFrameIndex); return i < _fences.size() ? _fences[i].get() : nullptr; }
 
         ref_ptr<Queue> queue; // assign in application for GraphicsQueue from device
 
         ref_ptr<DatabasePager> databasePager;
+
+    protected:
+        size_t _currentFrameIndex;
+        std::vector<size_t> _indices;
+        std::vector<ref_ptr<Fence>> _fences;
+
     };
     VSG_type_name(vsg::RecordAndSubmitTask);
 

--- a/include/vsg/viewer/Viewer.h
+++ b/include/vsg/viewer/Viewer.h
@@ -93,8 +93,7 @@ namespace vsg
         using Presentations = std::vector<ref_ptr<Presentation>>;
         Presentations presentations;
 
-        void assignRecordAndSubmitTaskAndPresentation(CommandGraphs commandGraphs, DatabasePager* databasePager = nullptr);
-        ;
+        void assignRecordAndSubmitTaskAndPresentation(CommandGraphs commandGraphs);
 
         std::list<std::thread> threads;
 

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -12,8 +12,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <any>
-
 #include <vsg/ui/UIEvent.h>
 
 #include <vsg/vk/CommandBuffer.h>
@@ -124,15 +122,16 @@ namespace vsg
         Framebuffer* framebuffer(size_t i) { return _frames[i].framebuffer; }
         const Framebuffer* framebuffer(size_t i) const { return _frames[i].framebuffer; }
 
-        VkResult acquireNextImage(uint64_t timeout = std::numeric_limits<uint64_t>::max())
-        {
-            if (!_swapchain) _initSwapchain();
-            return vkAcquireNextImageKHR(*_device, *_swapchain, timeout, *(_frames[_nextImageIndex].imageAvailableSemaphore), VK_NULL_HANDLE, &_nextImageIndex);
-        }
+        /// call vkAquireNextImageKHR to find the next imageIndex of the swapchain images/framebuffers
+        VkResult acquireNextImage(uint64_t timeout = std::numeric_limits<uint64_t>::max());
 
+        /// return the index of the last aquired image and the next one to be rendered.
+        /// return values < numFrames() are valid, >= numFrame() are invalid.
         uint32_t nextImageIndex() const { return _nextImageIndex; }
 
-        void advanceNextImageIndex() { _nextImageIndex = (_nextImageIndex + 1) % _frames.size(); }
+        /// return the index of the previous aquired image
+        /// return values < numFrames() are valid, >= numFrame() are invalid.
+        uint32_t previousImageIndex() const { return _previousImageIndex; }
 
         bool debugLayersEnabled() const { return _traits->debugLayer; }
 
@@ -187,7 +186,10 @@ namespace vsg
         ref_ptr<Image> _multisampleImage;
         ref_ptr<ImageView> _multisampleImageView;
 
+        ref_ptr<Semaphore> _availableSemaphore;
+
         Frames _frames;
+        uint32_t _previousImageIndex;
         uint32_t _nextImageIndex;
     };
     VSG_type_name(vsg::Window);

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -125,13 +125,9 @@ namespace vsg
         /// call vkAquireNextImageKHR to find the next imageIndex of the swapchain images/framebuffers
         VkResult acquireNextImage(uint64_t timeout = std::numeric_limits<uint64_t>::max());
 
-        /// return the index of the last aquired image and the next one to be rendered.
-        /// return values < numFrames() are valid, >= numFrame() are invalid.
-        uint32_t nextImageIndex() const { return _nextImageIndex; }
+        /// get the image index for specified relative frame index, a 0 value is the current frame being rendered, 1 is the previous frame, 2 is the previous frame that.
+        size_t imageIndex(size_t relativeFrameIndex = 0) const { return relativeFrameIndex < _indices.size() ? _indices[relativeFrameIndex] : _indices.size(); }
 
-        /// return the index of the previous aquired image
-        /// return values < numFrames() are valid, >= numFrame() are invalid.
-        uint32_t previousImageIndex() const { return _previousImageIndex; }
 
         bool debugLayersEnabled() const { return _traits->debugLayer; }
 
@@ -189,8 +185,8 @@ namespace vsg
         ref_ptr<Semaphore> _availableSemaphore;
 
         Frames _frames;
-        uint32_t _previousImageIndex;
-        uint32_t _nextImageIndex;
+        std::vector<size_t> _indices;
+
     };
     VSG_type_name(vsg::Window);
 

--- a/include/vsg/vk/Fence.h
+++ b/include/vsg/vk/Fence.h
@@ -22,9 +22,9 @@ namespace vsg
     public:
         Fence(Device* device, VkFenceCreateFlags flags = 0, AllocationCallbacks* allocator = nullptr);
 
-        VkResult wait(uint64_t timeout) const { return vkWaitForFences(*_device, 1, &_vkFence, VK_TRUE, timeout); }
+        VkResult wait(uint64_t timeout) const;
 
-        VkResult reset() const { return vkResetFences(*_device, 1, &_vkFence); }
+        VkResult reset() const;
 
         VkResult status() const { return vkGetFenceStatus(*_device, _vkFence); }
 

--- a/include/vsg/vk/Image.h
+++ b/include/vsg/vk/Image.h
@@ -29,6 +29,11 @@ namespace vsg
         Device* getDevice() { return _device; }
         const Device* getDevice() const { return _device; }
 
+        DeviceMemory* getDeviceMemory() { return _deviceMemory; }
+        const DeviceMemory* getDeviceMemory() const { return _deviceMemory; }
+
+        VkDeviceSize getMemoryOffset() const { return _memoryOffset; }
+
         VkMemoryRequirements getMemoryRequirements() const;
 
         VkResult bind(DeviceMemory* deviceMemory, VkDeviceSize memoryOffset)

--- a/include/vsg/vk/Semaphore.h
+++ b/include/vsg/vk/Semaphore.h
@@ -43,7 +43,9 @@ namespace vsg
         ref_ptr<Device> _device;
         ref_ptr<AllocationCallbacks> _allocator;
     };
+    VSG_type_name(vsg::Semaphore);
 
     using Semaphores = std::vector<ref_ptr<Semaphore>>;
+
 
 } // namespace vsg

--- a/include/vsg/vk/Swapchain.h
+++ b/include/vsg/vk/Swapchain.h
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/vk/ImageView.h>
 #include <vsg/vk/Surface.h>
+#include <vsg/vk/Fence.h>
 
 namespace vsg
 {
@@ -60,6 +61,9 @@ namespace vsg
 
         ImageViews& getImageViews() { return _imageViews; }
         const ImageViews& getImageViews() const { return _imageViews; }
+
+        /// call vkAcquireNextImageKHR
+        VkResult aquireNextImage(uint64_t timeout, ref_ptr<Semaphore> semaphore, ref_ptr<Fence> fence, uint32_t& imageIndex);
 
     protected:
         virtual ~Swapchain();

--- a/include/vsg/vk/Swapchain.h
+++ b/include/vsg/vk/Swapchain.h
@@ -63,7 +63,7 @@ namespace vsg
         const ImageViews& getImageViews() const { return _imageViews; }
 
         /// call vkAcquireNextImageKHR
-        VkResult aquireNextImage(uint64_t timeout, ref_ptr<Semaphore> semaphore, ref_ptr<Fence> fence, uint32_t& imageIndex);
+        VkResult acquireNextImage(uint64_t timeout, ref_ptr<Semaphore> semaphore, ref_ptr<Fence> fence, uint32_t& imageIndex);
 
     protected:
         virtual ~Swapchain();

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -248,9 +248,14 @@ void CompileTraversal::apply(RenderGraph& renderGraph)
     {
         context.defaultPipelineStates.emplace_back(renderGraph.camera->getViewportState());
     }
-    else
+    else if (renderGraph.window)
     {
         context.defaultPipelineStates.push_back(vsg::ViewportState::create(renderGraph.window->extent2D()));
+    }
+    else if (renderGraph.framebuffer)
+    {
+        VkExtent2D extent{renderGraph.framebuffer->width(), renderGraph.framebuffer->height()};
+        context.defaultPipelineStates.push_back(vsg::ViewportState::create(extent));
     }
 
     if (context.renderPass && context.renderPass->maxSamples() != VK_SAMPLE_COUNT_1_BIT)

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -69,21 +69,41 @@ void CollectDescriptorStats::apply(const ResourceHints& resourceHints)
 
 void CollectDescriptorStats::apply(const Node& node)
 {
-    if (checkForResourceHints(node)) return;
+    bool hasResourceHints = checkForResourceHints(node);
+    if (hasResourceHints) ++_numResourceHintsAbove;
 
     node.traverse(*this);
+
+    if (hasResourceHints) --_numResourceHintsAbove;
 }
 
 void CollectDescriptorStats::apply(const StateGroup& stategroup)
 {
-    if (checkForResourceHints(stategroup)) return;
+    bool hasResourceHints = checkForResourceHints(stategroup);
+    if (hasResourceHints) ++_numResourceHintsAbove;
 
-    for (auto& command : stategroup.getStateCommands())
+    if (_numResourceHintsAbove==0)
     {
-        command->accept(*this);
+        for (auto& command : stategroup.getStateCommands())
+        {
+            command->accept(*this);
+        }
     }
 
     stategroup.traverse(*this);
+
+    if (hasResourceHints) --_numResourceHintsAbove;
+}
+
+void CollectDescriptorStats::apply(const PagedLOD& plod)
+{
+    bool hasResourceHints = checkForResourceHints(plod);
+    if (hasResourceHints) ++_numResourceHintsAbove;
+
+    containsPagedLOD = true;
+    plod.traverse(*this);
+
+    if (hasResourceHints) --_numResourceHintsAbove;
 }
 
 void CollectDescriptorStats::apply(const StateCommand& stateCommand)

--- a/src/vsg/viewer/CopyImageViewToWindow.cpp
+++ b/src/vsg/viewer/CopyImageViewToWindow.cpp
@@ -22,9 +22,10 @@ void CopyImageViewToWindow::record(CommandBuffer& commandBuffer) const
     // TODO: replace this implementation with a list of commands rather than present create commands, record commands, delete commands
 
     // do nothing if the nextImageIndex() is invalid.
-    if (window->nextImageIndex() >= window->numFrames()) return;
+    size_t imageIndex = window->imageIndex();
+    if (imageIndex >= window->numFrames()) return;
 
-    auto imageView = window->imageView(window->nextImageIndex());
+    auto imageView = window->imageView(imageIndex);
 
     //  transition image layouts for copy
     auto imb_transitionSwapChainToWriteDest = ImageMemoryBarrier::create(

--- a/src/vsg/viewer/CopyImageViewToWindow.cpp
+++ b/src/vsg/viewer/CopyImageViewToWindow.cpp
@@ -21,6 +21,9 @@ void CopyImageViewToWindow::record(CommandBuffer& commandBuffer) const
 {
     // TODO: replace this implementation with a list of commands rather than present create commands, record commands, delete commands
 
+    // do nothing if the nextImageIndex() is invalid.
+    if (window->nextImageIndex() >= window->numFrames()) return;
+
     auto imageView = window->imageView(window->nextImageIndex());
 
     //  transition image layouts for copy

--- a/src/vsg/viewer/Presentation.cpp
+++ b/src/vsg/viewer/Presentation.cpp
@@ -32,10 +32,11 @@ VkResult Presentation::present()
     std::vector<uint32_t> indices;
     for (auto& window : windows)
     {
-        if (window->visible() && window->nextImageIndex() < window->numFrames())
+        size_t imageIndex = window->imageIndex();
+        if (window->visible() && imageIndex < window->numFrames())
         {
             vk_swapchains.emplace_back(*(window->getOrCreateSwapchain()));
-            indices.emplace_back(window->nextImageIndex());
+            indices.emplace_back(static_cast<uint32_t>(imageIndex));
         }
     }
 

--- a/src/vsg/viewer/Presentation.cpp
+++ b/src/vsg/viewer/Presentation.cpp
@@ -32,8 +32,8 @@ VkResult Presentation::present()
     std::vector<uint32_t> indices;
     for (auto& window : windows)
     {
-        //vk_semaphores.push_back(*(window->frame(window->nextImageIndex()).imageAvailableSemaphore));
-        if (window->visible())
+        //vk_semaphores.push_back(*(window->frame(window->imageIndex()).imageAvailableSemaphore));
+        if (window->visible() && window->nextImageIndex() < window->numFrames())
         {
             vk_swapchains.emplace_back(*(window->getOrCreateSwapchain()));
             indices.emplace_back(window->nextImageIndex());
@@ -69,14 +69,6 @@ VkResult Presentation::present()
     }
     std::cout << std::endl;
 #endif
-
-    for (auto& window : windows)
-    {
-        if (window->visible())
-        {
-            window->advanceNextImageIndex();
-        }
-    }
 
     return queue->present(presentInfo);
 }

--- a/src/vsg/viewer/Presentation.cpp
+++ b/src/vsg/viewer/Presentation.cpp
@@ -32,7 +32,6 @@ VkResult Presentation::present()
     std::vector<uint32_t> indices;
     for (auto& window : windows)
     {
-        //vk_semaphores.push_back(*(window->frame(window->imageIndex()).imageAvailableSemaphore));
         if (window->visible() && window->nextImageIndex() < window->numFrames())
         {
             vk_swapchains.emplace_back(*(window->getOrCreateSwapchain()));

--- a/src/vsg/viewer/RecordAndSubmitTask.cpp
+++ b/src/vsg/viewer/RecordAndSubmitTask.cpp
@@ -160,7 +160,5 @@ VkResult RecordAndSubmitTask::finish(CommandBuffers& recordedCommandBuffers)
     std::cout << std::endl;
 #endif
 
-    index = (index + 1) % fences.size();
-
     return queue->submit(submitInfo, fence);
 }

--- a/src/vsg/viewer/RecordAndSubmitTask.cpp
+++ b/src/vsg/viewer/RecordAndSubmitTask.cpp
@@ -21,11 +21,37 @@ using namespace vsg;
 
 RecordAndSubmitTask::RecordAndSubmitTask(Device* device, uint32_t numBuffers)
 {
+    _currentFrameIndex = numBuffers; // numBuffers is used to signify unset value
     for (uint32_t i = 0; i < numBuffers; ++i)
     {
-        fences.emplace_back(vsg::Fence::create(device));
+        _fences.emplace_back(vsg::Fence::create(device));
+        _indices.emplace_back(numBuffers); // numBuffers is used to signify unset value
     }
 }
+
+void RecordAndSubmitTask::advance()
+{
+    if (_currentFrameIndex >= _indices.size())
+    {
+        // first frame so set to 0
+        _currentFrameIndex = 0;
+    }
+    else
+    {
+        ++_currentFrameIndex;
+        if (_currentFrameIndex > _indices.size()-1) _currentFrameIndex = 0;
+
+        // shift the index for previous frames
+        for(size_t i=1; i<_indices.size(); ++i)
+        {
+            _indices[i] = _indices[i-1];
+        }
+    }
+
+    // ass the index for the current frame
+    _indices[0] = _currentFrameIndex;
+}
+
 
 VkResult RecordAndSubmitTask::submit(ref_ptr<FrameStamp> frameStamp)
 {
@@ -37,13 +63,13 @@ VkResult RecordAndSubmitTask::submit(ref_ptr<FrameStamp> frameStamp)
 
 VkResult RecordAndSubmitTask::start()
 {
-    auto fence = fences[index];
-    if (fence->hasDependencies())
+    auto current_fence = fence();
+    if (current_fence->hasDependencies())
     {
         uint64_t timeout = std::numeric_limits<uint64_t>::max();
-        if (VkResult result; (result = fence->wait(timeout)) != VK_SUCCESS) return result;
+        if (VkResult result; (result = current_fence->wait(timeout)) != VK_SUCCESS) return result;
 
-        fence->resetFenceAndDependencies();
+        current_fence->resetFenceAndDependencies();
     }
     return VK_SUCCESS;
 }
@@ -59,7 +85,7 @@ VkResult RecordAndSubmitTask::record(CommandBuffers& recordedCommandBuffers, ref
 
 VkResult RecordAndSubmitTask::finish(CommandBuffers& recordedCommandBuffers)
 {
-    auto fence = fences[index];
+    auto current_fence = fence();
 
     if (recordedCommandBuffers.empty())
     {
@@ -79,16 +105,17 @@ VkResult RecordAndSubmitTask::finish(CommandBuffers& recordedCommandBuffers)
     {
         if (commandBuffer->level() == VK_COMMAND_BUFFER_LEVEL_PRIMARY) vk_commandBuffers.push_back(*commandBuffer);
 
-        fence->dependentCommandBuffers().emplace_back(commandBuffer);
+        current_fence->dependentCommandBuffers().emplace_back(commandBuffer);
     }
 
-    fence->dependentSemaphores() = signalSemaphores;
+    current_fence->dependentSemaphores() = signalSemaphores;
 
     for (auto& window : windows)
     {
-        if (window->nextImageIndex() >= window->numFrames()) continue;
+        size_t imageIndex = window->imageIndex();
+        if (imageIndex >= window->numFrames()) continue;
 
-        auto& semaphore = window->frame(window->nextImageIndex()).imageAvailableSemaphore;
+        auto& semaphore = window->frame(imageIndex).imageAvailableSemaphore;
 
         vk_waitSemaphores.emplace_back(*semaphore);
         vk_waitStages.emplace_back(semaphore->pipelineStageFlags());
@@ -117,7 +144,7 @@ VkResult RecordAndSubmitTask::finish(CommandBuffers& recordedCommandBuffers)
             vk_waitStages.emplace_back(semaphore->pipelineStageFlags());
 
             semaphore->numDependentSubmissions().fetch_add(1);
-            fence->dependentSemaphores().emplace_back(semaphore);
+            current_fence->dependentSemaphores().emplace_back(semaphore);
         }
     }
 
@@ -140,7 +167,7 @@ VkResult RecordAndSubmitTask::finish(CommandBuffers& recordedCommandBuffers)
     submitInfo.pSignalSemaphores = vk_signalSemaphores.data();
 
 #if 0
-    std::cout << "pdo.graphicsQueue->submit(..) fence = " << fence.get() << "\n";
+    std::cout << "pdo.graphicsQueue->submit(..) current_fence = " << current_fence << "\n";
     std::cout << "    submitInfo.waitSemaphoreCount = " << submitInfo.waitSemaphoreCount << "\n";
     for (uint32_t i = 0; i < submitInfo.waitSemaphoreCount; ++i)
     {
@@ -160,5 +187,5 @@ VkResult RecordAndSubmitTask::finish(CommandBuffers& recordedCommandBuffers)
     std::cout << std::endl;
 #endif
 
-    return queue->submit(submitInfo, fence);
+    return queue->submit(submitInfo, current_fence);
 }

--- a/src/vsg/viewer/RecordAndSubmitTask.cpp
+++ b/src/vsg/viewer/RecordAndSubmitTask.cpp
@@ -86,6 +86,8 @@ VkResult RecordAndSubmitTask::finish(CommandBuffers& recordedCommandBuffers)
 
     for (auto& window : windows)
     {
+        if (window->nextImageIndex() >= window->numFrames()) continue;
+
         auto& semaphore = window->frame(window->nextImageIndex()).imageAvailableSemaphore;
 
         vk_waitSemaphores.emplace_back(*semaphore);

--- a/src/vsg/viewer/RenderGraph.cpp
+++ b/src/vsg/viewer/RenderGraph.cpp
@@ -141,10 +141,11 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
     }
     else
     {
-        if (window->nextImageIndex() >= window->numFrames()) return;
+        size_t imageIndex = window->imageIndex();
+        if (imageIndex >= window->numFrames()) return;
 
         renderPassInfo.renderPass = *(window->getRenderPass());
-        renderPassInfo.framebuffer = *(window->framebuffer(window->nextImageIndex()));
+        renderPassInfo.framebuffer = *(window->framebuffer(imageIndex));
     }
 
     renderPassInfo.renderArea = renderArea;

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -309,6 +309,8 @@ void Viewer::assignRecordAndSubmitTaskAndPresentation(CommandGraphs in_commandGr
             commandGraphs.insert(commandGraphs.end(), primary_commandGraphs.begin(), primary_commandGraphs.end());
         }
 
+        uint32_t numBuffers = 3;
+
         auto device = deviceQueueFamily.device;
         if (deviceQueueFamily.presentFamily >= 0)
         {
@@ -324,7 +326,7 @@ void Viewer::assignRecordAndSubmitTaskAndPresentation(CommandGraphs in_commandGr
             auto renderFinishedSemaphore = vsg::Semaphore::create(device);
 
             // set up Submission with CommandBuffer and signals
-            auto recordAndSubmitTask = vsg::RecordAndSubmitTask::create(device);
+            auto recordAndSubmitTask = vsg::RecordAndSubmitTask::create(device, numBuffers);
             recordAndSubmitTask->commandGraphs = commandGraphs;
             recordAndSubmitTask->signalSemaphores.emplace_back(renderFinishedSemaphore);
             recordAndSubmitTask->databasePager = databasePager;
@@ -342,7 +344,7 @@ void Viewer::assignRecordAndSubmitTaskAndPresentation(CommandGraphs in_commandGr
         {
             // with don't have a presentFamily so this set of commandGraphs aren't associated with a widnow
             // set up Submission with CommandBuffer and signals
-            auto recordAndSubmitTask = vsg::RecordAndSubmitTask::create(device);
+            auto recordAndSubmitTask = vsg::RecordAndSubmitTask::create(device, numBuffers);
             recordAndSubmitTask->commandGraphs = commandGraphs;
             recordAndSubmitTask->databasePager = databasePager;
             recordAndSubmitTask->queue = device->getQueue(deviceQueueFamily.queueFamily);

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -130,7 +130,7 @@ bool Viewer::advanceToNextFrame()
 
         for(auto& task : recordAndSubmitTasks)
         {
-            task->index = 0;
+            task->advance();
         }
     }
     else
@@ -140,7 +140,7 @@ bool Viewer::advanceToNextFrame()
 
         for(auto& task : recordAndSubmitTasks)
         {
-            task->index = (task->index+1) % task->fences.size();
+            task->advance();
         }
     }
 

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -123,7 +123,26 @@ bool Viewer::advanceToNextFrame()
 
     // create FrameStamp for frame
     auto time = vsg::clock::now();
-    _frameStamp = _frameStamp ? new vsg::FrameStamp(time, _frameStamp->frameCount + 1) : new vsg::FrameStamp(time, 0);
+    if (!_frameStamp)
+    {
+        // first frame, initialze to frame count and indices to 0
+        _frameStamp = new vsg::FrameStamp(time, 0);
+
+        for(auto& task : recordAndSubmitTasks)
+        {
+            task->index = 0;
+        }
+    }
+    else
+    {
+        // after forst frame so increment frame count and indices
+        _frameStamp = new vsg::FrameStamp(time, _frameStamp->frameCount + 1);
+
+        for(auto& task : recordAndSubmitTasks)
+        {
+            task->index = (task->index+1) % task->fences.size();
+        }
+    }
 
     // create an event for the new frame.
     _events.emplace_back(new FrameEvent(_frameStamp));

--- a/src/vsg/vk/Fence.cpp
+++ b/src/vsg/vk/Fence.cpp
@@ -55,3 +55,13 @@ void Fence::resetFenceAndDependencies()
 
     reset();
 }
+
+VkResult Fence::wait(uint64_t timeout) const
+{
+    return vkWaitForFences(*_device, 1, &_vkFence, VK_TRUE, timeout);
+}
+
+VkResult Fence::reset() const
+{
+    return vkResetFences(*_device, 1, &_vkFence);
+}

--- a/src/vsg/vk/Swapchain.cpp
+++ b/src/vsg/vk/Swapchain.cpp
@@ -239,3 +239,10 @@ Swapchain::~Swapchain()
         vkDestroySwapchainKHR(*_device, _swapchain, _allocator);
     }
 }
+
+VkResult Swapchain::aquireNextImage(uint64_t timeout, ref_ptr<Semaphore> semaphore, ref_ptr<Fence> fence, uint32_t& imageIndex)
+{
+    VkSemaphore vk_semaphore = semaphore ? semaphore->vk() : VK_NULL_HANDLE;
+    VkFence vk_fence = fence ? fence->vk() : VK_NULL_HANDLE;
+    return vkAcquireNextImageKHR(*_device, _swapchain, timeout, vk_semaphore, vk_fence, &imageIndex);
+}

--- a/src/vsg/vk/Swapchain.cpp
+++ b/src/vsg/vk/Swapchain.cpp
@@ -240,7 +240,7 @@ Swapchain::~Swapchain()
     }
 }
 
-VkResult Swapchain::aquireNextImage(uint64_t timeout, ref_ptr<Semaphore> semaphore, ref_ptr<Fence> fence, uint32_t& imageIndex)
+VkResult Swapchain::acquireNextImage(uint64_t timeout, ref_ptr<Semaphore> semaphore, ref_ptr<Fence> fence, uint32_t& imageIndex)
 {
     VkSemaphore vk_semaphore = semaphore ? semaphore->vk() : VK_NULL_HANDLE;
     VkFence vk_fence = fence ? fence->vk() : VK_NULL_HANDLE;


### PR DESCRIPTION
Refactored the management of image indices in Window and RecordAndSubmitTask to make it easier to track current and prev frames.  Streamlined DatabasePager setup so it's now done automatically.