### PR TITLE
Db lockup

### DIFF
--- a/src/vsg/io/DatabasePager.cpp
+++ b/src/vsg/io/DatabasePager.cpp
@@ -406,9 +406,16 @@ void DatabasePager::start()
                             plod->semaphore = ct->context.semaphore;
                             plod->requestStatus.exchange(PagedLOD::MergeRequest);
                         }
+                        toMergeQueue->add(nodesCompiled);
                     }
-
-                    toMergeQueue->add(nodesCompiled);
+                    else
+                    {
+                        ct->context.semaphore->numDependentSubmissions().exchange(0);
+                        for (auto& plod : nodesCompiled)
+                        {
+                            databasePager.requestDiscarded(plod);
+                        }
+                    }
                 }
                 else
                 {

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -169,7 +169,7 @@ CompileTraversal::CompileTraversal(Window* window, ViewportState* viewport, Buff
     auto device = window->getDevice();
     auto queueFamily = device->getPhysicalDevice()->getQueueFamily(VK_QUEUE_GRAPHICS_BIT);
     context.renderPass = window->getOrCreateRenderPass();
-    context.commandPool = vsg::CommandPool::create(device, queueFamily);
+    context.commandPool = vsg::CommandPool::create(device, queueFamily, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     context.graphicsQueue = device->getQueue(queueFamily);
 
     if (viewport) context.defaultPipelineStates.emplace_back(viewport);

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -244,7 +244,7 @@ void Viewer::compile(BufferPreferences bufferPreferences)
         auto queueFamily = physicalDevice->getQueueFamily(VK_QUEUE_GRAPHICS_BIT); // TODO : could we just use transfer bit?
 
         deviceResource.compile = new vsg::CompileTraversal(device, bufferPreferences);
-        deviceResource.compile->context.commandPool = vsg::CommandPool::create(device, queueFamily);
+        deviceResource.compile->context.commandPool = vsg::CommandPool::create(device, queueFamily, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
         deviceResource.compile->context.graphicsQueue = device->getQueue(queueFamily);
 
         if (descriptorPoolSizes.size() > 0) deviceResource.compile->context.descriptorPool = vsg::DescriptorPool::create(device, maxSets, descriptorPoolSizes);


### PR DESCRIPTION
# Pull Request Template

## Description

(1) 
The databasePager "stopped working" after zooming and panning my scene in apparently random places. I traced the issue to this line in databasePager.cpp
                while (ct->context.semaphore->numDependentSubmissions().load() > 0)

This problem leads on from the one that Robert helped me with a few months ago where context->record() was returning early so that semaphores were not being signalled and the application locked up. This PR handles the 'false' return from context->record() better so that the databasePager is not left stranded waiting for semaphores as well.

(2)
Also caught up in this PR because I don't really know how to do PRs is a change to add back in VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT when creating the commandPool. This was changed in a commit back in December 2020. Without this my application throws Vulkan warnings. I'm not sure of the implications, so please apply it at your own discretion.


Fixes # (issue)

## Type of change
Handles false return from context->record()

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
In my own code that previously locked the DBP.

**Test Configuration**:
* Firmware version: 22240d3d79db7fb3a9b6322827441432fb306844
* OS: Linux

