### PR TITLE
Allocation callbacks refactor

### DIFF
--- a/include/vsg/platform/unix/Xcb_Window.h
+++ b/include/vsg/platform/unix/Xcb_Window.h
@@ -44,7 +44,7 @@ namespace vsgXcb
     class Xcb_Surface : public vsg::Surface
     {
     public:
-        Xcb_Surface(vsg::Instance* instance, xcb_connection_t* connection, xcb_window_t window, vsg::AllocationCallbacks* allocator = nullptr);
+        Xcb_Surface(vsg::Instance* instance, xcb_connection_t* connection, xcb_window_t window);
     };
 
     class Xcb_Window : public vsg::Inherit<vsg::Window, Xcb_Window>

--- a/include/vsg/raytracing/RayTracingPipeline.h
+++ b/include/vsg/raytracing/RayTracingPipeline.h
@@ -25,7 +25,7 @@ namespace vsg
     public:
         RayTracingPipeline();
 
-        RayTracingPipeline(PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const RayTracingShaderGroups& shaderGroups, AllocationCallbacks* allocator = nullptr);
+        RayTracingPipeline(PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const RayTracingShaderGroups& shaderGroups);
 
         void read(Input& input) override;
         void write(Output& output) const override;
@@ -38,9 +38,6 @@ namespace vsg
 
         RayTracingShaderGroups& getRayTracingShaderGroups() { return _rayTracingShaderGroups; }
         const RayTracingShaderGroups& getRayTracingShaderGroups() const { return _rayTracingShaderGroups; }
-
-        AllocationCallbacks* getAllocationCallbacks() { return _allocator; }
-        const AllocationCallbacks* getAllocationCallbacks() const { return _allocator; }
 
         uint32_t& maxRecursionDepth() { return _maxRecursionDepth; }
         const uint32_t& maxRecursionDepth() const { return _maxRecursionDepth; }
@@ -69,7 +66,6 @@ namespace vsg
             ref_ptr<PipelineLayout> _pipelineLayout;
             ShaderStages _shaderStages;
             RayTracingShaderGroups _shaderGroups;
-            ref_ptr<AllocationCallbacks> _allocator;
         };
 
         vk_buffer<ref_ptr<Implementation>> _implementation;
@@ -78,8 +74,6 @@ namespace vsg
         ShaderStages _shaderStages;
         RayTracingShaderGroups _rayTracingShaderGroups;
         uint32_t _maxRecursionDepth = 1;
-
-        ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::RayTracingPipeline);
 

--- a/include/vsg/state/ComputePipeline.h
+++ b/include/vsg/state/ComputePipeline.h
@@ -23,7 +23,7 @@ namespace vsg
     {
     public:
         ComputePipeline();
-        ComputePipeline(PipelineLayout* pipelineLayout, ShaderStage* shaderStage, AllocationCallbacks* allocator = nullptr);
+        ComputePipeline(PipelineLayout* pipelineLayout, ShaderStage* shaderStage);
 
         void read(Input& input) override;
         void write(Output& output) const override;
@@ -48,7 +48,7 @@ namespace vsg
 
         struct Implementation : public Inherit<Object, Implementation>
         {
-            Implementation(Context& context, Device* device, PipelineLayout* pipelineLayout, ShaderStage* shaderStage, AllocationCallbacks* allocator = nullptr);
+            Implementation(Context& context, Device* device, PipelineLayout* pipelineLayout, ShaderStage* shaderStage);
             virtual ~Implementation();
 
             VkPipeline _pipeline;

--- a/include/vsg/state/ComputePipeline.h
+++ b/include/vsg/state/ComputePipeline.h
@@ -56,14 +56,12 @@ namespace vsg
             ref_ptr<Device> _device;
             ref_ptr<PipelineLayout> _pipelineLayout;
             ref_ptr<ShaderStage> _shaderStage;
-            ref_ptr<AllocationCallbacks> _allocator;
         };
 
         vk_buffer<ref_ptr<Implementation>> _implementation;
 
         ref_ptr<PipelineLayout> _pipelineLayout;
         ref_ptr<ShaderStage> _shaderStage;
-        ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::ComputePipeline);
 

--- a/include/vsg/state/DescriptorSetLayout.h
+++ b/include/vsg/state/DescriptorSetLayout.h
@@ -45,13 +45,12 @@ namespace vsg
 
         struct Implementation : public Inherit<Object, Implementation>
         {
-            Implementation(Device* device, const DescriptorSetLayoutBindings& descriptorSetLayoutBindings, AllocationCallbacks* allocator = nullptr);
+            Implementation(Device* device, const DescriptorSetLayoutBindings& descriptorSetLayoutBindings);
 
             virtual ~Implementation();
 
             ref_ptr<Device> _device;
             VkDescriptorSetLayout _descriptorSetLayout;
-            ref_ptr<AllocationCallbacks> _allocator;
         };
 
         vk_buffer<ref_ptr<Implementation>> _implementation;

--- a/include/vsg/state/GraphicsPipeline.h
+++ b/include/vsg/state/GraphicsPipeline.h
@@ -26,7 +26,7 @@ namespace vsg
     public:
         GraphicsPipeline();
 
-        GraphicsPipeline(PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const GraphicsPipelineStates& pipelineStates, uint32_t subpass = 0, AllocationCallbacks* allocator = nullptr);
+        GraphicsPipeline(PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const GraphicsPipelineStates& pipelineStates, uint32_t subpass = 0);
 
         void read(Input& input) override;
         void write(Output& output) const override;
@@ -57,7 +57,7 @@ namespace vsg
 
         struct Implementation : public Inherit<Object, Implementation>
         {
-            Implementation(Context& context, Device* device, RenderPass* renderPass, PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const GraphicsPipelineStates& pipelineStates, uint32_t subpass, AllocationCallbacks* allocator = nullptr);
+            Implementation(Context& context, Device* device, RenderPass* renderPass, PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const GraphicsPipelineStates& pipelineStates, uint32_t subpass);
 
             virtual ~Implementation();
 
@@ -65,7 +65,6 @@ namespace vsg
 
             // TODO need to convert to use Implementation versions of RenderPass and PipelineLayout
             ref_ptr<Device> _device;
-            ref_ptr<AllocationCallbacks> _allocator;
         };
 
         vk_buffer<ref_ptr<Implementation>> _implementation;
@@ -75,7 +74,6 @@ namespace vsg
         ShaderStages _shaderStages;
         GraphicsPipelineStates _pipelineStates;
         uint32_t _subpass;
-        ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::GraphicsPipeline);
 

--- a/include/vsg/state/PipelineLayout.h
+++ b/include/vsg/state/PipelineLayout.h
@@ -53,7 +53,7 @@ namespace vsg
 
         struct Implementation : public Inherit<Object, Implementation>
         {
-            Implementation(Device* device, const DescriptorSetLayouts& descriptorSetLayouts, const PushConstantRanges& pushConstantRanges, VkPipelineLayoutCreateFlags flags = 0, AllocationCallbacks* allocator = nullptr);
+            Implementation(Device* device, const DescriptorSetLayouts& descriptorSetLayouts, const PushConstantRanges& pushConstantRanges, VkPipelineLayoutCreateFlags flags = 0);
 
             virtual ~Implementation();
 
@@ -61,7 +61,6 @@ namespace vsg
             DescriptorSetLayouts _descriptorSetLayouts;
 
             ref_ptr<Device> _device;
-            ref_ptr<AllocationCallbacks> _allocator;
         };
 
         vk_buffer<ref_ptr<Implementation>> _implementation;

--- a/include/vsg/state/Sampler.h
+++ b/include/vsg/state/Sampler.h
@@ -42,13 +42,12 @@ namespace vsg
 
         struct Implementation : public Inherit<Object, Implementation>
         {
-            Implementation(Device* device, const VkSamplerCreateInfo& createSamplerInfo, AllocationCallbacks* allocator = nullptr);
+            Implementation(Device* device, const VkSamplerCreateInfo& createSamplerInfo);
 
             virtual ~Implementation();
 
             VkSampler _sampler;
             ref_ptr<Device> _device;
-            ref_ptr<AllocationCallbacks> _allocator;
         };
 
         vk_buffer<ref_ptr<Implementation>> _implementation;

--- a/include/vsg/state/ShaderModule.h
+++ b/include/vsg/state/ShaderModule.h
@@ -80,13 +80,12 @@ namespace vsg
 
         struct Implementation : public Inherit<Object, Implementation>
         {
-            Implementation(Device* device, ShaderModule* shader, AllocationCallbacks* allocator = nullptr);
+            Implementation(Device* device, ShaderModule* shader);
 
             virtual ~Implementation();
 
             VkShaderModule _shaderModule;
             ref_ptr<Device> _device;
-            ref_ptr<AllocationCallbacks> _allocator;
         };
 
         vk_buffer<ref_ptr<Implementation>> _implementation;

--- a/include/vsg/viewer/WindowTraits.h
+++ b/include/vsg/viewer/WindowTraits.h
@@ -79,8 +79,6 @@ namespace vsg
 
         Window* shareWindow = nullptr;
 
-        ref_ptr<AllocationCallbacks> allocator;
-
         std::any nativeWindow;
         std::any systemConnection;
 

--- a/include/vsg/viewer/WindowTraits.h
+++ b/include/vsg/viewer/WindowTraits.h
@@ -79,7 +79,7 @@ namespace vsg
 
         Window* shareWindow = nullptr;
 
-        AllocationCallbacks* allocator = nullptr;
+        ref_ptr<AllocationCallbacks> allocator;
 
         std::any nativeWindow;
         std::any systemConnection;

--- a/include/vsg/vk/Buffer.h
+++ b/include/vsg/vk/Buffer.h
@@ -19,7 +19,7 @@ namespace vsg
     class VSG_DECLSPEC Buffer : public Inherit<Object, Buffer>
     {
     public:
-        Buffer(Device* device, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode, AllocationCallbacks* allocator = nullptr);
+        Buffer(Device* device, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode);
 
         VkBufferUsageFlags usage() const { return _usage; }
         VkSharingMode shaderMode() const { return _sharingMode; }
@@ -63,7 +63,6 @@ namespace vsg
         VkSharingMode _sharingMode;
 
         ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
 
         ref_ptr<DeviceMemory> _deviceMemory;
         VkDeviceSize _memoryOffset;

--- a/include/vsg/vk/BufferView.h
+++ b/include/vsg/vk/BufferView.h
@@ -19,7 +19,7 @@ namespace vsg
     class VSG_DECLSPEC BufferView : public Inherit<Object, BufferView>
     {
     public:
-        BufferView(Buffer* buffer, VkFormat format, VkDeviceSize offset, VkDeviceSize range, AllocationCallbacks* allocator = nullptr);
+        BufferView(Buffer* buffer, VkFormat format, VkDeviceSize offset, VkDeviceSize range);
 
         operator VkBufferView() const { return _bufferView; }
 
@@ -35,6 +35,5 @@ namespace vsg
         VkBufferView _bufferView;
         ref_ptr<Device> _device;
         ref_ptr<Buffer> _buffer;
-        ref_ptr<AllocationCallbacks> _allocator;
     };
 } // namespace vsg

