### PR TITLE
Added members needed to define 'iterator_category' for 'stride_iterator'

### DIFF
--- a/include/vsg/core/Data.h
+++ b/include/vsg/core/Data.h
@@ -38,6 +38,10 @@ namespace vsg
     struct stride_iterator
     {
         using value_type = T;
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using pointer = T*;
+        using reference = T&;
 
         value_type* ptr;
         uint32_t stride; // stride in bytes


### PR DESCRIPTION
## Description

Latest `vsgXchange` master with enabled `Assimp` support doesn't compile against latest `VulkanSceneGraph` master on macOS using clang version 12.0.0/XCode 12.4 

## Type of change

- [x] Fixed compiler error thrown at [ReaderWriter_assimp.cpp, line 95](https://github.com/vsg-dev/vsgXchange/blob/74dc1cd87acc01e2b5b3ef20670662fb12704d52/src/assimp/ReaderWriter_assimp.cpp#L95):
```bash
No type named 'iterator_category' in 'std::__1::iterator_traits<vsg::stride_iterator<vsg::t_vec4<float> > >'
```

## How Has This Been Tested?

Checked out and compiled `vsg`, `vsgXchange`, `vsgImGui` and `vsgExamples`; ran `vsgviewer`
<img width="1272" alt="Screenshot 2021-02-10 at 21 16 14" src="https://user-images.githubusercontent.com/6074172/107587111-7d6d1500-6c01-11eb-917c-f478ce839b7c.png">
<img width="1265" alt="Screenshot 2021-02-10 at 21 17 34" src="https://user-images.githubusercontent.com/6074172/107587129-81993280-6c01-11eb-8071-822af3e999a2.png">


**Test Configuration**:
* Toolchain: macOS 10.15, clang version 12.0.0/XCode 12.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes