### PR TITLE
Added extensionHint to vsg::Options

### DIFF
--- a/include/vsg/io/Options.h
+++ b/include/vsg/io/Options.h
@@ -53,6 +53,8 @@ namespace vsg
 
         Paths paths;
 
+        std::string extensionHint;
+
     protected:
         virtual ~Options();
     };

--- a/include/vsg/io/ReaderWriter.h
+++ b/include/vsg/io/ReaderWriter.h
@@ -64,6 +64,8 @@ namespace vsg
 
         vsg::ref_ptr<vsg::Object> read(const vsg::Path& filename, vsg::ref_ptr<const vsg::Options> options = {}) const override;
 
+        vsg::ref_ptr<vsg::Object> read(std::istream& fin, vsg::ref_ptr<const vsg::Options> options = {}) const override;
+
         bool write(const vsg::Object* object, const vsg::Path& filename, vsg::ref_ptr<const vsg::Options> options = {}) const override;
 
         /// read the command line arguments for any options apprpriate for this ReaderWriter

--- a/src/vsg/io/Options.cpp
+++ b/src/vsg/io/Options.cpp
@@ -32,7 +32,8 @@ Options::Options(const Options& options) :
     //    fileCache(options.fileCache),
     objectCache(options.objectCache),
     readerWriter(options.readerWriter),
-    operationThreads(options.operationThreads)
+    operationThreads(options.operationThreads),
+    extensionHint(options.extensionHint)
 {
 }
 

--- a/src/vsg/io/ReaderWriter.cpp
+++ b/src/vsg/io/ReaderWriter.cpp
@@ -29,6 +29,15 @@ vsg::ref_ptr<vsg::Object> CompositeReaderWriter::read(const vsg::Path& filename,
     return vsg::ref_ptr<vsg::Object>();
 }
 
+vsg::ref_ptr<vsg::Object> CompositeReaderWriter::read(std::istream& fin, ref_ptr<const Options> options) const
+{
+    for (auto& reader : readerWriters)
+    {
+        if (auto object = reader->read(fin, options); object.valid()) return object;
+    }
+    return vsg::ref_ptr<vsg::Object>();
+}
+
 bool CompositeReaderWriter::write(const vsg::Object* object, const vsg::Path& filename, ref_ptr<const Options> options) const
 {
     for (auto& writer : readerWriters)


### PR DESCRIPTION
- Added extensionHint to vsg::Options to help ReaderWriter to check if it is a supported stream
- Added stream support to vsg::CompositeReaderWriter

This is needed for the assimp importer