--- a/include/vsg/vk/CommandPool.h
+++ b/include/vsg/vk/CommandPool.h
@@ -19,7 +19,7 @@ namespace vsg
     class VSG_DECLSPEC CommandPool : public Inherit<Object, CommandPool>
     {
     public:
-        CommandPool(Device* device, uint32_t queueFamilyIndex, AllocationCallbacks* allocator = nullptr);
+        CommandPool(Device* device, uint32_t queueFamilyIndex);
 
         operator VkCommandPool() const { return _commandPool; }
 
@@ -33,7 +33,6 @@ namespace vsg
 
         VkCommandPool _commandPool;
         ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::CommandPool);
 

--- a/include/vsg/vk/DescriptorPool.h
+++ b/include/vsg/vk/DescriptorPool.h
@@ -22,7 +22,7 @@ namespace vsg
     class VSG_DECLSPEC DescriptorPool : public Inherit<Object, DescriptorPool>
     {
     public:
-        DescriptorPool(Device* device, uint32_t maxSets, const DescriptorPoolSizes& descriptorPoolSizes, AllocationCallbacks* allocator = nullptr);
+        DescriptorPool(Device* device, uint32_t maxSets, const DescriptorPoolSizes& descriptorPoolSizes);
 
         operator const VkDescriptorPool&() const { return _descriptorPool; }
 
@@ -36,7 +36,6 @@ namespace vsg
 
         VkDescriptorPool _descriptorPool;
         ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
         mutable std::mutex _mutex;
     };
     VSG_type_name(vsg::DescriptorPool);

--- a/include/vsg/vk/Device.h
+++ b/include/vsg/vk/Device.h
@@ -49,8 +49,8 @@ namespace vsg
 
         const uint32_t deviceID = 0;
 
-        AllocationCallbacks* getAllocationCallbacks() { return _allocator.get(); }
-        const AllocationCallbacks* getAllocationCallbacks() const { return _allocator.get(); }
+        AllocationCallbacks* getAllocator() { return _allocator.get(); }
+        const AllocationCallbacks* getAllocator() const { return _allocator.get(); }
 
         ref_ptr<Queue> getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex = 0);
 

--- a/include/vsg/vk/Device.h
+++ b/include/vsg/vk/Device.h
@@ -42,6 +42,9 @@ namespace vsg
         PhysicalDevice* getPhysicalDevice() { return _physicalDevice.get(); }
         const PhysicalDevice* getPhysicalDevice() const { return _physicalDevice.get(); }
 
+        AllocationCallbacks* getAllocationCallbacks() { return _allocator.get(); }
+        const AllocationCallbacks* getAllocationCallbacks() const { return _allocator.get(); }
+
         operator VkDevice() const { return _device; }
         VkDevice getDevice() const { return _device; }
 
@@ -49,8 +52,6 @@ namespace vsg
 
         const uint32_t deviceID = 0;
 
-        AllocationCallbacks* getAllocator() { return _allocator.get(); }
-        const AllocationCallbacks* getAllocator() const { return _allocator.get(); }
 
         ref_ptr<Queue> getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex = 0);
 

--- a/include/vsg/vk/DeviceMemory.h
+++ b/include/vsg/vk/DeviceMemory.h
@@ -60,7 +60,7 @@ namespace vsg
     class VSG_DECLSPEC DeviceMemory : public Inherit<Object, DeviceMemory>
     {
     public:
-        DeviceMemory(Device* device, const VkMemoryRequirements& memRequirements, VkMemoryPropertyFlags properties, void* pNextAllocInfo = nullptr, AllocationCallbacks* allocator = nullptr);
+        DeviceMemory(Device* device, const VkMemoryRequirements& memRequirements, VkMemoryPropertyFlags properties, void* pNextAllocInfo = nullptr);
 
         void copy(VkDeviceSize offset, VkDeviceSize size, const void* src_data);
         void copy(VkDeviceSize offset, const Data* data);
@@ -85,7 +85,6 @@ namespace vsg
         VkDeviceMemory _deviceMemory;
         VkMemoryRequirements _memoryRequirements;
         ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
 
         MemorySlots _memorySlots;
     };

--- a/include/vsg/vk/Fence.h
+++ b/include/vsg/vk/Fence.h
@@ -20,7 +20,7 @@ namespace vsg
     class VSG_DECLSPEC Fence : public Inherit<Object, Fence>
     {
     public:
-        Fence(Device* device, VkFenceCreateFlags flags = 0, AllocationCallbacks* allocator = nullptr);
+        Fence(Device* device, VkFenceCreateFlags flags = 0);
 
         VkResult wait(uint64_t timeout) const;
 
@@ -49,7 +49,6 @@ namespace vsg
         CommandBuffers _dependentCommandBuffers;
 
         ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::Fence);
 

--- a/include/vsg/vk/Image.h
+++ b/include/vsg/vk/Image.h
@@ -19,8 +19,8 @@ namespace vsg
     class VSG_DECLSPEC Image : public Inherit<Object, Image>
     {
     public:
-        Image(VkImage image, Device* device, AllocationCallbacks* allocator = nullptr);
-        Image(Device* device, const VkImageCreateInfo& createImageInfo, AllocationCallbacks* allocator = nullptr);
+        Image(VkImage image, Device* device);
+        Image(Device* device, const VkImageCreateInfo& createImageInfo);
 
         VkImage image() const { return _image; }
 
@@ -52,7 +52,6 @@ namespace vsg
 
         VkImage _image;
         ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
 
         ref_ptr<DeviceMemory> _deviceMemory;
         VkDeviceSize _memoryOffset;

--- a/include/vsg/vk/ImageView.h
+++ b/include/vsg/vk/ImageView.h
@@ -21,9 +21,9 @@ namespace vsg
     class VSG_DECLSPEC ImageView : public Inherit<Object, ImageView>
     {
     public:
-        ImageView(Device* device, const VkImageViewCreateInfo& createInfo, AllocationCallbacks* allocator = nullptr);
-        ImageView(Device* device, VkImage image, VkImageViewType type, VkFormat format, VkImageAspectFlags aspectFlags, AllocationCallbacks* allocator = nullptr);
-        ImageView(Device* device, Image* image, VkImageViewType type, VkFormat format, VkImageAspectFlags aspectFlags, AllocationCallbacks* allocator = nullptr);
+        ImageView(Device* device, const VkImageViewCreateInfo& createInfo);
+        ImageView(Device* device, VkImage image, VkImageViewType type, VkFormat format, VkImageAspectFlags aspectFlags);
+        ImageView(Device* device, Image* image, VkImageViewType type, VkFormat format, VkImageAspectFlags aspectFlags);
 
         operator VkImageView() const { return _imageView; }
 
@@ -40,7 +40,6 @@ namespace vsg
         VkImageView _imageView;
         ref_ptr<Device> _device;
         ref_ptr<Image> _image;
-        ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::ImageView);
 

--- a/include/vsg/vk/Instance.h
+++ b/include/vsg/vk/Instance.h
@@ -37,8 +37,8 @@ namespace vsg
         operator VkInstance() const { return _instance; }
         VkInstance getInstance() const { return _instance; }
 
-        AllocationCallbacks* getAllocator() { return _allocator.get(); }
-        const AllocationCallbacks* getAllocator() const { return _allocator.get(); }
+        AllocationCallbacks* getAllocationCallbacks() { return _allocator.get(); }
+        const AllocationCallbacks* getAllocationCallbacks() const { return _allocator.get(); }
 
         using PhysicalDevices = std::vector<ref_ptr<PhysicalDevice>>;
         PhysicalDevices& getPhysicalDevices() { return _physicalDevices; }

--- a/include/vsg/vk/Instance.h
+++ b/include/vsg/vk/Instance.h
@@ -37,8 +37,8 @@ namespace vsg
         operator VkInstance() const { return _instance; }
         VkInstance getInstance() const { return _instance; }
 
-        AllocationCallbacks* getAllocationCallbacks() { return _allocator.get(); }
-        const AllocationCallbacks* getAllocationCallbacks() const { return _allocator.get(); }
+        AllocationCallbacks* getAllocator() { return _allocator.get(); }
+        const AllocationCallbacks* getAllocator() const { return _allocator.get(); }
 
         using PhysicalDevices = std::vector<ref_ptr<PhysicalDevice>>;
         PhysicalDevices& getPhysicalDevices() { return _physicalDevices; }

--- a/include/vsg/vk/RenderPass.h
+++ b/include/vsg/vk/RenderPass.h
@@ -41,7 +41,7 @@ namespace vsg
         using Subpasses = std::vector<SubpassDescription>;
         using Dependencies = std::vector<SubpassDependency>;
 
-        RenderPass(Device* device, const Attachments& attachments, const Subpasses& subpasses, const Dependencies& dependencies, AllocationCallbacks* allocator = nullptr);
+        RenderPass(Device* device, const Attachments& attachments, const Subpasses& subpasses, const Dependencies& dependencies);
 
         operator VkRenderPass() const { return _renderPass; }
 
@@ -59,15 +59,14 @@ namespace vsg
         VkSampleCountFlagBits _maxSamples;
 
         ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::RenderPass);
 
     extern VSG_DECLSPEC AttachmentDescription defaultColorAttachment(VkFormat imageFormat);
     extern VSG_DECLSPEC AttachmentDescription defaultDepthAttachment(VkFormat depthFormat);
 
-    extern VSG_DECLSPEC ref_ptr<RenderPass> createRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat, AllocationCallbacks* allocator = nullptr);
+    extern VSG_DECLSPEC ref_ptr<RenderPass> createRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat);
     extern VSG_DECLSPEC ref_ptr<RenderPass> createMultisampledRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat,
-                                                                         VkSampleCountFlagBits samples, AllocationCallbacks* allocator = nullptr);
+                                                                         VkSampleCountFlagBits samples);
 
 } // namespace vsg

--- a/include/vsg/vk/Semaphore.h
+++ b/include/vsg/vk/Semaphore.h
@@ -19,7 +19,7 @@ namespace vsg
     class VSG_DECLSPEC Semaphore : public Inherit<Object, Semaphore>
     {
     public:
-        Semaphore(Device* device, VkPipelineStageFlags pipelineStageFlags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, void* pNextCreateInfo = nullptr, AllocationCallbacks* allocator = nullptr);
+        Semaphore(Device* device, VkPipelineStageFlags pipelineStageFlags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, void* pNextCreateInfo = nullptr);
 
         operator VkSemaphore() const { return _semaphore; }
         VkSemaphore vk() const { return _semaphore; }
@@ -41,7 +41,6 @@ namespace vsg
         VkPipelineStageFlags _pipelineStageFlags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
         std::atomic_uint _numDependentSubmissions{0};
         ref_ptr<Device> _device;
-        ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::Semaphore);
 

