### PR TITLE
Added vsg::View, vsg::ClearAttachments and vsg::WindowResizeHandler

### DIFF
--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -147,6 +147,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/viewer/ViewMatrix.h>
 #include <vsg/viewer/Viewer.h>
 #include <vsg/viewer/Window.h>
+#include <vsg/viewer/WindowResizeHandler.h>
 #include <vsg/viewer/WindowTraits.h>
 
 // Vulkan related header files

--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -62,6 +62,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/commands/BindIndexBuffer.h>
 #include <vsg/commands/BindVertexBuffers.h>
 #include <vsg/commands/BlitImage.h>
+#include <vsg/commands/ClearAttachments.h>
 #include <vsg/commands/Command.h>
 #include <vsg/commands/Commands.h>
 #include <vsg/commands/CopyAndReleaseBuffer.h>

--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -142,6 +142,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/viewer/RecordAndSubmitTask.h>
 #include <vsg/viewer/RenderGraph.h>
 #include <vsg/viewer/Trackball.h>
+#include <vsg/viewer/View.h>
 #include <vsg/viewer/ViewMatrix.h>
 #include <vsg/viewer/Viewer.h>
 #include <vsg/viewer/Window.h>

--- a/include/vsg/commands/ClearAttachments.h
+++ b/include/vsg/commands/ClearAttachments.h
@@ -1,0 +1,38 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2019 Thomas Hogarth
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/commands/Command.h>
+
+namespace vsg
+{
+
+    /// Encapsulation of vkCmdCopyAttachments functionality
+    class VSG_DECLSPEC ClearAttachments : public Inherit<Command, ClearAttachments>
+    {
+    public:
+
+        using Attachments = std::vector<VkClearAttachment>;
+        using Rects = std::vector<VkClearRect>;
+
+        ClearAttachments();
+        ClearAttachments(const Attachments& in_attachments, const Rects& in_rects);
+
+        Attachments attachments;
+        Rects rects;
+
+        void record(CommandBuffer& commandBuffer) const override;
+    };
+    VSG_type_name(vsg::ClearAttachments);
+
+} // namespace vsg

--- a/include/vsg/commands/ClearAttachments.h
+++ b/include/vsg/commands/ClearAttachments.h
@@ -21,7 +21,6 @@ namespace vsg
     class VSG_DECLSPEC ClearAttachments : public Inherit<Command, ClearAttachments>
     {
     public:
-
         using Attachments = std::vector<VkClearAttachment>;
         using Rects = std::vector<VkClearRect>;
 

--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -68,6 +68,7 @@ namespace vsg
     class ColorBlendState;
     class DynamicState;
     class ResourceHints;
+    class ClearAttachments;
 
     // forward declare ui events classes
     class UIEvent;
@@ -252,6 +253,7 @@ namespace vsg
         virtual void apply(const ResourceHints&);
         virtual void apply(const Draw&);
         virtual void apply(const DrawIndexed&);
+        virtual void apply(const ClearAttachments&);
 
         // ui events
         virtual void apply(const UIEvent&);

--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -91,8 +91,11 @@ namespace vsg
     class FrameEvent;
 
     // forward declare viewer classes
+    class Camera;
     class CommandGraph;
     class RenderGraph;
+    class View;
+    class Viewer;
 
     // forward declare general classes
     class FrameStamp;
@@ -271,9 +274,12 @@ namespace vsg
         virtual void apply(const TerminateEvent&);
         virtual void apply(const FrameEvent&);
 
-        // viewer class
+        // viewer
+        virtual void apply(const Camera&);
         virtual void apply(const CommandGraph&);
         virtual void apply(const RenderGraph&);
+        virtual void apply(const View&);
+        virtual void apply(const Viewer&);
 
         // general classes
         virtual void apply(const FrameStamp&);

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -91,8 +91,11 @@ namespace vsg
     class FrameEvent;
 
     // forward declare viewer classes
+    class Camera;
     class CommandGraph;
     class RenderGraph;
+    class View;
+    class Viewer;
 
     // forward declare general classes
     class FrameStamp;
@@ -271,9 +274,12 @@ namespace vsg
         virtual void apply(TerminateEvent&);
         virtual void apply(FrameEvent&);
 
-        // viewer class
+        // viewer
+        virtual void apply(Camera&);
         virtual void apply(CommandGraph&);
         virtual void apply(RenderGraph&);
+        virtual void apply(View&);
+        virtual void apply(Viewer&);
 
         // general classes
         virtual void apply(FrameStamp&);

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -68,6 +68,7 @@ namespace vsg
     class ColorBlendState;
     class DynamicState;
     class ResourceHints;
+    class ClearAttachments;
 
     // forward declare ui events classes
     class UIEvent;
@@ -252,6 +253,7 @@ namespace vsg
         virtual void apply(ResourceHints&);
         virtual void apply(Draw&);
         virtual void apply(DrawIndexed&);
+        virtual void apply(ClearAttachments&);
 
         // ui events
         virtual void apply(UIEvent&);

--- a/include/vsg/traversals/CompileTraversal.h
+++ b/include/vsg/traversals/CompileTraversal.h
@@ -79,6 +79,7 @@ namespace vsg
         void apply(Geometry& geometry) override;
         void apply(CommandGraph& commandGraph) override;
         void apply(RenderGraph& renderGraph) override;
+        void apply(View& view) override;
 
         void compile(Object* object);
 

--- a/include/vsg/viewer/Camera.h
+++ b/include/vsg/viewer/Camera.h
@@ -42,4 +42,6 @@ namespace vsg
         ref_ptr<ViewMatrix> _viewMatrix;
         ref_ptr<ViewportState> _viewportState;
     };
