### PR TITLE
added a cmake option to disable msvc iterator checking in debug mode

### DIFF
--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -253,7 +253,7 @@ if(MSVC)
         target_compile_options(vsg PRIVATE "/MP")
     endif()
 
-    option(DISABLE_CHECKED_ITERATORS "Turning on this option will disable checked iterators in debug mode for visual studio. All imported projects must adhere to this requirement")
+    option(DISABLE_CHECKED_ITERATORS "Turning on this option will disable checked iterators in debug mode for visual studio. All imported projects must adhere to this requirement" OFF)
 
     if(DISABLE_CHECKED_ITERATORS)
         target_compile_definitions(vsg PUBLIC "_ITERATOR_DEBUG_LEVEL=0")

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -246,11 +246,17 @@ if(MSVC)
     endmacro()
 
     SET_OUTPUT_DIR_PROPERTY(vsg "")
-	
+
     option(ENABLE_MP_FLAG "Turning on this option will add the multi-processor flag in MSVC for VSG and it's included projects" ON)
-	
+
     if(ENABLE_MP_FLAG)
         target_compile_options(vsg PRIVATE "/MP")
+    endif()
+
+    option(DISABLE_CHECKED_ITERATORS "Turning on this option will disable checked iterators in debug mode for visual studio. All imported projects must adhere to this requirement")
+
+    if(DISABLE_CHECKED_ITERATORS)
+        target_compile_definitions(vsg PUBLIC "_ITERATOR_DEBUG_LEVEL=0")
     endif()
 
 endif()


### PR DESCRIPTION
# Pull Request Template

## Description

Added a CMake option to disable iterator checking in debug mode. This open is currently flagged as `PUBLIC` so it gets inherited by projects that import VulkanSceneGraph. This is important because if the target applications settings don't have this flag - users will get a crash.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I created a very simple CMake project to ensure the flag was getting imported:

```
cmake_minimum_required(VERSION 3.7)

project(vsg-test)

find_package(vsg REQUIRED)

add_executable (vsg-test main.cpp)
target_link_libraries (vsg-test vsg::vsg)
```

I then validated it was in the `Preprocess Definitions` in Visual Studio: ```WIN32;_WINDOWS;_ITERATOR_DEBUG_LEVEL=0;CMAKE_INTDIR="Debug";%(PreprocessorDefinitions)```

**Test Configuration**:
* Hardware: MSVC 2019

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