--- a/include/vsg/vk/Surface.h
+++ b/include/vsg/vk/Surface.h
@@ -20,7 +20,7 @@ namespace vsg
     class VSG_DECLSPEC Surface : public Inherit<Object, Surface>
     {
     public:
-        Surface(VkSurfaceKHR surface, Instance* instance, AllocationCallbacks* allocator = nullptr);
+        Surface(VkSurfaceKHR surface, Instance* instance);
 
         operator VkSurfaceKHR() const { return _surface; }
 
@@ -32,7 +32,6 @@ namespace vsg
 
         VkSurfaceKHR _surface;
         ref_ptr<Instance> _instance;
-        ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::Surface);
 

--- a/include/vsg/vk/Swapchain.h
+++ b/include/vsg/vk/Swapchain.h
@@ -41,7 +41,7 @@ namespace vsg
     class SwapchainImage : public Inherit<Image, SwapchainImage>
     {
     public:
-        SwapchainImage(VkImage image, Device* device, AllocationCallbacks* allocator = nullptr);
+        SwapchainImage(VkImage image, Device* device);
 
     protected:
         virtual ~SwapchainImage();
@@ -51,7 +51,7 @@ namespace vsg
     class VSG_DECLSPEC Swapchain : public Inherit<Object, Swapchain>
     {
     public:
-        Swapchain(PhysicalDevice* physicalDevice, Device* device, Surface* surface, uint32_t width, uint32_t height, SwapchainPreferences& preferences, AllocationCallbacks* allocator = nullptr);
+        Swapchain(PhysicalDevice* physicalDevice, Device* device, Surface* surface, uint32_t width, uint32_t height, SwapchainPreferences& preferences);
 
         operator VkSwapchainKHR() const { return _swapchain; }
 
@@ -74,8 +74,6 @@ namespace vsg
         VkFormat _format;
         VkExtent2D _extent;
         ImageViews _imageViews;
-
-        vsg::ref_ptr<AllocationCallbacks> _allocator;
     };
     VSG_type_name(vsg::Swapchain);
 

--- a/src/vsg/platform/android/Android_Window.cpp
+++ b/src/vsg/platform/android/Android_Window.cpp
@@ -45,8 +45,8 @@ namespace vsgAndroid
     class AndroidSurface : public vsg::Surface
     {
     public:
-        AndroidSurface(vsg::Instance* instance, ANativeWindow* window, vsg::AllocationCallbacks* allocator = nullptr) :
-            vsg::Surface(VK_NULL_HANDLE, instance, allocator)
+        AndroidSurface(vsg::Instance* instance, ANativeWindow* window) :
+            vsg::Surface(VK_NULL_HANDLE, instance)
         {
             VkAndroidSurfaceCreateInfoKHR surfaceCreateInfo{};
             surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
@@ -54,7 +54,7 @@ namespace vsgAndroid
             surfaceCreateInfo.flags = 0;
             surfaceCreateInfo.window = window;
 
-            auto result = vkCreateAndroidSurfaceKHR(*instance, &surfaceCreateInfo, nullptr, &_surface);
+            auto result = vkCreateAndroidSurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocator(), &_surface);
         }
     };
 

--- a/src/vsg/platform/android/Android_Window.cpp
+++ b/src/vsg/platform/android/Android_Window.cpp
@@ -363,7 +363,7 @@ void Android_Window::_initSurface()
 {
     if (!_instance) _initInstance();
 
-    _surface = new vsgAndroid::AndroidSurface(_instance, _window, _traits->allocator);
+    _surface = new vsgAndroid::AndroidSurface(_instance, _window);
 }
 
 bool Android_Window::pollEvents(vsg::UIEvents& events)

--- a/src/vsg/platform/android/Android_Window.cpp
+++ b/src/vsg/platform/android/Android_Window.cpp
@@ -54,7 +54,7 @@ namespace vsgAndroid
             surfaceCreateInfo.flags = 0;
             surfaceCreateInfo.window = window;
 
-            auto result = vkCreateAndroidSurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocator(), &_surface);
+            auto result = vkCreateAndroidSurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocationCallbacks(), &_surface);
         }
     };
 

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -846,7 +846,7 @@ void MacOS_Window::_initSurface()
 {
     if (!_instance) _initInstance();
 
-    _surface = new vsgMacOS::MacOSSurface(_instance, _view, _traits->allocator);
+    _surface = new vsgMacOS::MacOSSurface(_instance, _view);
 }
 
 bool MacOS_Window::pollEvents(vsg::UIEvents& events)

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -395,7 +395,7 @@ namespace vsgMacOS
             surfaceCreateInfo.flags = 0;
             surfaceCreateInfo.pView = window;
 
-            /*auto result = */ vkCreateMacOSSurfaceMVK(*instance, &surfaceCreateInfo, _instance->getAllocator(), &_surface);
+            /*auto result = */ vkCreateMacOSSurfaceMVK(*instance, &surfaceCreateInfo, _instance->getAllocationCallbacks(), &_surface);
         }
     };
 

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -386,8 +386,8 @@ namespace vsgMacOS
     class MacOSSurface : public vsg::Surface
     {
     public:
-        MacOSSurface(vsg::Instance* instance, NSView* window, vsg::AllocationCallbacks* allocator = nullptr) :
-            vsg::Surface(VK_NULL_HANDLE, instance, allocator)
+        MacOSSurface(vsg::Instance* instance, NSView* window) :
+            vsg::Surface(VK_NULL_HANDLE, instance)
         {
             VkMacOSSurfaceCreateInfoMVK surfaceCreateInfo{};
             surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK;
@@ -395,7 +395,7 @@ namespace vsgMacOS
             surfaceCreateInfo.flags = 0;
             surfaceCreateInfo.pView = window;
 
-            /*auto result = */ vkCreateMacOSSurfaceMVK(*instance, &surfaceCreateInfo, nullptr, &_surface);
+            /*auto result = */ vkCreateMacOSSurfaceMVK(*instance, &surfaceCreateInfo, _instance->getAllocator(), &_surface);
         }
     };
 

--- a/src/vsg/platform/unix/Xcb_Window.cpp
+++ b/src/vsg/platform/unix/Xcb_Window.cpp
@@ -225,7 +225,7 @@ Xcb_Surface::Xcb_Surface(vsg::Instance* instance, xcb_connection_t* connection, 
     surfaceCreateInfo.connection = connection;
     surfaceCreateInfo.window = window;
 
-    /*VkResult result =*/vkCreateXcbSurfaceKHR(*instance, &surfaceCreateInfo, nullptr, &_surface);
+    /*VkResult result =*/vkCreateXcbSurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocator(), &_surface);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/src/vsg/platform/unix/Xcb_Window.cpp
+++ b/src/vsg/platform/unix/Xcb_Window.cpp
@@ -217,8 +217,8 @@ void KeyboardMap::add(uint16_t keycode, std::initializer_list<std::pair<uint16_t
 //
 // Xcb_Surface
 //
-Xcb_Surface::Xcb_Surface(vsg::Instance* instance, xcb_connection_t* connection, xcb_window_t window, vsg::AllocationCallbacks* allocator) :
-    vsg::Surface(VK_NULL_HANDLE, instance, allocator)
+Xcb_Surface::Xcb_Surface(vsg::Instance* instance, xcb_connection_t* connection, xcb_window_t window) :
+    vsg::Surface(VK_NULL_HANDLE, instance)
 {
     VkXcbSurfaceCreateInfoKHR surfaceCreateInfo{};
     surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
@@ -441,7 +441,7 @@ void Xcb_Window::_initSurface()
 {
     if (!_instance) _initInstance();
 
-    _surface = new Xcb_Surface(_instance, _connection, _window, _traits->allocator);
+    _surface = new Xcb_Surface(_instance, _connection, _window);
 }
 
 bool Xcb_Window::valid() const

--- a/src/vsg/platform/unix/Xcb_Window.cpp
+++ b/src/vsg/platform/unix/Xcb_Window.cpp
@@ -225,7 +225,7 @@ Xcb_Surface::Xcb_Surface(vsg::Instance* instance, xcb_connection_t* connection, 
     surfaceCreateInfo.connection = connection;
     surfaceCreateInfo.window = window;
 
-    /*VkResult result =*/vkCreateXcbSurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocator(), &_surface);
+    /*VkResult result =*/vkCreateXcbSurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocationCallbacks(), &_surface);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -462,7 +462,7 @@ void Win32_Window::_initSurface()
 {
     if (!_instance) _initInstance();
 
-    _surface = new vsgWin32::Win32Surface(_instance, _window, _traits->allocator);
+    _surface = new vsgWin32::Win32Surface(_instance, _window);
 }
 
 bool Win32_Window::pollEvents(vsg::UIEvents& events)

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -45,7 +45,7 @@ namespace vsgWin32
             surfaceCreateInfo.hwnd = window;
             surfaceCreateInfo.pNext = nullptr;
 
-            auto result = vkCreateWin32SurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocator(), &_surface);
+            auto result = vkCreateWin32SurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocationCallbacks(), &_surface);
         }
     };
 

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -36,8 +36,8 @@ namespace vsgWin32
     class VSG_DECLSPEC Win32Surface : public vsg::Surface
     {
     public:
-        Win32Surface(vsg::Instance* instance, HWND window, vsg::AllocationCallbacks* allocator = nullptr) :
-            vsg::Surface(VK_NULL_HANDLE, instance, allocator)
+        Win32Surface(vsg::Instance* instance, HWND window) :
+            vsg::Surface(VK_NULL_HANDLE, instance)
         {
             VkWin32SurfaceCreateInfoKHR surfaceCreateInfo{};
             surfaceCreateInfo.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
@@ -45,7 +45,7 @@ namespace vsgWin32
             surfaceCreateInfo.hwnd = window;
             surfaceCreateInfo.pNext = nullptr;
 
-            auto result = vkCreateWin32SurfaceKHR(*instance, &surfaceCreateInfo, nullptr, &_surface);
+            auto result = vkCreateWin32SurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocator(), &_surface);
         }
     };
 

--- a/src/vsg/raytracing/RayTracingPipeline.cpp
+++ b/src/vsg/raytracing/RayTracingPipeline.cpp
@@ -28,11 +28,10 @@ RayTracingPipeline::RayTracingPipeline()
 {
 }
 
-RayTracingPipeline::RayTracingPipeline(PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const RayTracingShaderGroups& shaderGroups, AllocationCallbacks* allocator) :
+RayTracingPipeline::RayTracingPipeline(PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const RayTracingShaderGroups& shaderGroups) :
     _pipelineLayout(pipelineLayout),
     _shaderStages(shaderStages),
-    _rayTracingShaderGroups(shaderGroups),
-    _allocator(allocator)
+    _rayTracingShaderGroups(shaderGroups)
 {
 }
 