+    VSG_type_name(vsg::Camera);
+
 } // namespace vsg

--- a/include/vsg/viewer/CommandGraph.h
+++ b/include/vsg/viewer/CommandGraph.h
@@ -68,9 +68,9 @@ namespace vsg
     using CommandGraphs = std::vector<ref_ptr<CommandGraph>>;
 
     /// convience function that sets up RenderGraph inside primary CommandGraph to render the specified scene graph from the speified Camera view
-    extern VSG_DECLSPEC ref_ptr<CommandGraph> createCommandGraphForView(Window* window, Camera* camera, Node* scenegraph, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
+    extern VSG_DECLSPEC ref_ptr<CommandGraph> createCommandGraphForView(ref_ptr<Window> window, ref_ptr<Camera> camera, ref_ptr<Node> scenegraph, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
 
     /// convience function that sets up secondaryCommandGraph to render the specified scene graph from the speified Camera view
-    extern VSG_DECLSPEC ref_ptr<CommandGraph> createSecondaryCommandGraphForView(Window* window, Camera* camera, Node* scenegraph, uint32_t subpass);
+    extern VSG_DECLSPEC ref_ptr<CommandGraph> createSecondaryCommandGraphForView(ref_ptr<Window> window, ref_ptr<Camera> camera, ref_ptr<Node> scenegraph, uint32_t subpass);
 
 } // namespace vsg

--- a/include/vsg/viewer/RenderGraph.h
+++ b/include/vsg/viewer/RenderGraph.h
@@ -28,18 +28,24 @@ namespace vsg
 
         using Group::accept;
 
+        /// execute vkCmdBeginRenderPass and then traverse the RenderGraph subgraph
         void accept(RecordTraversal& recordTraversal) const override;
 
         /// either window or framebuffer must be assigned. If framebuffer is set then it takes precidence, if not sense the appropriate window's framebuffer is used.
         ref_ptr<Framebuffer> framebuffer;
         ref_ptr<Window> window;
 
+        /// RenderPass tp use passed to the vkCmdBeginRenderPass, either obtained from which of the framebuffer or window are active
         RenderPass* getRenderPass();
 
-        VkRect2D renderArea; // viewport dimensions
+        /// ReandingArea settings for VkRenderPassBeginInfo.renderArea passed to the vkCmdBeginRenderPass, usually maps the ViewportState's scissor
+        VkRect2D renderArea;
 
+        /// Buffer clearing stttings for vkRrenderPassInfo.clearValueCount & vkRenderPassInfo.pClearValues passed to the vkCmdBeginRenderPass
         using ClearValues = std::vector<VkClearValue>;
         ClearValues clearValues; // initialize window colour and depth/stencil
+
+        /// Subpass contents settting passed to vkCmdBeginRenderPass
         VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE;
 
         ref_ptr<WindowResizeHandler> windowResizeHandler;

--- a/include/vsg/viewer/RenderGraph.h
+++ b/include/vsg/viewer/RenderGraph.h
@@ -26,6 +26,9 @@ namespace vsg
     public:
         RenderGraph();
 
+        /// Construct RenderGraph assigning window and setting up clearValues with the appropriate settings for the Window's attachments and color.
+        RenderGraph(ref_ptr<Window> in_window);
+
         using Group::accept;
 
         /// execute vkCmdBeginRenderPass and then traverse the RenderGraph subgraph
@@ -48,15 +51,18 @@ namespace vsg
         /// Subpass contents settting passed to vkCmdBeginRenderPass
         VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE;
 
+        /// Callback used to automatically update viewports, sciessor, renderAraa and clears when the window is resized.
+        /// By default is null so no resize handling is done.
         ref_ptr<WindowResizeHandler> windowResizeHandler;
 
-        // windopw extent at previous frame
+        /// windopw extent at previous frame, used to track window resizes
         const uint32_t invalid_dimension = std::numeric_limits<uint32_t>::max();
         mutable VkExtent2D previous_extent = VkExtent2D{invalid_dimension, invalid_dimension};
     };
     VSG_type_name(vsg::RenderGraph);
 
-    /// convience function that sets up RenderGraph to render the specified scene graph from the speified Camera view
+    /// Convience function that sets up RenderGraph and associated View to render the specified scene graph from the speified camera view.
+    /// Assigns the WindowResizeHandler to povide basic widnow resize handling.
     extern VSG_DECLSPEC ref_ptr<RenderGraph> createRenderGraphForView(ref_ptr<Window> window, ref_ptr<Camera> camera, ref_ptr<Node> scenegraph, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
 
 } // namespace vsg

--- a/include/vsg/viewer/RenderGraph.h
+++ b/include/vsg/viewer/RenderGraph.h
@@ -46,6 +46,6 @@ namespace vsg
     };
 
     /// convience function that sets up RenderGraph to render the specified scene graph from the speified Camera view
