### PR TITLE
Moved the vsg::Image::usage entirely setting to the vsg::Image rather…

### DIFF
--- a/src/vsg/state/DescriptorImage.cpp
+++ b/src/vsg/state/DescriptorImage.cpp
@@ -72,6 +72,8 @@ DescriptorImage::DescriptorImage(ref_ptr<Sampler> sampler, ref_ptr<Data> data, u
     if (sampler && data)
     {
         auto image = Image::create(data);
+        image->usage |= (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
         auto imageView = ImageView::create(image);
         imageInfoList.emplace_back(ImageInfo{sampler, imageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL});
     }
@@ -95,6 +97,8 @@ DescriptorImage::DescriptorImage(const SamplerImage& si, uint32_t in_dstBinding,
     if (si.sampler && si.data)
     {
         auto image = Image::create(si.data);
+        image->usage |= (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
         auto imageView = ImageView::create(image);
         imageInfoList.emplace_back(ImageInfo{si.sampler, imageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL});
     }
@@ -108,6 +112,8 @@ DescriptorImage::DescriptorImage(const SamplerImages& samplerImages, uint32_t in
         if (si.sampler && si.data)
         {
             auto image = Image::create(si.data);
+            image->usage |= (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
             auto imageView = ImageView::create(image);
             imageInfoList.emplace_back(ImageInfo{si.sampler, imageView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL});
         }
@@ -130,6 +136,9 @@ void DescriptorImage::read(Input& input)
         input.readObject("Image", data);
 
         auto image = Image::create(data);
+        if (imageData.sampler) image->usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
+        image->usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
         imageData.imageView = ImageView::create(image);
         imageData.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }

--- a/src/vsg/state/Image.cpp
+++ b/src/vsg/state/Image.cpp
@@ -109,8 +109,6 @@ void Image::compile(Device* device)
     info.pQueueFamilyIndices = queueFamilyIndices.data();
     info.initialLayout = initialLayout;
 
-    info.usage |= (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT); // TODO need to review this setting.
-
     vd.device = device;
 
     if (VkResult result = vkCreateImage(*vd.device, &info, vd.device->getAllocationCallbacks(), &vd.image); result != VK_SUCCESS)


### PR DESCRIPTION
Fixed Vulkan debug layer error reported on issue #219 by removing the override of vsg::Image::usage from vsg::Image::compile() into vsg::Image setup.