@@ -89,8 +88,7 @@ RayTracingPipeline::Implementation::Implementation(Context& context, RayTracingP
     _device(context.device),
     _pipelineLayout(rayTracingPipeline->getPipelineLayout()),
     _shaderStages(rayTracingPipeline->getShaderStages()),
-    _shaderGroups(rayTracingPipeline->getRayTracingShaderGroups()),
-    _allocator(rayTracingPipeline->getAllocationCallbacks())
+    _shaderGroups(rayTracingPipeline->getRayTracingShaderGroups())
 {
 
     auto pipelineLayout = rayTracingPipeline->getPipelineLayout();
@@ -129,7 +127,7 @@ RayTracingPipeline::Implementation::Implementation(Context& context, RayTracingP
 
     pipelineInfo.maxRecursionDepth = rayTracingPipeline->maxRecursionDepth();
 
-    VkResult result = extensions->vkCreateRayTracingPipelinesNV(*_device, VK_NULL_HANDLE, 1, &pipelineInfo, rayTracingPipeline->getAllocationCallbacks(), &_pipeline);
+    VkResult result = extensions->vkCreateRayTracingPipelinesNV(*_device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocator(), &_pipeline);
     if (result == VK_SUCCESS)
     {
         auto rayTracingProperties = _device->getPhysicalDevice()->getProperties<VkPhysicalDeviceRayTracingPropertiesNV, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV>();
@@ -165,7 +163,7 @@ RayTracingPipeline::Implementation::Implementation(Context& context, RayTracingP
 
 RayTracingPipeline::Implementation::~Implementation()
 {
-    vkDestroyPipeline(*_device, _pipeline, _allocator);
+    vkDestroyPipeline(*_device, _pipeline, _device->getAllocator());
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/vsg/raytracing/RayTracingPipeline.cpp
+++ b/src/vsg/raytracing/RayTracingPipeline.cpp
@@ -127,7 +127,7 @@ RayTracingPipeline::Implementation::Implementation(Context& context, RayTracingP
 
     pipelineInfo.maxRecursionDepth = rayTracingPipeline->maxRecursionDepth();
 
-    VkResult result = extensions->vkCreateRayTracingPipelinesNV(*_device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocator(), &_pipeline);
+    VkResult result = extensions->vkCreateRayTracingPipelinesNV(*_device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocationCallbacks(), &_pipeline);
     if (result == VK_SUCCESS)
     {
         auto rayTracingProperties = _device->getPhysicalDevice()->getProperties<VkPhysicalDeviceRayTracingPropertiesNV, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV>();
@@ -163,7 +163,7 @@ RayTracingPipeline::Implementation::Implementation(Context& context, RayTracingP
 
 RayTracingPipeline::Implementation::~Implementation()
 {
-    vkDestroyPipeline(*_device, _pipeline, _device->getAllocator());
+    vkDestroyPipeline(*_device, _pipeline, _device->getAllocationCallbacks());
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/vsg/state/ComputePipeline.cpp
+++ b/src/vsg/state/ComputePipeline.cpp
@@ -82,7 +82,7 @@ ComputePipeline::Implementation::Implementation(Context& context, Device* device
     pipelineInfo.basePipelineHandle = VK_NULL_HANDLE;
     pipelineInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateComputePipelines(*device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocator(), &_pipeline); result != VK_SUCCESS)
+    if (VkResult result = vkCreateComputePipelines(*device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocationCallbacks(), &_pipeline); result != VK_SUCCESS)
     {
         throw Exception{"Error: vsg::Pipeline::createCompute(...) failed to create VkPipeline.", result};
     }
@@ -90,7 +90,7 @@ ComputePipeline::Implementation::Implementation(Context& context, Device* device
 
 ComputePipeline::Implementation::~Implementation()
 {
-    vkDestroyPipeline(*_device, _pipeline, _device->getAllocator());
+    vkDestroyPipeline(*_device, _pipeline, _device->getAllocationCallbacks());
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/vsg/state/ComputePipeline.cpp
+++ b/src/vsg/state/ComputePipeline.cpp
@@ -26,10 +26,9 @@ ComputePipeline::ComputePipeline()
 {
 }
 
-ComputePipeline::ComputePipeline(PipelineLayout* pipelineLayout, ShaderStage* shaderStage, AllocationCallbacks* allocator) :
+ComputePipeline::ComputePipeline(PipelineLayout* pipelineLayout, ShaderStage* shaderStage) :
     _pipelineLayout(pipelineLayout),
-    _shaderStage(shaderStage),
-    _allocator(allocator)
+    _shaderStage(shaderStage)
 {
 }
 
@@ -59,7 +58,7 @@ void ComputePipeline::compile(Context& context)
     {
         _pipelineLayout->compile(context);
         _shaderStage->compile(context);
-        _implementation[context.deviceID] = ComputePipeline::Implementation::create(context, context.device, _pipelineLayout, _shaderStage, _allocator);
+        _implementation[context.deviceID] = ComputePipeline::Implementation::create(context, context.device, _pipelineLayout, _shaderStage);
     }
 }
 
@@ -67,11 +66,10 @@ void ComputePipeline::compile(Context& context)
 //
 // ComputePipeline::Implementation
 //
-ComputePipeline::Implementation::Implementation(Context& context, Device* device, PipelineLayout* pipelineLayout, ShaderStage* shaderStage, AllocationCallbacks* allocator) :
+ComputePipeline::Implementation::Implementation(Context& context, Device* device, PipelineLayout* pipelineLayout, ShaderStage* shaderStage) :
     _device(device),
     _pipelineLayout(pipelineLayout),
-    _shaderStage(shaderStage),
-    _allocator(allocator)
+    _shaderStage(shaderStage)
 {
     VkPipelineShaderStageCreateInfo stageInfo = {};
     stageInfo.pNext = nullptr;
@@ -84,7 +82,7 @@ ComputePipeline::Implementation::Implementation(Context& context, Device* device
     pipelineInfo.basePipelineHandle = VK_NULL_HANDLE;
     pipelineInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateComputePipelines(*device, VK_NULL_HANDLE, 1, &pipelineInfo, allocator, &_pipeline); result != VK_SUCCESS)
+    if (VkResult result = vkCreateComputePipelines(*device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocator(), &_pipeline); result != VK_SUCCESS)
     {
         throw Exception{"Error: vsg::Pipeline::createCompute(...) failed to create VkPipeline.", result};
     }
@@ -92,7 +90,7 @@ ComputePipeline::Implementation::Implementation(Context& context, Device* device
 
 ComputePipeline::Implementation::~Implementation()
 {
-    vkDestroyPipeline(*_device, _pipeline, _allocator);
+    vkDestroyPipeline(*_device, _pipeline, _device->getAllocator());
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/vsg/state/DescriptorSetLayout.cpp
+++ b/src/vsg/state/DescriptorSetLayout.cpp
@@ -80,7 +80,7 @@ DescriptorSetLayout::Implementation::Implementation(Device* device, const Descri
     layoutInfo.pBindings = descriptorSetLayoutBindings.data();
     layoutInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateDescriptorSetLayout(*device, &layoutInfo, _device->getAllocator(), &_descriptorSetLayout); result != VK_SUCCESS)
+    if (VkResult result = vkCreateDescriptorSetLayout(*device, &layoutInfo, _device->getAllocationCallbacks(), &_descriptorSetLayout); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create DescriptorSetLayout.", result};
     }
@@ -90,6 +90,6 @@ DescriptorSetLayout::Implementation::~Implementation()
 {
     if (_descriptorSetLayout)
     {
-        vkDestroyDescriptorSetLayout(*_device, _descriptorSetLayout, _device->getAllocator());
+        vkDestroyDescriptorSetLayout(*_device, _descriptorSetLayout, _device->getAllocationCallbacks());
     }
 }

--- a/src/vsg/state/DescriptorSetLayout.cpp
+++ b/src/vsg/state/DescriptorSetLayout.cpp
@@ -71,9 +71,8 @@ void DescriptorSetLayout::compile(Context& context)
 //
 // DescriptorSetLayout::Implementation
 //
-DescriptorSetLayout::Implementation::Implementation(Device* device, const DescriptorSetLayoutBindings& descriptorSetLayoutBindings, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+DescriptorSetLayout::Implementation::Implementation(Device* device, const DescriptorSetLayoutBindings& descriptorSetLayoutBindings) :
+    _device(device)
 {
     VkDescriptorSetLayoutCreateInfo layoutInfo = {};
     layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -81,7 +80,7 @@ DescriptorSetLayout::Implementation::Implementation(Device* device, const Descri
     layoutInfo.pBindings = descriptorSetLayoutBindings.data();
     layoutInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateDescriptorSetLayout(*device, &layoutInfo, allocator, &_descriptorSetLayout); result != VK_SUCCESS)
+    if (VkResult result = vkCreateDescriptorSetLayout(*device, &layoutInfo, _device->getAllocator(), &_descriptorSetLayout); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create DescriptorSetLayout.", result};
     }
@@ -91,6 +90,6 @@ DescriptorSetLayout::Implementation::~Implementation()
 {
     if (_descriptorSetLayout)
     {
-        vkDestroyDescriptorSetLayout(*_device, _descriptorSetLayout, _allocator);
+        vkDestroyDescriptorSetLayout(*_device, _descriptorSetLayout, _device->getAllocator());
     }
 }

--- a/src/vsg/state/GraphicsPipeline.cpp
+++ b/src/vsg/state/GraphicsPipeline.cpp
@@ -26,12 +26,11 @@ GraphicsPipeline::GraphicsPipeline()
 {
 }
 
-GraphicsPipeline::GraphicsPipeline(PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const GraphicsPipelineStates& pipelineStates, uint32_t subpass, AllocationCallbacks* allocator) :
+GraphicsPipeline::GraphicsPipeline(PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const GraphicsPipelineStates& pipelineStates, uint32_t subpass) :
     _pipelineLayout(pipelineLayout),
     _shaderStages(shaderStages),
     _pipelineStates(pipelineStates),
-    _subpass(subpass),
-    _allocator(allocator)
+    _subpass(subpass)
 {
 }
 
@@ -98,7 +97,7 @@ void GraphicsPipeline::compile(Context& context)
 
         // TODO : current buffering of GraphicsPipeline::Implementation assumes a single VkPipelie for each Device, but could potentially vary with Device, RenerPass, combined_PipelinStates
         // so will need to have some form of contextID/renderID that wraps all these variables up and indexes the buffer using it instead of deviceID.
-        _implementation[context.deviceID] = GraphicsPipeline::Implementation::create(context, context.device, context.renderPass, _pipelineLayout, _shaderStages, combined_pipelineStates, _subpass, _allocator);
+        _implementation[context.deviceID] = GraphicsPipeline::Implementation::create(context, context.device, context.renderPass, _pipelineLayout, _shaderStages, combined_pipelineStates, _subpass);
     }
 }
 
@@ -106,9 +105,8 @@ void GraphicsPipeline::compile(Context& context)
 //
 // GraphicsPipeline::Implementation
 //
-GraphicsPipeline::Implementation::Implementation(Context& context, Device* device, RenderPass* renderPass, PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const GraphicsPipelineStates& pipelineStates, uint32_t subpass, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+GraphicsPipeline::Implementation::Implementation(Context& context, Device* device, RenderPass* renderPass, PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const GraphicsPipelineStates& pipelineStates, uint32_t subpass) :
+    _device(device)
 {
     VkGraphicsPipelineCreateInfo pipelineInfo = {};
     pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
@@ -135,7 +133,7 @@ GraphicsPipeline::Implementation::Implementation(Context& context, Device* devic
         pipelineState->apply(context, pipelineInfo);
     }
 
-    VkResult result = vkCreateGraphicsPipelines(*device, VK_NULL_HANDLE, 1, &pipelineInfo, allocator, &_pipeline);
+    VkResult result = vkCreateGraphicsPipelines(*device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocator(), &_pipeline);
 
     context.scratchMemory->release();
 
@@ -147,7 +145,7 @@ GraphicsPipeline::Implementation::Implementation(Context& context, Device* devic
 
 GraphicsPipeline::Implementation::~Implementation()
 {
-    vkDestroyPipeline(*_device, _pipeline, _allocator);
+    vkDestroyPipeline(*_device, _pipeline, _device->getAllocator());
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/vsg/state/GraphicsPipeline.cpp
+++ b/src/vsg/state/GraphicsPipeline.cpp
@@ -133,7 +133,7 @@ GraphicsPipeline::Implementation::Implementation(Context& context, Device* devic
         pipelineState->apply(context, pipelineInfo);
     }
 
-    VkResult result = vkCreateGraphicsPipelines(*device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocator(), &_pipeline);
+    VkResult result = vkCreateGraphicsPipelines(*device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocationCallbacks(), &_pipeline);
 
     context.scratchMemory->release();
 
@@ -145,7 +145,7 @@ GraphicsPipeline::Implementation::Implementation(Context& context, Device* devic
 
 GraphicsPipeline::Implementation::~Implementation()
 {
-    vkDestroyPipeline(*_device, _pipeline, _device->getAllocator());
+    vkDestroyPipeline(*_device, _pipeline, _device->getAllocationCallbacks());
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/vsg/state/PipelineLayout.cpp
+++ b/src/vsg/state/PipelineLayout.cpp
@@ -95,10 +95,9 @@ void PipelineLayout::compile(Context& context)
 //
 // PipelineLayout::Implementation
 //
-PipelineLayout::Implementation::Implementation(Device* device, const DescriptorSetLayouts& descriptorSetLayouts, const PushConstantRanges& pushConstantRanges, VkPipelineLayoutCreateFlags flags, AllocationCallbacks* allocator) :
+PipelineLayout::Implementation::Implementation(Device* device, const DescriptorSetLayouts& descriptorSetLayouts, const PushConstantRanges& pushConstantRanges, VkPipelineLayoutCreateFlags flags) :
     _descriptorSetLayouts(descriptorSetLayouts),
-    _device(device),
-    _allocator(allocator)
+    _device(device)
 {
     std::vector<VkDescriptorSetLayout> layouts;
     for (auto& dsl : descriptorSetLayouts)
@@ -115,7 +114,7 @@ PipelineLayout::Implementation::Implementation(Device* device, const DescriptorS
     pipelineLayoutInfo.pPushConstantRanges = pushConstantRanges.data();
     pipelineLayoutInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreatePipelineLayout(*device, &pipelineLayoutInfo, allocator, &_pipelineLayout); result != VK_SUCCESS)
+    if (VkResult result = vkCreatePipelineLayout(*device, &pipelineLayoutInfo, _device->getAllocator(), &_pipelineLayout); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create PipelineLayout.", result};
     }
@@ -125,6 +124,6 @@ PipelineLayout::Implementation::~Implementation()
 {
     if (_pipelineLayout)
     {
-        vkDestroyPipelineLayout(*_device, _pipelineLayout, _allocator);
+        vkDestroyPipelineLayout(*_device, _pipelineLayout, _device->getAllocator());
     }
 }

--- a/src/vsg/state/PipelineLayout.cpp
+++ b/src/vsg/state/PipelineLayout.cpp
@@ -114,7 +114,7 @@ PipelineLayout::Implementation::Implementation(Device* device, const DescriptorS
     pipelineLayoutInfo.pPushConstantRanges = pushConstantRanges.data();
     pipelineLayoutInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreatePipelineLayout(*device, &pipelineLayoutInfo, _device->getAllocator(), &_pipelineLayout); result != VK_SUCCESS)
+    if (VkResult result = vkCreatePipelineLayout(*device, &pipelineLayoutInfo, _device->getAllocationCallbacks(), &_pipelineLayout); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create PipelineLayout.", result};
     }
@@ -124,6 +124,6 @@ PipelineLayout::Implementation::~Implementation()
 {
     if (_pipelineLayout)
     {
-        vkDestroyPipelineLayout(*_device, _pipelineLayout, _device->getAllocator());
+        vkDestroyPipelineLayout(*_device, _pipelineLayout, _device->getAllocationCallbacks());
     }
 }

--- a/src/vsg/state/Sampler.cpp
+++ b/src/vsg/state/Sampler.cpp
@@ -97,7 +97,7 @@ void Sampler::compile(Context& context)
 Sampler::Implementation::Implementation(Device* device, const VkSamplerCreateInfo& createSamplerInfo) :
     _device(device)
 {
-    if (VkResult result = vkCreateSampler(*device, &createSamplerInfo, device->getAllocator(), &_sampler); result != VK_SUCCESS)
+    if (VkResult result = vkCreateSampler(*device, &createSamplerInfo, _device->getAllocationCallbacks(), &_sampler); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create vkSampler.", result};
     }
@@ -107,6 +107,6 @@ Sampler::Implementation::~Implementation()
 {
     if (_sampler)
     {
-        vkDestroySampler(*_device, _sampler, _device->getAllocator());
+        vkDestroySampler(*_device, _sampler, _device->getAllocationCallbacks());
     }
 }

--- a/src/vsg/state/Sampler.cpp
+++ b/src/vsg/state/Sampler.cpp
@@ -94,11 +94,10 @@ void Sampler::compile(Context& context)
     _implementation[context.deviceID] = Implementation::create(context.device, _samplerInfo);
 }
 
-Sampler::Implementation::Implementation(Device* device, const VkSamplerCreateInfo& createSamplerInfo, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+Sampler::Implementation::Implementation(Device* device, const VkSamplerCreateInfo& createSamplerInfo) :
+    _device(device)
 {
-    if (VkResult result = vkCreateSampler(*device, &createSamplerInfo, allocator, &_sampler); result != VK_SUCCESS)
+    if (VkResult result = vkCreateSampler(*device, &createSamplerInfo, device->getAllocator(), &_sampler); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create vkSampler.", result};
     }
@@ -108,6 +107,6 @@ Sampler::Implementation::~Implementation()
 {
     if (_sampler)
     {
-        vkDestroySampler(*_device, _sampler, _allocator);
+        vkDestroySampler(*_device, _sampler, _device->getAllocator());
     }
 }

--- a/src/vsg/state/ShaderModule.cpp
+++ b/src/vsg/state/ShaderModule.cpp
@@ -97,7 +97,7 @@ ShaderModule::Implementation::Implementation(Device* device, ShaderModule* shade
     createInfo.pCode = shaderModule->spirv().data();
     createInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateShaderModule(*device, &createInfo, _device->getAllocator(), &_shaderModule); result != VK_SUCCESS)
+    if (VkResult result = vkCreateShaderModule(*device, &createInfo, _device->getAllocationCallbacks(), &_shaderModule); result != VK_SUCCESS)
     {
         throw Exception{"Error: vsg::ShaderModule::create(...) failed to create shader module.", result};
     }
@@ -105,5 +105,5 @@ ShaderModule::Implementation::Implementation(Device* device, ShaderModule* shade
 
 ShaderModule::Implementation::~Implementation()
 {
-    vkDestroyShaderModule(*_device, _shaderModule, _device->getAllocator());
+    vkDestroyShaderModule(*_device, _shaderModule, _device->getAllocationCallbacks());
 }

--- a/src/vsg/state/ShaderModule.cpp
+++ b/src/vsg/state/ShaderModule.cpp
@@ -88,9 +88,8 @@ void ShaderModule::compile(Context& context)
     if (!_implementation[context.deviceID]) _implementation[context.deviceID] = Implementation::create(context.device, this);
 }
 
-ShaderModule::Implementation::Implementation(Device* device, ShaderModule* shaderModule, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+ShaderModule::Implementation::Implementation(Device* device, ShaderModule* shaderModule) :
+    _device(device)
 {
     VkShaderModuleCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
@@ -98,7 +97,7 @@ ShaderModule::Implementation::Implementation(Device* device, ShaderModule* shade
     createInfo.pCode = shaderModule->spirv().data();
     createInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateShaderModule(*device, &createInfo, allocator, &_shaderModule); result != VK_SUCCESS)
+    if (VkResult result = vkCreateShaderModule(*device, &createInfo, _device->getAllocator(), &_shaderModule); result != VK_SUCCESS)
     {
         throw Exception{"Error: vsg::ShaderModule::create(...) failed to create shader module.", result};
     }
@@ -106,5 +105,5 @@ ShaderModule::Implementation::Implementation(Device* device, ShaderModule* shade
 
 ShaderModule::Implementation::~Implementation()
 {
-    vkDestroyShaderModule(*_device, _shaderModule, _allocator);
+    vkDestroyShaderModule(*_device, _shaderModule, _device->getAllocator());
 }

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -84,10 +84,8 @@ void Window::_initInstance()
             if (_traits->apiDumpLayer) requestedLayers.push_back("VK_LAYER_LUNARG_api_dump");
         }
 
-        vsg::AllocationCallbacks* allocator = _traits->allocator;
-
         vsg::Names validatedNames = vsg::validateInstancelayerNames(requestedLayers);
-        _instance = vsg::Instance::create(instanceExtensions, validatedNames, allocator);
+        _instance = vsg::Instance::create(instanceExtensions, validatedNames);
     }
 }
 
@@ -152,7 +150,7 @@ void Window::_initDevice()
         if (!physicalDevice || queueFamily < 0 || presentFamily < 0) throw Exception{"Error: vsg::Window::create(...) failed to create Window, no Vulkan PhysicalDevice supported.", VK_ERROR_INVALID_EXTERNAL_HANDLE};
 
         vsg::QueueSettings queueSettings{vsg::QueueSetting{queueFamily, {1.0}}, vsg::QueueSetting{presentFamily, {1.0}}};
-        _device = vsg::Device::create(physicalDevice, queueSettings, validatedNames, deviceExtensions, _traits->allocator);
+        _device = vsg::Device::create(physicalDevice, queueSettings, validatedNames, deviceExtensions, _instance->getAllocator());
         _physicalDevice = physicalDevice;
     }
 

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -84,8 +84,7 @@ void Window::_initInstance()
             if (_traits->apiDumpLayer) requestedLayers.push_back("VK_LAYER_LUNARG_api_dump");
         }
 
-        // TODO need to decide whether we need to have a Window::_allocator or traits member.
-        vsg::AllocationCallbacks* allocator = nullptr;
+        vsg::AllocationCallbacks* allocator = _traits->allocator;
 
         vsg::Names validatedNames = vsg::validateInstancelayerNames(requestedLayers);
         _instance = vsg::Instance::create(instanceExtensions, validatedNames, allocator);
@@ -166,11 +165,11 @@ void Window::_initRenderPass()
 
     if (_framebufferSamples == VK_SAMPLE_COUNT_1_BIT)
     {
-        _renderPass = vsg::createRenderPass(_device, _imageFormat.format, _depthFormat, _traits->allocator);
+        _renderPass = vsg::createRenderPass(_device, _imageFormat.format, _depthFormat);
     }
     else
     {
-        _renderPass = vsg::createMultisampledRenderPass(_device, _imageFormat.format, _depthFormat, _framebufferSamples, _traits->allocator);
+        _renderPass = vsg::createMultisampledRenderPass(_device, _imageFormat.format, _depthFormat, _framebufferSamples);
     }
 }
 

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -150,7 +150,7 @@ void Window::_initDevice()
         if (!physicalDevice || queueFamily < 0 || presentFamily < 0) throw Exception{"Error: vsg::Window::create(...) failed to create Window, no Vulkan PhysicalDevice supported.", VK_ERROR_INVALID_EXTERNAL_HANDLE};
 
         vsg::QueueSettings queueSettings{vsg::QueueSetting{queueFamily, {1.0}}, vsg::QueueSetting{presentFamily, {1.0}}};
-        _device = vsg::Device::create(physicalDevice, queueSettings, validatedNames, deviceExtensions, _instance->getAllocator());
+        _device = vsg::Device::create(physicalDevice, queueSettings, validatedNames, deviceExtensions, _instance->getAllocationCallbacks());
         _physicalDevice = physicalDevice;
     }
 

--- a/src/vsg/vk/Buffer.cpp
+++ b/src/vsg/vk/Buffer.cpp
@@ -20,11 +20,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-Buffer::Buffer(Device* device, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode, AllocationCallbacks* allocator) :
+Buffer::Buffer(Device* device, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode) :
     _usage(usage),
     _sharingMode(sharingMode),
     _device(device),
-    _allocator(allocator),
     _memorySlots(size)
 {
     VkBufferCreateInfo bufferInfo = {};
@@ -33,7 +32,7 @@ Buffer::Buffer(Device* device, VkDeviceSize size, VkBufferUsageFlags usage, VkSh
     bufferInfo.usage = usage;
     bufferInfo.sharingMode = sharingMode;
 
-    if (VkResult result = vkCreateBuffer(*device, &bufferInfo, allocator, &_buffer); result != VK_SUCCESS)
+    if (VkResult result = vkCreateBuffer(*device, &bufferInfo, _device->getAllocator(), &_buffer); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create vkBuffer.", result};
     }
@@ -47,7 +46,7 @@ Buffer::~Buffer()
 
     if (_buffer)
     {
-        vkDestroyBuffer(*_device, _buffer, _allocator);
+        vkDestroyBuffer(*_device, _buffer, _device->getAllocator());
     }
 
     if (_deviceMemory)

--- a/src/vsg/vk/Buffer.cpp
+++ b/src/vsg/vk/Buffer.cpp
@@ -32,7 +32,7 @@ Buffer::Buffer(Device* device, VkDeviceSize size, VkBufferUsageFlags usage, VkSh
     bufferInfo.usage = usage;
     bufferInfo.sharingMode = sharingMode;
 
-    if (VkResult result = vkCreateBuffer(*device, &bufferInfo, _device->getAllocator(), &_buffer); result != VK_SUCCESS)
+    if (VkResult result = vkCreateBuffer(*device, &bufferInfo, _device->getAllocationCallbacks(), &_buffer); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create vkBuffer.", result};
     }
@@ -46,7 +46,7 @@ Buffer::~Buffer()
 
     if (_buffer)
     {
-        vkDestroyBuffer(*_device, _buffer, _device->getAllocator());
+        vkDestroyBuffer(*_device, _buffer, _device->getAllocationCallbacks());
     }
 
     if (_deviceMemory)

--- a/src/vsg/vk/BufferView.cpp
+++ b/src/vsg/vk/BufferView.cpp
@@ -28,7 +28,7 @@ BufferView::BufferView(Buffer* buffer, VkFormat format, VkDeviceSize offset, VkD
     createInfo.range = range;
     createInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateBufferView(*(buffer->getDevice()), &createInfo, _device->getAllocator(), &_bufferView); result != VK_SUCCESS)
+    if (VkResult result = vkCreateBufferView(*(buffer->getDevice()), &createInfo, _device->getAllocationCallbacks(), &_bufferView); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create BufferView.", result};
     }
@@ -38,6 +38,6 @@ BufferView::~BufferView()
 {
     if (_bufferView)
     {
-        vkDestroyBufferView(*_device, _bufferView, _device->getAllocator());
+        vkDestroyBufferView(*_device, _bufferView, _device->getAllocationCallbacks());
     }
 }

--- a/src/vsg/vk/BufferView.cpp
+++ b/src/vsg/vk/BufferView.cpp
@@ -16,10 +16,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-BufferView::BufferView(Buffer* buffer, VkFormat format, VkDeviceSize offset, VkDeviceSize range, AllocationCallbacks* allocator) :
+BufferView::BufferView(Buffer* buffer, VkFormat format, VkDeviceSize offset, VkDeviceSize range) :
     _device(buffer->getDevice()),
-    _buffer(buffer),
-    _allocator(allocator)
+    _buffer(buffer)
 {
     VkBufferViewCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO;
@@ -29,7 +28,7 @@ BufferView::BufferView(Buffer* buffer, VkFormat format, VkDeviceSize offset, VkD
     createInfo.range = range;
     createInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateBufferView(*(buffer->getDevice()), &createInfo, allocator, &_bufferView); result != VK_SUCCESS)
+    if (VkResult result = vkCreateBufferView(*(buffer->getDevice()), &createInfo, _device->getAllocator(), &_bufferView); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create BufferView.", result};
     }
@@ -39,6 +38,6 @@ BufferView::~BufferView()
 {
     if (_bufferView)
     {
-        vkDestroyBufferView(*_device, _bufferView, _allocator);
+        vkDestroyBufferView(*_device, _bufferView, _device->getAllocator());
     }
 }

--- a/src/vsg/vk/CommandPool.cpp
+++ b/src/vsg/vk/CommandPool.cpp
@@ -27,7 +27,7 @@ CommandPool::CommandPool(Device* device, uint32_t queueFamilyIndex) :
     //poolInfo.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
     poolInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateCommandPool(*device, &poolInfo, _device->getAllocator(), &_commandPool); result != VK_SUCCESS)
+    if (VkResult result = vkCreateCommandPool(*device, &poolInfo, _device->getAllocationCallbacks(), &_commandPool); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create command pool.", result};
     }
@@ -37,6 +37,6 @@ CommandPool::~CommandPool()
 {
     if (_commandPool)
     {
-        vkDestroyCommandPool(*_device, _commandPool, _device->getAllocator());
+        vkDestroyCommandPool(*_device, _commandPool, _device->getAllocationCallbacks());
     }
 }

--- a/src/vsg/vk/CommandPool.cpp
+++ b/src/vsg/vk/CommandPool.cpp
@@ -16,9 +16,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-CommandPool::CommandPool(Device* device, uint32_t queueFamilyIndex, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+CommandPool::CommandPool(Device* device, uint32_t queueFamilyIndex) :
+    _device(device)
 {
     VkCommandPoolCreateInfo poolInfo = {};
     poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
@@ -28,7 +27,7 @@ CommandPool::CommandPool(Device* device, uint32_t queueFamilyIndex, AllocationCa
     //poolInfo.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
     poolInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateCommandPool(*device, &poolInfo, allocator, &_commandPool); result != VK_SUCCESS)
+    if (VkResult result = vkCreateCommandPool(*device, &poolInfo, _device->getAllocator(), &_commandPool); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create command pool.", result};
     }
@@ -38,6 +37,6 @@ CommandPool::~CommandPool()
 {
     if (_commandPool)
     {
-        vkDestroyCommandPool(*_device, _commandPool, _allocator);
+        vkDestroyCommandPool(*_device, _commandPool, _device->getAllocator());
     }
 }

--- a/src/vsg/vk/DescriptorPool.cpp
+++ b/src/vsg/vk/DescriptorPool.cpp
@@ -16,9 +16,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-DescriptorPool::DescriptorPool(Device* device, uint32_t maxSets, const DescriptorPoolSizes& descriptorPoolSizes, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+DescriptorPool::DescriptorPool(Device* device, uint32_t maxSets, const DescriptorPoolSizes& descriptorPoolSizes) :
+    _device(device)
 {
     VkDescriptorPoolCreateInfo poolInfo = {};
     poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
@@ -28,7 +27,7 @@ DescriptorPool::DescriptorPool(Device* device, uint32_t maxSets, const Descripto
     poolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT; // will we need VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT_EXT later?
     poolInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateDescriptorPool(*device, &poolInfo, allocator, &_descriptorPool); result != VK_SUCCESS)
+    if (VkResult result = vkCreateDescriptorPool(*device, &poolInfo, _device->getAllocator(), &_descriptorPool); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create DescriptorPool.", result};
     }
@@ -38,6 +37,6 @@ DescriptorPool::~DescriptorPool()
 {
     if (_descriptorPool)
     {
-        vkDestroyDescriptorPool(*_device, _descriptorPool, _allocator);
+        vkDestroyDescriptorPool(*_device, _descriptorPool, _device->getAllocator());
     }
 }

--- a/src/vsg/vk/DescriptorPool.cpp
+++ b/src/vsg/vk/DescriptorPool.cpp
@@ -27,7 +27,7 @@ DescriptorPool::DescriptorPool(Device* device, uint32_t maxSets, const Descripto
     poolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT; // will we need VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT_EXT later?
     poolInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateDescriptorPool(*device, &poolInfo, _device->getAllocator(), &_descriptorPool); result != VK_SUCCESS)
+    if (VkResult result = vkCreateDescriptorPool(*device, &poolInfo, _device->getAllocationCallbacks(), &_descriptorPool); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create DescriptorPool.", result};
     }
@@ -37,6 +37,6 @@ DescriptorPool::~DescriptorPool()
 {
     if (_descriptorPool)
     {
-        vkDestroyDescriptorPool(*_device, _descriptorPool, _device->getAllocator());
+        vkDestroyDescriptorPool(*_device, _descriptorPool, _device->getAllocationCallbacks());
     }
 }

--- a/src/vsg/vk/DeviceMemory.cpp
+++ b/src/vsg/vk/DeviceMemory.cpp
@@ -329,7 +329,7 @@ DeviceMemory::DeviceMemory(Device* device, const VkMemoryRequirements& memRequir
     allocateInfo.memoryTypeIndex = memoryTypeIndex;
     allocateInfo.pNext = pNextAllocInfo;
 
-    if (VkResult result = vkAllocateMemory(*device, &allocateInfo, _device->getAllocator(), &_deviceMemory); result != VK_SUCCESS)
+    if (VkResult result = vkAllocateMemory(*device, &allocateInfo, _device->getAllocationCallbacks(), &_deviceMemory); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create DeviceMemory.", result};
     }
@@ -343,7 +343,7 @@ DeviceMemory::~DeviceMemory()
         std::cout << "DeviceMemory::~DeviceMemory() vkFreeMemory(*_device, " << _deviceMemory << ", _allocator);" << std::endl;
 #endif
 
-        vkFreeMemory(*_device, _deviceMemory, _device->getAllocator());
+        vkFreeMemory(*_device, _deviceMemory, _device->getAllocationCallbacks());
     }
 }
 

--- a/src/vsg/vk/DeviceMemory.cpp
+++ b/src/vsg/vk/DeviceMemory.cpp
@@ -287,10 +287,9 @@ void MemorySlots::release(VkDeviceSize offset, VkDeviceSize size)
 //
 // DeviceMemory
 //
-DeviceMemory::DeviceMemory(Device* device, const VkMemoryRequirements& memRequirements, VkMemoryPropertyFlags properties, void* pNextAllocInfo, AllocationCallbacks* allocator) :
+DeviceMemory::DeviceMemory(Device* device, const VkMemoryRequirements& memRequirements, VkMemoryPropertyFlags properties, void* pNextAllocInfo) :
     _memoryRequirements(memRequirements),
     _device(device),
-    _allocator(allocator),
     _memorySlots(memRequirements.size)
 {
     uint32_t typeFilter = memRequirements.memoryTypeBits;
@@ -330,7 +329,7 @@ DeviceMemory::DeviceMemory(Device* device, const VkMemoryRequirements& memRequir
     allocateInfo.memoryTypeIndex = memoryTypeIndex;
     allocateInfo.pNext = pNextAllocInfo;
 
-    if (VkResult result = vkAllocateMemory(*device, &allocateInfo, allocator, &_deviceMemory); result != VK_SUCCESS)
+    if (VkResult result = vkAllocateMemory(*device, &allocateInfo, _device->getAllocator(), &_deviceMemory); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create DeviceMemory.", result};
     }
@@ -344,7 +343,7 @@ DeviceMemory::~DeviceMemory()
         std::cout << "DeviceMemory::~DeviceMemory() vkFreeMemory(*_device, " << _deviceMemory << ", _allocator);" << std::endl;
 #endif
 
-        vkFreeMemory(*_device, _deviceMemory, _allocator);
+        vkFreeMemory(*_device, _deviceMemory, _device->getAllocator());
     }
 }
 

--- a/src/vsg/vk/Fence.cpp
+++ b/src/vsg/vk/Fence.cpp
@@ -16,16 +16,15 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-Fence::Fence(Device* device, VkFenceCreateFlags flags, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+Fence::Fence(Device* device, VkFenceCreateFlags flags) :
+    _device(device)
 {
     VkFenceCreateInfo createFenceInfo = {};
     createFenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
     createFenceInfo.flags = flags;
     createFenceInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateFence(*device, &createFenceInfo, allocator, &_vkFence); result != VK_SUCCESS)
+    if (VkResult result = vkCreateFence(*device, &createFenceInfo, _device->getAllocator(), &_vkFence); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create Fence.", result};
     }
@@ -35,7 +34,7 @@ Fence::~Fence()
 {
     if (_vkFence)
     {
-        vkDestroyFence(*_device, _vkFence, _allocator);
+        vkDestroyFence(*_device, _vkFence, _device->getAllocator());
     }
 }
 

--- a/src/vsg/vk/Fence.cpp
+++ b/src/vsg/vk/Fence.cpp
@@ -24,7 +24,7 @@ Fence::Fence(Device* device, VkFenceCreateFlags flags) :
     createFenceInfo.flags = flags;
     createFenceInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateFence(*device, &createFenceInfo, _device->getAllocator(), &_vkFence); result != VK_SUCCESS)
+    if (VkResult result = vkCreateFence(*device, &createFenceInfo, _device->getAllocationCallbacks(), &_vkFence); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create Fence.", result};
     }
@@ -34,7 +34,7 @@ Fence::~Fence()
 {
     if (_vkFence)
     {
-        vkDestroyFence(*_device, _vkFence, _device->getAllocator());
+        vkDestroyFence(*_device, _vkFence, _device->getAllocationCallbacks());
     }
 }
 

--- a/src/vsg/vk/Image.cpp
+++ b/src/vsg/vk/Image.cpp
@@ -16,18 +16,16 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-Image::Image(VkImage image, Device* device, AllocationCallbacks* allocator) :
+Image::Image(VkImage image, Device* device) :
     _image(image),
-    _device(device),
-    _allocator(allocator)
+    _device(device)
 {
 }
 
-Image::Image(Device* device, const VkImageCreateInfo& createImageInfo, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+Image::Image(Device* device, const VkImageCreateInfo& createImageInfo) :
+    _device(device)
 {
-    if (VkResult result = vkCreateImage(*device, &createImageInfo, allocator, &_image); result != VK_SUCCESS)
+    if (VkResult result = vkCreateImage(*device, &createImageInfo, _device->getAllocator(), &_image); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create vkImage.", result};
     }
@@ -42,7 +40,7 @@ Image::~Image()
 
     if (_image)
     {
-        vkDestroyImage(*_device, _image, _allocator);
+        vkDestroyImage(*_device, _image, _device->getAllocator());
     }
 }
 

--- a/src/vsg/vk/Image.cpp
+++ b/src/vsg/vk/Image.cpp
@@ -25,7 +25,7 @@ Image::Image(VkImage image, Device* device) :
 Image::Image(Device* device, const VkImageCreateInfo& createImageInfo) :
     _device(device)
 {
-    if (VkResult result = vkCreateImage(*device, &createImageInfo, _device->getAllocator(), &_image); result != VK_SUCCESS)
+    if (VkResult result = vkCreateImage(*device, &createImageInfo, _device->getAllocationCallbacks(), &_image); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create vkImage.", result};
     }
@@ -40,7 +40,7 @@ Image::~Image()
 
     if (_image)
     {
-        vkDestroyImage(*_device, _image, _device->getAllocator());
+        vkDestroyImage(*_device, _image, _device->getAllocationCallbacks());
     }
 }
 

--- a/src/vsg/vk/ImageView.cpp
+++ b/src/vsg/vk/ImageView.cpp
@@ -20,7 +20,7 @@ using namespace vsg;
 ImageView::ImageView(Device* device, const VkImageViewCreateInfo& createInfo) :
     _device(device)
 {
-    if (VkResult result = vkCreateImageView(*device, &createInfo, _device->getAllocator(), &_imageView); result != VK_SUCCESS)
+    if (VkResult result = vkCreateImageView(*device, &createInfo, _device->getAllocationCallbacks(), &_imageView); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create ImageView.", result};
     }
@@ -41,7 +41,7 @@ ImageView::ImageView(Device* device, VkImage image, VkImageViewType type, VkForm
     createInfo.subresourceRange.layerCount = 1;
     createInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateImageView(*device, &createInfo, _device->getAllocator(), &_imageView); result != VK_SUCCESS)
+    if (VkResult result = vkCreateImageView(*device, &createInfo, _device->getAllocationCallbacks(), &_imageView); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create ImageView.", result};
     }
@@ -63,7 +63,7 @@ ImageView::ImageView(Device* device, Image* image, VkImageViewType type, VkForma
     createInfo.subresourceRange.layerCount = 1;
     createInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateImageView(*device, &createInfo, _device->getAllocator(), &_imageView); result != VK_SUCCESS)
+    if (VkResult result = vkCreateImageView(*device, &createInfo, _device->getAllocationCallbacks(), &_imageView); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create ImageView.", result};
     }
@@ -73,7 +73,7 @@ ImageView::~ImageView()
 {
     if (_imageView)
     {
-        vkDestroyImageView(*_device, _imageView, _device->getAllocator());
+        vkDestroyImageView(*_device, _imageView, _device->getAllocationCallbacks());
     }
 }
 

--- a/src/vsg/vk/ImageView.cpp
+++ b/src/vsg/vk/ImageView.cpp
@@ -17,19 +17,17 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-ImageView::ImageView(Device* device, const VkImageViewCreateInfo& createInfo, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+ImageView::ImageView(Device* device, const VkImageViewCreateInfo& createInfo) :
+    _device(device)
 {
-    if (VkResult result = vkCreateImageView(*device, &createInfo, allocator, &_imageView); result != VK_SUCCESS)
+    if (VkResult result = vkCreateImageView(*device, &createInfo, _device->getAllocator(), &_imageView); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create ImageView.", result};
     }
 }
 
-ImageView::ImageView(Device* device, VkImage image, VkImageViewType type, VkFormat format, VkImageAspectFlags aspectFlags, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+ImageView::ImageView(Device* device, VkImage image, VkImageViewType type, VkFormat format, VkImageAspectFlags aspectFlags) :
+    _device(device)
 {
     VkImageViewCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -43,16 +41,15 @@ ImageView::ImageView(Device* device, VkImage image, VkImageViewType type, VkForm
     createInfo.subresourceRange.layerCount = 1;
     createInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateImageView(*device, &createInfo, allocator, &_imageView); result != VK_SUCCESS)
+    if (VkResult result = vkCreateImageView(*device, &createInfo, _device->getAllocator(), &_imageView); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create ImageView.", result};
     }
 }
 
-ImageView::ImageView(Device* device, Image* image, VkImageViewType type, VkFormat format, VkImageAspectFlags aspectFlags, AllocationCallbacks* allocator) :
+ImageView::ImageView(Device* device, Image* image, VkImageViewType type, VkFormat format, VkImageAspectFlags aspectFlags) :
     _device(device),
-    _image(image),
-    _allocator(allocator)
+    _image(image)
 {
     VkImageViewCreateInfo createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -66,7 +63,7 @@ ImageView::ImageView(Device* device, Image* image, VkImageViewType type, VkForma
     createInfo.subresourceRange.layerCount = 1;
     createInfo.pNext = nullptr;
 
-    if (VkResult result = vkCreateImageView(*device, &createInfo, allocator, &_imageView); result != VK_SUCCESS)
+    if (VkResult result = vkCreateImageView(*device, &createInfo, _device->getAllocator(), &_imageView); result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create ImageView.", result};
     }
@@ -76,7 +73,7 @@ ImageView::~ImageView()
 {
     if (_imageView)
     {
-        vkDestroyImageView(*_device, _imageView, _allocator);
+        vkDestroyImageView(*_device, _imageView, _device->getAllocator());
     }
 }
 

--- a/src/vsg/vk/RenderPass.cpp
+++ b/src/vsg/vk/RenderPass.cpp
@@ -18,9 +18,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-RenderPass::RenderPass(Device* device, const Attachments& attachments, const Subpasses& subpasses, const Dependencies& dependencies, AllocationCallbacks* allocator) :
-    _device(device),
-    _allocator(allocator)
+RenderPass::RenderPass(Device* device, const Attachments& attachments, const Subpasses& subpasses, const Dependencies& dependencies) :
+    _device(device)
 {
     _maxSamples = VK_SAMPLE_COUNT_1_BIT;
     for (auto& attachment : attachments)
@@ -54,7 +53,7 @@ RenderPass::RenderPass(Device* device, const Attachments& attachments, const Sub
     renderPassInfo.dependencyCount = static_cast<uint32_t>(dependencies.size());
     renderPassInfo.pDependencies = dependencies.data();
 
-    VkResult result = vkCreateRenderPass(*device, &renderPassInfo, allocator, &_renderPass);
+    VkResult result = vkCreateRenderPass(*device, &renderPassInfo, _device->getAllocator(), &_renderPass);
     if (result != VK_SUCCESS)
     {
         throw Exception{"Error: vsg::RenderPass::create(...) Failed to create VkRenderPass.", result};
@@ -65,7 +64,7 @@ RenderPass::~RenderPass()
 {
     if (_renderPass)
     {
-        vkDestroyRenderPass(*_device, _renderPass, _allocator);
+        vkDestroyRenderPass(*_device, _renderPass, _device->getAllocator());
     }
 }
 
@@ -99,7 +98,7 @@ AttachmentDescription vsg::defaultDepthAttachment(VkFormat depthFormat)
     return depthAttachment;
 }
 
-ref_ptr<RenderPass> vsg::createRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat, AllocationCallbacks* allocator)
+ref_ptr<RenderPass> vsg::createRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat)
 {
     RenderPass::Attachments attachments{
         defaultColorAttachment(imageFormat),
@@ -130,15 +129,14 @@ ref_ptr<RenderPass> vsg::createRenderPass(Device* device, VkFormat imageFormat, 
 
     RenderPass::Dependencies dependencies{dependency};
 
-    return RenderPass::create(device, attachments, subpasses, dependencies, allocator);
+    return RenderPass::create(device, attachments, subpasses, dependencies);
 }
 
-ref_ptr<RenderPass> vsg::createMultisampledRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat,
-                                                      VkSampleCountFlagBits samples, AllocationCallbacks* allocator)
+ref_ptr<RenderPass> vsg::createMultisampledRenderPass(Device* device, VkFormat imageFormat, VkFormat depthFormat, VkSampleCountFlagBits samples)
 {
     if (samples == VK_SAMPLE_COUNT_1_BIT)
     {
-        return createRenderPass(device, imageFormat, depthFormat, allocator);
+        return createRenderPass(device, imageFormat, depthFormat);
     }
 
     // First attachment is multisampled target.
@@ -216,5 +214,5 @@ ref_ptr<RenderPass> vsg::createMultisampledRenderPass(Device* device, VkFormat i
 
     RenderPass::Dependencies dependencies{dependency, dependency2};
 
-    return RenderPass::create(device, attachments, subpasses, dependencies, allocator);
+    return RenderPass::create(device, attachments, subpasses, dependencies);
 }

--- a/src/vsg/vk/RenderPass.cpp
+++ b/src/vsg/vk/RenderPass.cpp
@@ -53,7 +53,7 @@ RenderPass::RenderPass(Device* device, const Attachments& attachments, const Sub
     renderPassInfo.dependencyCount = static_cast<uint32_t>(dependencies.size());
     renderPassInfo.pDependencies = dependencies.data();
 
-    VkResult result = vkCreateRenderPass(*device, &renderPassInfo, _device->getAllocator(), &_renderPass);
+    VkResult result = vkCreateRenderPass(*device, &renderPassInfo, _device->getAllocationCallbacks(), &_renderPass);
     if (result != VK_SUCCESS)
     {
         throw Exception{"Error: vsg::RenderPass::create(...) Failed to create VkRenderPass.", result};
@@ -64,7 +64,7 @@ RenderPass::~RenderPass()
 {
     if (_renderPass)
     {
-        vkDestroyRenderPass(*_device, _renderPass, _device->getAllocator());
+        vkDestroyRenderPass(*_device, _renderPass, _device->getAllocationCallbacks());
     }
 }
 

--- a/src/vsg/vk/Semaphore.cpp
+++ b/src/vsg/vk/Semaphore.cpp
@@ -16,16 +16,15 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-Semaphore::Semaphore(Device* device, VkPipelineStageFlags pipelineStageFlags, void* pNextCreateInfo, AllocationCallbacks* allocator) :
+Semaphore::Semaphore(Device* device, VkPipelineStageFlags pipelineStageFlags, void* pNextCreateInfo) :
     _pipelineStageFlags(pipelineStageFlags),
-    _device(device),
-    _allocator(allocator)
+    _device(device)
 {
     VkSemaphoreCreateInfo semaphoreInfo = {};
     semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
     semaphoreInfo.pNext = pNextCreateInfo;
 
-    VkResult result = vkCreateSemaphore(*device, &semaphoreInfo, allocator, &_semaphore);
+    VkResult result = vkCreateSemaphore(*device, &semaphoreInfo, _device->getAllocator(), &_semaphore);
     if (result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create semaphore.", result};
@@ -36,6 +35,6 @@ Semaphore::~Semaphore()
 {
     if (_semaphore)
     {
-        vkDestroySemaphore(*_device, _semaphore, _allocator);
+        vkDestroySemaphore(*_device, _semaphore, _device->getAllocator());
     }
 }

--- a/src/vsg/vk/Semaphore.cpp
+++ b/src/vsg/vk/Semaphore.cpp
@@ -24,7 +24,7 @@ Semaphore::Semaphore(Device* device, VkPipelineStageFlags pipelineStageFlags, vo
     semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
     semaphoreInfo.pNext = pNextCreateInfo;
 
-    VkResult result = vkCreateSemaphore(*device, &semaphoreInfo, _device->getAllocator(), &_semaphore);
+    VkResult result = vkCreateSemaphore(*device, &semaphoreInfo, _device->getAllocationCallbacks(), &_semaphore);
     if (result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create semaphore.", result};
@@ -35,6 +35,6 @@ Semaphore::~Semaphore()
 {
     if (_semaphore)
     {
-        vkDestroySemaphore(*_device, _semaphore, _device->getAllocator());
+        vkDestroySemaphore(*_device, _semaphore, _device->getAllocationCallbacks());
     }
 }

--- a/src/vsg/vk/Surface.cpp
+++ b/src/vsg/vk/Surface.cpp
@@ -16,10 +16,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-Surface::Surface(VkSurfaceKHR surface, Instance* instance, AllocationCallbacks* allocator) :
+Surface::Surface(VkSurfaceKHR surface, Instance* instance) :
     _surface(surface),
-    _instance(instance),
-    _allocator(allocator)
+    _instance(instance)
 {
 }
 
@@ -27,6 +26,6 @@ Surface::~Surface()
 {
     if (_surface)
     {
-        vkDestroySurfaceKHR(*_instance, _surface, _allocator);
+        vkDestroySurfaceKHR(*_instance, _surface, _instance->getAllocator());
     }
 }

--- a/src/vsg/vk/Surface.cpp
+++ b/src/vsg/vk/Surface.cpp
@@ -26,6 +26,6 @@ Surface::~Surface()
 {
     if (_surface)
     {
-        vkDestroySurfaceKHR(*_instance, _surface, _instance->getAllocator());
+        vkDestroySurfaceKHR(*_instance, _surface, _instance->getAllocationCallbacks());
     }
 }

--- a/src/vsg/vk/Swapchain.cpp
+++ b/src/vsg/vk/Swapchain.cpp
@@ -131,8 +131,8 @@ VkPresentModeKHR vsg::selectSwapPresentMode(const SwapChainSupportDetails& detai
 //
 // SwapchainImage
 //
-SwapchainImage::SwapchainImage(VkImage image, Device* device, AllocationCallbacks* allocator) :
-    Inherit(image, device, allocator)
+SwapchainImage::SwapchainImage(VkImage image, Device* device) :
+    Inherit(image, device)
 {
 }
 
@@ -146,7 +146,8 @@ SwapchainImage::~SwapchainImage()
 //
 // Swapchain
 //
-Swapchain::Swapchain(PhysicalDevice* physicalDevice, Device* device, Surface* surface, uint32_t width, uint32_t height, SwapchainPreferences& preferences, AllocationCallbacks* allocator)
+Swapchain::Swapchain(PhysicalDevice* physicalDevice, Device* device, Surface* surface, uint32_t width, uint32_t height, SwapchainPreferences& preferences):
+    _device(device)
 {
     SwapChainSupportDetails details = querySwapChainSupport(*physicalDevice, *surface);
 
@@ -203,17 +204,15 @@ Swapchain::Swapchain(PhysicalDevice* physicalDevice, Device* device, Surface* su
     createInfo.pNext = nullptr;
 
     VkSwapchainKHR swapchain;
-    VkResult result = vkCreateSwapchainKHR(*device, &createInfo, allocator, &swapchain);
+    VkResult result = vkCreateSwapchainKHR(*device, &createInfo, _device->getAllocator(), &swapchain);
     if (result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create swap chain.", result};
     }
 
     // assign data to this Swapchain object
-    _device = device;
     _surface = surface;
     _swapchain = swapchain;
-    _allocator = allocator;
 
     _format = surfaceFormat.format;
     _extent = extent;
@@ -225,7 +224,7 @@ Swapchain::Swapchain(PhysicalDevice* physicalDevice, Device* device, Surface* su
 
     for (std::size_t i = 0; i < images.size(); ++i)
     {
-        ref_ptr<ImageView> view = ImageView::create(device, new SwapchainImage(images[i], device), VK_IMAGE_VIEW_TYPE_2D, surfaceFormat.format, VK_IMAGE_ASPECT_COLOR_BIT, allocator);
+        ref_ptr<ImageView> view = ImageView::create(device, new SwapchainImage(images[i], device), VK_IMAGE_VIEW_TYPE_2D, surfaceFormat.format, VK_IMAGE_ASPECT_COLOR_BIT);
         if (view) getImageViews().push_back(view);
     }
 }
@@ -237,7 +236,7 @@ Swapchain::~Swapchain()
     if (_swapchain)
     {
         //std::cout << "Calling vkDestroySwapchainKHR(..)" << std::endl;
-        vkDestroySwapchainKHR(*_device, _swapchain, _allocator);
+        vkDestroySwapchainKHR(*_device, _swapchain, _device->getAllocator());
     }
 }
 

--- a/src/vsg/vk/Swapchain.cpp
+++ b/src/vsg/vk/Swapchain.cpp
@@ -204,7 +204,7 @@ Swapchain::Swapchain(PhysicalDevice* physicalDevice, Device* device, Surface* su
     createInfo.pNext = nullptr;
 
     VkSwapchainKHR swapchain;
-    VkResult result = vkCreateSwapchainKHR(*device, &createInfo, _device->getAllocator(), &swapchain);
+    VkResult result = vkCreateSwapchainKHR(*device, &createInfo, _device->getAllocationCallbacks(), &swapchain);
     if (result != VK_SUCCESS)
     {
         throw Exception{"Error: Failed to create swap chain.", result};
@@ -236,7 +236,7 @@ Swapchain::~Swapchain()
     if (_swapchain)
     {
         //std::cout << "Calling vkDestroySwapchainKHR(..)" << std::endl;
-        vkDestroySwapchainKHR(*_device, _swapchain, _device->getAllocator());
+        vkDestroySwapchainKHR(*_device, _swapchain, _device->getAllocationCallbacks());
     }
 }
 


### PR DESCRIPTION
Simplified public interfaces and slimmed down object footprint by removing individual vsg::AllocationCallbacks usage, centralizing it into vsg::Instance and vsg::Device.