-    extern VSG_DECLSPEC ref_ptr<RenderGraph> createRenderGraphForView(Window* window, Camera* camera, Node* scenegraph, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
+    extern VSG_DECLSPEC ref_ptr<RenderGraph> createRenderGraphForView(ref_ptr<Window> window, ref_ptr<Camera> camera, ref_ptr<Node> scenegraph, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
 
 } // namespace vsg

--- a/include/vsg/viewer/RenderGraph.h
+++ b/include/vsg/viewer/RenderGraph.h
@@ -16,9 +16,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/viewer/Camera.h>
 #include <vsg/viewer/Window.h>
+#include <vsg/viewer/WindowResizeHandler.h>
 
 namespace vsg
 {
+
     class VSG_DECLSPEC RenderGraph : public Inherit<Group, RenderGraph>
     {
     public:
@@ -40,10 +42,13 @@ namespace vsg
         ClearValues clearValues; // initialize window colour and depth/stencil
         VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE;
 
+        ref_ptr<WindowResizeHandler> windowResizeHandler;
+
         // windopw extent at previous frame
         const uint32_t invalid_dimension = std::numeric_limits<uint32_t>::max();
         mutable VkExtent2D previous_extent = VkExtent2D{invalid_dimension, invalid_dimension};
     };
+    VSG_type_name(vsg::RenderGraph);
 
     /// convience function that sets up RenderGraph to render the specified scene graph from the speified Camera view
     extern VSG_DECLSPEC ref_ptr<RenderGraph> createRenderGraphForView(ref_ptr<Window> window, ref_ptr<Camera> camera, ref_ptr<Node> scenegraph, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);

--- a/include/vsg/viewer/View.h
+++ b/include/vsg/viewer/View.h
@@ -19,33 +19,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    class VSG_DECLSPEC RenderGraph : public Inherit<Group, RenderGraph>
+    class VSG_DECLSPEC View : public Inherit<Group, View>
     {
     public:
-        RenderGraph();
+        View();
+
+        View(ref_ptr<Camera> in_camera, ref_ptr<Node> in_scenegraph = {});
 
         using Group::accept;
 
         void accept(RecordTraversal& recordTraversal) const override;
 
-        /// either window or framebuffer must be assigned. If framebuffer is set then it takes precidence, if not sense the appropriate window's framebuffer is used.
-        ref_ptr<Framebuffer> framebuffer;
-        ref_ptr<Window> window;
+        ref_ptr<Camera> camera;
 
-        RenderPass* getRenderPass();
-
-        VkRect2D renderArea; // viewport dimensions
-
-        using ClearValues = std::vector<VkClearValue>;
-        ClearValues clearValues; // initialize window colour and depth/stencil
-        VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE;
-
-        // windopw extent at previous frame
-        const uint32_t invalid_dimension = std::numeric_limits<uint32_t>::max();
-        mutable VkExtent2D previous_extent = VkExtent2D{invalid_dimension, invalid_dimension};
     };
-
-    /// convience function that sets up RenderGraph to render the specified scene graph from the speified Camera view
-    extern VSG_DECLSPEC ref_ptr<RenderGraph> createRenderGraphForView(Window* window, Camera* camera, Node* scenegraph, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
 
 } // namespace vsg

--- a/include/vsg/viewer/View.h
+++ b/include/vsg/viewer/View.h
@@ -31,7 +31,6 @@ namespace vsg
         void accept(RecordTraversal& recordTraversal) const override;
 
         ref_ptr<Camera> camera;
-
     };
 
 } // namespace vsg

--- a/include/vsg/viewer/WindowResizeHandler.h
+++ b/include/vsg/viewer/WindowResizeHandler.h
@@ -1,0 +1,54 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/nodes/Group.h>
+
+#include <vsg/viewer/Camera.h>
+#include <vsg/viewer/Window.h>
+
+#include <set>
+
+namespace vsg
+{
+    class VSG_DECLSPEC WindowResizeHandler : public Inherit<Visitor, WindowResizeHandler>
+    {
+    public:
+        ref_ptr<Context> context;
+        VkRect2D renderArea;
+        VkExtent2D previous_extent;
+        VkExtent2D new_extent;
+        std::set<Object*> visited;
+
+        WindowResizeHandler();
+
+        template<typename T, typename R>
+        T scale_parameter(T original, R extentOriginal, R extentNew)
+        {
+            if (original == static_cast<T>(extentOriginal)) return static_cast<T>(extentNew);
+            return static_cast<T>(static_cast<float>(original) * static_cast<float>(extentNew) / static_cast<float>(extentOriginal)+0.5f);
+        }
+
+        void scale_rect(VkRect2D& rect);
+
+        bool visit(Object* object);
+
+        void apply(BindGraphicsPipeline& bindPipeline) override;
+        void apply(Object& object) override;
+        void apply(StateGroup& sg) override;
+        void apply(ClearAttachments& clearAttachments) override;
+        void apply(View& view) override;
+    };
+    VSG_type_name(vsg::WindowResizeHandler);
+
+} // namespace vsg

--- a/include/vsg/viewer/WindowResizeHandler.h
+++ b/include/vsg/viewer/WindowResizeHandler.h
@@ -36,7 +36,7 @@ namespace vsg
         T scale_parameter(T original, R extentOriginal, R extentNew)
         {
             if (original == static_cast<T>(extentOriginal)) return static_cast<T>(extentNew);
-            return static_cast<T>(static_cast<float>(original) * static_cast<float>(extentNew) / static_cast<float>(extentOriginal)+0.5f);
+            return static_cast<T>(static_cast<float>(original) * static_cast<float>(extentNew) / static_cast<float>(extentOriginal) + 0.5f);
         }
 
         void scale_rect(VkRect2D& rect);

