### PR TITLE
Compilation fix for VS2017

### DIFF
--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -17,6 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #    include <cstdlib>
 #    include <direct.h>
 #    include <io.h>
+//	 cctype is needed for tolower()
 #    include <cctype>
 #else
 #    include <sys/stat.h>

--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -17,6 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #    include <cstdlib>
 #    include <direct.h>
 #    include <io.h>
+#    include <cctype>
 #else
 #    include <sys/stat.h>
 #    include <unistd.h>


### PR DESCRIPTION
# Description

The project did not compile under vs2017 - windows 10 as it was not finding `std::tolower()`.
I've added an `#include <cctype>` to `src\io\FileSystem.cpp`  to import the function.

Since I assume it was compiling correctly on other systems I've added the include only to 
the WIN32 conditional block.

I hadn't filed an issue yet.

## Type of change

- [x] Bug fix (non-breaking change which fixes a compilation issue)

## How Has This Been Tested?

The now code compiles on vs2017.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

