### PR TITLE
Remove unused DeviceResources::descriptorPool

### DIFF
--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -210,7 +210,6 @@ void Viewer::compile(BufferPreferences bufferPreferences)
     struct DeviceResources
     {
         vsg::CollectDescriptorStats collectStats;
-        vsg::ref_ptr<vsg::DescriptorPool> descriptorPool;
         vsg::ref_ptr<vsg::CompileTraversal> compile;
     };
 


### PR DESCRIPTION
## Description

As descriptorPool has already been included in DeviceResources::compile, DeviceResources::descriptorPool can be removed.

Fixes #216 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test if the whole project is still able to be compiled

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