--- a/include/vsg/vk/Context.h
+++ b/include/vsg/vk/Context.h
@@ -46,10 +46,13 @@ namespace vsg
         // scratch buffer set after compile traversal before record of build commands
         ref_ptr<Buffer> _scratchBuffer;
     };
+    VSG_type_name(vsg::BuildAccelerationStructureCommand);
 
-    class VSG_DECLSPEC Context
+    class VSG_DECLSPEC Context : public Inherit<Object, Context>
     {
     public:
+        Context();
+
         Context(Device* in_device, BufferPreferences bufferPreferences = {});
 
         Context(const Context& context);
@@ -105,5 +108,6 @@ namespace vsg
         VkDeviceSize scratchBufferSize;
         std::vector<ref_ptr<BuildAccelerationStructureCommand>> buildAccelerationStructureCommands;
     };
+    VSG_type_name(vsg::Context);
 
 } // namespace vsg

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -117,6 +117,7 @@ set(SOURCES
     viewer/RenderGraph.cpp
     viewer/Presentation.cpp
     viewer/RecordAndSubmitTask.cpp
+    viewer/WindowResizeHandler.cpp
     viewer/View.cpp
 
     raytracing/AccelerationGeometry.cpp

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -116,6 +116,7 @@ set(SOURCES
     viewer/RenderGraph.cpp
     viewer/Presentation.cpp
     viewer/RecordAndSubmitTask.cpp
+    viewer/View.cpp
 
     raytracing/AccelerationGeometry.cpp
     raytracing/AccelerationStructure.cpp

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES
     commands/CopyImageToBuffer.cpp
     commands/CopyAndReleaseBuffer.cpp
     commands/CopyAndReleaseImage.cpp
+    commands/ClearAttachments.cpp
     commands/PipelineBarrier.cpp
     commands/Event.cpp
     commands/NextSubPass.cpp

--- a/src/vsg/commands/ClearAttachments.cpp
+++ b/src/vsg/commands/ClearAttachments.cpp
@@ -1,0 +1,35 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/commands/ClearAttachments.h>
+#include <vsg/io/Options.h>
+#include <vsg/vk/CommandBuffer.h>
+
+using namespace vsg;
+
+ClearAttachments::ClearAttachments()
+{
+}
+
+ClearAttachments::ClearAttachments(const Attachments& in_attachments, const Rects& in_rects) :
+    attachments(in_attachments),
+    rects(in_rects)
+{
+}
+
+void ClearAttachments::record(CommandBuffer& commandBuffer) const
+{
+    vkCmdClearAttachments(commandBuffer,
+                        static_cast<uint32_t>(attachments.size()), attachments.data(),
+                        static_cast<uint32_t>(rects.size()), rects.data());
+}
+

--- a/src/vsg/commands/ClearAttachments.cpp
+++ b/src/vsg/commands/ClearAttachments.cpp
@@ -29,7 +29,6 @@ ClearAttachments::ClearAttachments(const Attachments& in_attachments, const Rect
 void ClearAttachments::record(CommandBuffer& commandBuffer) const
 {
     vkCmdClearAttachments(commandBuffer,
-                        static_cast<uint32_t>(attachments.size()), attachments.data(),
-                        static_cast<uint32_t>(rects.size()), rects.data());
+                          static_cast<uint32_t>(attachments.size()), attachments.data(),
+                          static_cast<uint32_t>(rects.size()), rects.data());
 }
-

--- a/src/vsg/core/ConstVisitor.cpp
+++ b/src/vsg/core/ConstVisitor.cpp
@@ -590,6 +590,10 @@ void ConstVisitor::apply(const DrawIndexed& value)
 {
     apply(static_cast<const Command&>(value));
 }
+void ConstVisitor::apply(const ClearAttachments& value)
+{
+    apply(static_cast<const Command&>(value));
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/vsg/core/ConstVisitor.cpp
+++ b/src/vsg/core/ConstVisitor.cpp
@@ -676,6 +676,10 @@ void ConstVisitor::apply(const FrameEvent& event)
 //
 // Viewer classes
 //
+void ConstVisitor::apply(const Camera& camera)
+{
+    apply(static_cast<const Object&>(camera));
+}
 void ConstVisitor::apply(const CommandGraph& cg)
 {
     apply(static_cast<const Group&>(cg));
@@ -683,6 +687,14 @@ void ConstVisitor::apply(const CommandGraph& cg)
 void ConstVisitor::apply(const RenderGraph& rg)
 {
     apply(static_cast<const Group&>(rg));
+}
+void ConstVisitor::apply(const View& view)
+{
+    apply(static_cast<const Group&>(view));
+}
+void ConstVisitor::apply(const Viewer& viewer)
+{
+    apply(static_cast<const Object&>(viewer));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/vsg/core/Visitor.cpp
+++ b/src/vsg/core/Visitor.cpp
@@ -676,6 +676,10 @@ void Visitor::apply(FrameEvent& event)
 //
 // Viewer classes
 //
+void Visitor::apply(Camera& camera)
+{
+    apply(static_cast<Object&>(camera));
+}
 void Visitor::apply(CommandGraph& cg)
 {
     apply(static_cast<Group&>(cg));
@@ -683,6 +687,14 @@ void Visitor::apply(CommandGraph& cg)
 void Visitor::apply(RenderGraph& rg)
 {
     apply(static_cast<Group&>(rg));
+}
+void Visitor::apply(View& view)
+{
+    apply(static_cast<Group&>(view));
+}
+void Visitor::apply(Viewer& viewer)
+{
+    apply(static_cast<Object&>(viewer));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/vsg/core/Visitor.cpp
+++ b/src/vsg/core/Visitor.cpp
@@ -590,6 +590,10 @@ void Visitor::apply(DrawIndexed& value)
 {
     apply(static_cast<Command&>(value));
 }
+void Visitor::apply(ClearAttachments& value)
+{
+    apply(static_cast<Command&>(value));
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -22,6 +22,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/state/StateGroup.h>
 #include <vsg/viewer/CommandGraph.h>
 #include <vsg/viewer/RenderGraph.h>
+#include <vsg/viewer/View.h>
 #include <vsg/vk/CommandBuffer.h>
 #include <vsg/vk/RenderPass.h>
 #include <vsg/vk/State.h>
@@ -244,11 +245,7 @@ void CompileTraversal::apply(RenderGraph& renderGraph)
     auto previousDefaultPipelineStates = context.defaultPipelineStates;
     auto previousOverridePipelineStates = context.overridePipelineStates;
 
-    if (renderGraph.camera && renderGraph.camera->getViewportState())
-    {
-        context.defaultPipelineStates.emplace_back(renderGraph.camera->getViewportState());
-    }
-    else if (renderGraph.window)
+    if (renderGraph.window)
     {
         context.defaultPipelineStates.push_back(vsg::ViewportState::create(renderGraph.window->extent2D()));
     }
@@ -269,4 +266,20 @@ void CompileTraversal::apply(RenderGraph& renderGraph)
     // restore previous values
     context.defaultPipelineStates = previousDefaultPipelineStates;
     context.overridePipelineStates = previousOverridePipelineStates;
+}
+
+void CompileTraversal::apply(View& view)
+{
+    if (view.camera && view.camera->getViewportState())
+    {
+        context.defaultPipelineStates.emplace_back(view.camera->getViewportState());
+
+        view.traverse(*this);
+
+        context.defaultPipelineStates.pop_back();
+    }
+    else
+    {
+        view.traverse(*this);
+    }
 }

--- a/src/vsg/viewer/CommandGraph.cpp
+++ b/src/vsg/viewer/CommandGraph.cpp
@@ -163,7 +163,7 @@ void CommandGraph::record(CommandBuffers& recordedCommandBuffers, ref_ptr<FrameS
     recordedCommandBuffers.push_back(commandBuffer);
 }
 
-ref_ptr<CommandGraph> vsg::createCommandGraphForView(Window* window, Camera* camera, Node* scenegraph, VkSubpassContents contents)
+ref_ptr<CommandGraph> vsg::createCommandGraphForView(ref_ptr<Window> window, ref_ptr<Camera> camera, ref_ptr<Node> scenegraph, VkSubpassContents contents)
 {
     auto commandGraph = CommandGraph::create(window);
 
@@ -172,7 +172,7 @@ ref_ptr<CommandGraph> vsg::createCommandGraphForView(Window* window, Camera* cam
     return commandGraph;
 }
 
-ref_ptr<CommandGraph> vsg::createSecondaryCommandGraphForView(Window* window, Camera* camera, Node* scenegraph, uint32_t subpass)
+ref_ptr<CommandGraph> vsg::createSecondaryCommandGraphForView(ref_ptr<Window> window, ref_ptr<Camera> camera, ref_ptr<Node> scenegraph, uint32_t subpass)
 {
     auto commandGraph = CommandGraph::create(window);
 

--- a/src/vsg/viewer/RenderGraph.cpp
+++ b/src/vsg/viewer/RenderGraph.cpp
@@ -14,24 +14,51 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/state/StateGroup.h>
 #include <vsg/traversals/RecordTraversal.h>
 #include <vsg/viewer/RenderGraph.h>
+#include <vsg/viewer/View.h>
 #include <vsg/vk/Context.h>
 #include <vsg/vk/State.h>
 
+#include <iostream>
+
 using namespace vsg;
+
+#define NEW_CODE 1
 
 namespace vsg
 {
-    class UpdatePipeline : public vsg::Visitor
+    template<typename T, typename R>
+    T scale_parameter(T original, R extentOriginal, R extentNew)
+    {
+        if (original == static_cast<T>(extentOriginal)) return static_cast<T>(extentNew);
+        return static_cast<T>(static_cast<float>(original) * static_cast<float>(extentNew) / static_cast<float>(extentOriginal)+0.5f);
+    }
+
+    class WindowResizeHandler : public vsg::Visitor
     {
     public:
         Context context;
+        VkRect2D renderArea;
+        VkExtent2D previous_extent;
+        VkExtent2D new_extent;
+        std::set<Object*> visited;
 
-        UpdatePipeline(Device* device) :
+        WindowResizeHandler(Device* device) :
             context(device) {}
+
+
+        bool visit(Object* object)
+        {
+            if (visited.count(object) != 0) return false;
+            visited.insert(object);
+            return true;
+        }
 
         void apply(vsg::BindGraphicsPipeline& bindPipeline)
         {
             GraphicsPipeline* graphicsPipeline = bindPipeline.pipeline;
+
+            if (!visit(graphicsPipeline)) return;
+
             if (graphicsPipeline)
             {
                 struct ContainsViewport : public ConstVisitor
@@ -69,11 +96,62 @@ namespace vsg
 
         void apply(vsg::StateGroup& sg)
         {
+            if (!visit(&sg)) return;
+
             for (auto& command : sg.getStateCommands())
             {
                 command->accept(*this);
             }
             sg.traverse(*this);
+        }
+
+        void apply(vsg::View& view)
+        {
+            if (!visit(&view)) return;
+
+            if (!view.camera)
+            {
+                view.traverse(*this);
+                return;
+            }
+
+            view.camera->getProjectionMatrix()->changeExtent(previous_extent, new_extent);
+
+            auto viewportState = view.camera->getViewportState();
+
+            size_t num_viewports = std::min(viewportState->viewports.size(), viewportState->scissors.size());
+            for(size_t i = 0; i<num_viewports; ++i)
+            {
+                auto& viewport = viewportState->viewports[i];
+                auto& scissor = viewportState->scissors[i];
+
+                bool renderAreaMatches = (renderArea.offset.x == scissor.offset.x) && (renderArea.offset.y == scissor.offset.y) &&
+                                         (renderArea.extent.width == scissor.extent.width) && (renderArea.extent.height == scissor.extent.height);
+
+                int32_t edge_x = scissor.offset.x + static_cast<int32_t>(scissor.extent.width);
+                int32_t edge_y = scissor.offset.y + static_cast<int32_t>(scissor.extent.height);
+
+                scissor.offset.x = scale_parameter(scissor.offset.x, previous_extent.width, new_extent.width);
+                scissor.offset.y = scale_parameter(scissor.offset.y, previous_extent.height, new_extent.height);
+                scissor.extent.width = static_cast<uint32_t>(scale_parameter(edge_x, previous_extent.width, new_extent.width) - scissor.offset.x);
+                scissor.extent.height = static_cast<uint32_t>(scale_parameter(edge_y, previous_extent.height, new_extent.height) - scissor.offset.y);
+
+                viewport.x = static_cast<float>(scissor.offset.x);
+                viewport.y = static_cast<float>(scissor.offset.y);
+                viewport.width = static_cast<float>(scissor.extent.width);
+                viewport.height = static_cast<float>(scissor.extent.height);
+
+                if (renderAreaMatches)
+                {
+                    renderArea = scissor;
+                }
+            }
+
+            context.defaultPipelineStates.emplace_back(viewportState);
+
+            view.traverse(*this);
+
+            context.defaultPipelineStates.pop_back();
         }
     };
 }; // namespace vsg
@@ -108,26 +186,20 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
         {
             // crude handling of window resize...TODO, come up with a user controllable way to handle resize.
 
-            vsg::UpdatePipeline updatePipeline(window->getDevice());
+            vsg::WindowResizeHandler resizeHandler(window->getDevice());
 
-            updatePipeline.context.commandPool = recordTraversal.getState()->_commandBuffer->getCommandPool();
-            updatePipeline.context.renderPass = window->getRenderPass();
+            resizeHandler.context.commandPool = recordTraversal.getState()->_commandBuffer->getCommandPool();
+            resizeHandler.context.renderPass = window->getRenderPass();
+            resizeHandler.renderArea = renderArea;
+            resizeHandler.previous_extent = previous_extent;
+            resizeHandler.new_extent = extent;
 
-            if (camera)
-            {
-                camera->getProjectionMatrix()->changeExtent(previous_extent, extent);
+            if (window->framebufferSamples() != VK_SAMPLE_COUNT_1_BIT) resizeHandler.context.overridePipelineStates.emplace_back(vsg::MultisampleState::create(window->framebufferSamples()));
 
-                auto viewportState = camera->getViewportState();
-                viewportState->set(extent);
-                updatePipeline.context.defaultPipelineStates.emplace_back(viewportState);
+            const_cast<RenderGraph*>(this)->traverse(resizeHandler);
 
-                const_cast<RenderGraph*>(this)->renderArea.offset = VkOffset2D{0, 0}; // need to use offsets of viewport?
-                const_cast<RenderGraph*>(this)->renderArea.extent = extent;
-            }
-
-            if (window->framebufferSamples() != VK_SAMPLE_COUNT_1_BIT) updatePipeline.context.overridePipelineStates.emplace_back(vsg::MultisampleState::create(window->framebufferSamples()));
-
-            const_cast<RenderGraph*>(this)->traverse(updatePipeline);
+            previous_extent = extent;
+            const_cast<RenderGraph*>(this)->renderArea = resizeHandler.renderArea;
 
             previous_extent = window->extent2D();
         }
@@ -152,20 +224,16 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
 
     renderPassInfo.renderArea = renderArea;
 
+#if 0
+    std::cout<<"RenaderGraph() "<<this<<" renderArea.offset.x = "<<renderArea.offset.x<<", renderArea.offset.y = "<<renderArea.offset.y
+                <<", renderArea.extent.width = "<<renderArea.extent.width<<", renderArea.extent.height = "<<renderArea.extent.height<<std::endl;
+#endif
+
     renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
     renderPassInfo.pClearValues = clearValues.data();
 
     VkCommandBuffer vk_commandBuffer = *(recordTraversal.getState()->_commandBuffer);
     vkCmdBeginRenderPass(vk_commandBuffer, &renderPassInfo, contents);
-
-    if (camera)
-    {
-        dmat4 projMatrix, viewMatrix;
-        camera->getProjectionMatrix()->get(projMatrix);
-        camera->getViewMatrix()->get(viewMatrix);
-
-        recordTraversal.setProjectionAndViewMatrix(projMatrix, viewMatrix);
-    }
 
     // traverse the command buffer to place the commands into the command buffer.
     traverse(recordTraversal);
@@ -177,9 +245,9 @@ ref_ptr<RenderGraph> vsg::createRenderGraphForView(Window* window, Camera* camer
 {
     // set up the render graph for viewport & scene
     auto renderGraph = vsg::RenderGraph::create();
-    renderGraph->addChild(ref_ptr<Node>(scenegraph));
 
-    renderGraph->camera = camera;
+    renderGraph->addChild(View::create(ref_ptr<Camera>(camera), ref_ptr<Node>(scenegraph)));
+
     renderGraph->window = window;
     renderGraph->contents = contents;
 

--- a/src/vsg/viewer/RenderGraph.cpp
+++ b/src/vsg/viewer/RenderGraph.cpp
@@ -241,7 +241,7 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
     vkCmdEndRenderPass(vk_commandBuffer);
 }
 
-ref_ptr<RenderGraph> vsg::createRenderGraphForView(Window* window, Camera* camera, Node* scenegraph, VkSubpassContents contents)
+ref_ptr<RenderGraph> vsg::createRenderGraphForView(ref_ptr<Window> window, ref_ptr<Camera> camera, ref_ptr<Node> scenegraph, VkSubpassContents contents)
 {
     // set up the render graph for viewport & scene
     auto renderGraph = vsg::RenderGraph::create();
@@ -251,8 +251,15 @@ ref_ptr<RenderGraph> vsg::createRenderGraphForView(Window* window, Camera* camer
     renderGraph->window = window;
     renderGraph->contents = contents;
 
-    renderGraph->renderArea.offset = {0, 0};
-    renderGraph->renderArea.extent = window->extent2D();
+    if (camera)
+    {
+        renderGraph->renderArea = camera->getRenderArea();
+    }
+    else
+    {
+        renderGraph->renderArea.offset = {0, 0};
+        renderGraph->renderArea.extent = window->extent2D();
+    }
 
     if (window->framebufferSamples() != VK_SAMPLE_COUNT_1_BIT)
     {

--- a/src/vsg/viewer/View.cpp
+++ b/src/vsg/viewer/View.cpp
@@ -1,0 +1,48 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/io/Options.h>
+#include <vsg/traversals/RecordTraversal.h>
+#include <vsg/viewer/View.h>
+
+#include <iostream>
+
+using namespace vsg;
+
+View::View()
+{
+}
+
+View::View(ref_ptr<Camera> in_camera, ref_ptr<Node> in_scenegraph)
+{
+    camera = in_camera;
+    if (in_scenegraph) addChild(in_scenegraph);
+}
+
+void View::accept(RecordTraversal& recordTraversal) const
+{
+    if (camera)
+    {
+        dmat4 projMatrix, viewMatrix;
+        camera->getProjectionMatrix()->get(projMatrix);
+        camera->getViewMatrix()->get(viewMatrix);
+
+        // TODO push/pop project and view matrices
+        recordTraversal.setProjectionAndViewMatrix(projMatrix, viewMatrix);
+
+        traverse(recordTraversal);
+    }
+    else
+    {
+        traverse(recordTraversal);
+    }
+}

--- a/src/vsg/viewer/WindowResizeHandler.cpp
+++ b/src/vsg/viewer/WindowResizeHandler.cpp
@@ -1,0 +1,151 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/io/Options.h>
+#include <vsg/commands/ClearAttachments.h>
+#include <vsg/viewer/WindowResizeHandler.h>
+#include <vsg/viewer/View.h>
+#include <vsg/state/StateGroup.h>
+#include <vsg/vk/Context.h>
+#include <vsg/vk/State.h>
+
+#include <iostream>
+
+using namespace vsg;
+
+WindowResizeHandler::WindowResizeHandler()
+{
+}
+
+void WindowResizeHandler::scale_rect(VkRect2D& rect)
+{
+    int32_t edge_x = rect.offset.x + static_cast<int32_t>(rect.extent.width);
+    int32_t edge_y = rect.offset.y + static_cast<int32_t>(rect.extent.height);
+
+    rect.offset.x = scale_parameter(rect.offset.x, previous_extent.width, new_extent.width);
+    rect.offset.y = scale_parameter(rect.offset.y, previous_extent.height, new_extent.height);
+    rect.extent.width = static_cast<uint32_t>(scale_parameter(edge_x, previous_extent.width, new_extent.width) - rect.offset.x);
+    rect.extent.height = static_cast<uint32_t>(scale_parameter(edge_y, previous_extent.height, new_extent.height) - rect.offset.y);
+}
+
+bool WindowResizeHandler::visit(Object* object)
+{
+    if (visited.count(object) != 0) return false;
+    visited.insert(object);
+    return true;
+}
+
+void WindowResizeHandler::apply(vsg::BindGraphicsPipeline& bindPipeline)
+{
+    GraphicsPipeline* graphicsPipeline = bindPipeline.pipeline;
+
+    if (!visit(graphicsPipeline)) return;
+
+    if (graphicsPipeline)
+    {
+        struct ContainsViewport : public ConstVisitor
+        {
+            bool foundViewport = false;
+            void apply(const ViewportState&) { foundViewport = true; }
+            bool operator()(const GraphicsPipeline& gp)
+            {
+                for (auto& pipelineState : gp.pipelineStates)
+                {
+                    pipelineState->accept(*this);
+                }
+                return foundViewport;
+            }
+        } containsViewport;
+
+        bool needToRegenerateGraphicsPipeline = !containsViewport(*graphicsPipeline);
+        if (needToRegenerateGraphicsPipeline)
+        {
+            vsg::ref_ptr<vsg::GraphicsPipeline> new_pipeline = vsg::GraphicsPipeline::create(graphicsPipeline->layout, graphicsPipeline->stages, graphicsPipeline->pipelineStates);
+
+            bindPipeline.release();
+
+            bindPipeline.pipeline = new_pipeline;
+
+            bindPipeline.compile(*context);
+        }
+    }
+}
+
+void WindowResizeHandler::apply(vsg::Object& object)
+{
+    object.traverse(*this);
+}
+
+void WindowResizeHandler::apply(vsg::StateGroup& sg)
+{
+    if (!visit(&sg)) return;
+
+    for (auto& command : sg.getStateCommands())
+    {
+        command->accept(*this);
+    }
+    sg.traverse(*this);
+}
+
+void WindowResizeHandler::apply(ClearAttachments& clearAttachments)
+{
+    if (!visit(&clearAttachments)) return;
+
+    for(auto& clearRect : clearAttachments.rects)
+    {
+        auto& rect = clearRect.rect;
+        scale_rect(rect);
+    }
+}
+
+void WindowResizeHandler::apply(vsg::View& view)
+{
+    if (!visit(&view)) return;
+
+    if (!view.camera)
+    {
+        view.traverse(*this);
+        return;
+    }
+
+    view.camera->getProjectionMatrix()->changeExtent(previous_extent, new_extent);
+
+    auto viewportState = view.camera->getViewportState();
+
+    size_t num_viewports = std::min(viewportState->viewports.size(), viewportState->scissors.size());
+    for(size_t i = 0; i<num_viewports; ++i)
+    {
+        auto& viewport = viewportState->viewports[i];
+        auto& scissor = viewportState->scissors[i];
+
+        bool renderAreaMatches = (renderArea.offset.x == scissor.offset.x) && (renderArea.offset.y == scissor.offset.y) &&
+                                    (renderArea.extent.width == scissor.extent.width) && (renderArea.extent.height == scissor.extent.height);
+
+        scale_rect(scissor);
+
+        viewport.x = static_cast<float>(scissor.offset.x);
+        viewport.y = static_cast<float>(scissor.offset.y);
+        viewport.width = static_cast<float>(scissor.extent.width);
+        viewport.height = static_cast<float>(scissor.extent.height);
+
+        if (renderAreaMatches)
+        {
+            renderArea = scissor;
+        }
+    }
+
+    context->defaultPipelineStates.emplace_back(viewportState);
+
+    view.traverse(*this);
+
+    context->defaultPipelineStates.pop_back();
+}

--- a/src/vsg/viewer/WindowResizeHandler.cpp
+++ b/src/vsg/viewer/WindowResizeHandler.cpp
@@ -10,11 +10,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-#include <vsg/io/Options.h>
 #include <vsg/commands/ClearAttachments.h>
-#include <vsg/viewer/WindowResizeHandler.h>
-#include <vsg/viewer/View.h>
+#include <vsg/io/Options.h>
 #include <vsg/state/StateGroup.h>
+#include <vsg/viewer/View.h>
+#include <vsg/viewer/WindowResizeHandler.h>
 #include <vsg/vk/Context.h>
 #include <vsg/vk/State.h>
 
@@ -100,7 +100,7 @@ void WindowResizeHandler::apply(ClearAttachments& clearAttachments)
 {
     if (!visit(&clearAttachments)) return;
 
-    for(auto& clearRect : clearAttachments.rects)
+    for (auto& clearRect : clearAttachments.rects)
     {
         auto& rect = clearRect.rect;
         scale_rect(rect);
@@ -122,13 +122,13 @@ void WindowResizeHandler::apply(vsg::View& view)
     auto viewportState = view.camera->getViewportState();
 
     size_t num_viewports = std::min(viewportState->viewports.size(), viewportState->scissors.size());
-    for(size_t i = 0; i<num_viewports; ++i)
+    for (size_t i = 0; i < num_viewports; ++i)
     {
         auto& viewport = viewportState->viewports[i];
         auto& scissor = viewportState->scissors[i];
 
         bool renderAreaMatches = (renderArea.offset.x == scissor.offset.x) && (renderArea.offset.y == scissor.offset.y) &&
-                                    (renderArea.extent.width == scissor.extent.width) && (renderArea.extent.height == scissor.extent.height);
+                                 (renderArea.extent.width == scissor.extent.width) && (renderArea.extent.height == scissor.extent.height);
 
         scale_rect(scissor);
 

--- a/src/vsg/vk/Context.cpp
+++ b/src/vsg/vk/Context.cpp
@@ -82,6 +82,7 @@ Context::Context(Device* in_device, BufferPreferences bufferPreferences) :
 }
 
 Context::Context(const Context& context) :
+    Inherit(context),
     deviceID(context.deviceID),
     device(context.device),
     renderPass(context.renderPass),


### PR DESCRIPTION
Implement multiple view support refactoring RenderGraph so that defers projection/view matrix setup to a new dedicated vsg::View class that pairs a vsg::Camera with a subgraph.

Additional flexibility of which attachments to clear is provided by the new vsg::ClearAttachments command class that implements a call to vkCmdClearAttachements.

Moved the window resize functionality into a dedicated vsg::WindowResizeHandler class that can be assigned to RenderGraph to provide support for resizing rendering area/viewport/sciessor as the window size is changed.