### PR TITLE
Automatic mapping of RGB to RGBA

### DIFF
--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -61,6 +61,12 @@ namespace vsg
         void add(BufferInfo src, ImageInfo dest);
         void add(BufferInfo src, ImageInfo dest, uint32_t numMipMapLevels);
 
+        /// MemoryBufferPools used for allocation staging buffer used by the copy(ref_ptr<Data>, ImageInfo) method.  Users should assign a MemoryBufferPools with appropriate settings.
+        ref_ptr<MemoryBufferPools> stagingMemoryBufferPools;
+
+        /// copy data into a staging buffer and then use copy command to transfer this to the GPU image specified by ImageInfo
+        void copy(ref_ptr<Data> data, ImageInfo dest);
+
         void record(CommandBuffer& commandBuffer) const override;
 
     protected:

--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -35,8 +35,6 @@ namespace vsg
     {
     public:
         CopyAndReleaseImage() {}
-        CopyAndReleaseImage(BufferInfo src, ImageInfo dest);
-        CopyAndReleaseImage(BufferInfo src, ImageInfo dest, uint32_t numMipMapLevels);
 
         struct VSG_DECLSPEC CopyData
         {

--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -73,6 +73,8 @@ namespace vsg
     protected:
         virtual ~CopyAndReleaseImage();
 
+        void _copyDirectly(ref_ptr<Data> data, ImageInfo dest, uint32_t numMipMapLevels);
+
         mutable std::vector<CopyData> pending;
         mutable std::vector<CopyData> completed;
         mutable std::vector<CopyData> readyToClear;

--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -38,6 +38,26 @@ namespace vsg
         CopyAndReleaseImage(BufferInfo src, ImageInfo dest);
         CopyAndReleaseImage(BufferInfo src, ImageInfo dest, uint32_t numMipMapLevels);
 
+        struct CopyData
+        {
+            CopyData() {}
+            CopyData(BufferInfo src, ImageInfo dest, uint32_t numMipMapLevels = 1);
+
+            BufferInfo source;
+            ImageInfo destination;
+
+            uint32_t mipLevels = 1;
+
+            Data::Layout layout;
+            uint32_t width = 0;
+            uint32_t height = 0;
+            uint32_t depth = 0;
+            Data::MipmapOffsets mipmapOffsets;
+
+            void record(CommandBuffer& commandBuffer) const;
+        };
+
+        void add(const CopyData& cd) { pending.push_back(cd); }
         void add(BufferInfo src, ImageInfo dest);
         void add(BufferInfo src, ImageInfo dest, uint32_t numMipMapLevels);
 
@@ -46,14 +66,6 @@ namespace vsg
     protected:
         virtual ~CopyAndReleaseImage();
 
-        struct CopyData
-        {
-            BufferInfo source;
-            ImageInfo destination;
-            uint32_t mipLevels = 1;
-
-            void record(CommandBuffer& commandBuffer) const;
-        };
 
         mutable std::vector<CopyData> pending;
         mutable std::vector<CopyData> completed;

--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -34,7 +34,7 @@ namespace vsg
     class VSG_DECLSPEC CopyAndReleaseImage : public Inherit<Command, CopyAndReleaseImage>
     {
     public:
-        CopyAndReleaseImage() {}
+        CopyAndReleaseImage(ref_ptr<MemoryBufferPools> optional_stagingMemoryBufferPools = {});
 
         struct VSG_DECLSPEC CopyData
         {

--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -66,6 +66,7 @@ namespace vsg
 
         /// copy data into a staging buffer and then use copy command to transfer this to the GPU image specified by ImageInfo
         void copy(ref_ptr<Data> data, ImageInfo dest);
+        void copy(ref_ptr<Data> data, ImageInfo dest, uint32_t numMipMapLevels);
 
         void record(CommandBuffer& commandBuffer) const override;
 

--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -38,7 +38,7 @@ namespace vsg
         CopyAndReleaseImage(BufferInfo src, ImageInfo dest);
         CopyAndReleaseImage(BufferInfo src, ImageInfo dest, uint32_t numMipMapLevels);
 
-        struct CopyData
+        struct VSG_DECLSPEC CopyData
         {
             CopyData() {}
             CopyData(BufferInfo src, ImageInfo dest, uint32_t numMipMapLevels = 1);

--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -66,9 +66,9 @@ namespace vsg
     protected:
         virtual ~CopyAndReleaseImage();
 
-
         mutable std::vector<CopyData> pending;
         mutable std::vector<CopyData> completed;
+        mutable std::vector<CopyData> readyToClear;
     };
 
 } // namespace vsg

--- a/include/vsg/core/ScratchMemory.h
+++ b/include/vsg/core/ScratchMemory.h
@@ -49,7 +49,7 @@ namespace vsg
         template<typename T>
         T* allocate(size_t num = 1)
         {
-            if (num==0) return nullptr;
+            if (num == 0) return nullptr;
 
             size_t allocate_size = sizeof(T) * num;
 

--- a/include/vsg/state/DescriptorImage.h
+++ b/include/vsg/state/DescriptorImage.h
@@ -17,8 +17,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    extern VSG_DECLSPEC uint32_t computeNumMipMapLevels(const Data* data, const Sampler* sampler);
-
     /// deprecated, use ImageInfo instead
     struct SamplerImage
     {

--- a/include/vsg/state/ImageInfo.h
+++ b/include/vsg/state/ImageInfo.h
@@ -17,6 +17,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
+    extern VSG_DECLSPEC uint32_t computeNumMipMapLevels(const Data* data, const Sampler* sampler);
+
     /// Settings that map to VkDescriptorImageInfo
     class VSG_DECLSPEC ImageInfo
     {

--- a/include/vsg/vk/Context.h
+++ b/include/vsg/vk/Context.h
@@ -27,6 +27,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/ShaderCompiler.h>
 
 #include <vsg/commands/Command.h>
+#include <vsg/commands/CopyAndReleaseImage.h>
 
 namespace vsg
 {
@@ -99,6 +100,11 @@ namespace vsg
         ref_ptr<ScratchMemory> scratchMemory;
 
         std::vector<ref_ptr<Command>> commands;
+
+        ref_ptr<CopyAndReleaseImage> copyImageCmd;
+
+        void copy(ref_ptr<Data> data, ImageInfo dest);
+        void copy(ref_ptr<Data> data, ImageInfo dest, uint32_t numMipMapLevels);
 
         /// return true if there are commands that have been submitted
         bool record();

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SOURCES
     state/StateCommand.cpp
     state/StateGroup.cpp
     state/Image.cpp
+    state/ImageInfo.cpp
     state/ImageView.cpp
 
     io/FileSystem.cpp

--- a/src/vsg/commands/CopyAndReleaseImage.cpp
+++ b/src/vsg/commands/CopyAndReleaseImage.cpp
@@ -115,16 +115,6 @@ FormatTraits FormatTraits::get(VkFormat format, bool default_one)
     return traits;
 }
 
-CopyAndReleaseImage::CopyAndReleaseImage(BufferInfo src, ImageInfo dest)
-{
-    add(src, dest);
-}
-
-CopyAndReleaseImage::CopyAndReleaseImage(BufferInfo src, ImageInfo dest, uint32_t numMipMapLevels)
-{
-    add(src, dest, numMipMapLevels);
-}
-
 CopyAndReleaseImage::~CopyAndReleaseImage()
 {
     for (auto& copyData : completed) copyData.source.release();

--- a/src/vsg/commands/CopyAndReleaseImage.cpp
+++ b/src/vsg/commands/CopyAndReleaseImage.cpp
@@ -50,18 +50,22 @@ static FormatTraits computeFormatTraits(VkFormat format, bool default_one = true
     {
         traits.numBitsPerComponent = 8;
 
-        if (format <= VK_FORMAT_R8_SRGB) traits.numComponents = 1;
-        else if (format <= VK_FORMAT_R8G8_SRGB) traits.numComponents = 2;
-        else if (format <= VK_FORMAT_B8G8R8_SRGB) traits.numComponents = 3;
-        else traits.numComponents = 4;
+        if (format <= VK_FORMAT_R8_SRGB)
+            traits.numComponents = 1;
+        else if (format <= VK_FORMAT_R8G8_SRGB)
+            traits.numComponents = 2;
+        else if (format <= VK_FORMAT_B8G8R8_SRGB)
+            traits.numComponents = 3;
+        else
+            traits.numComponents = 4;
 
-        switch((format - VK_FORMAT_R8_UNORM)%7)
+        switch ((format - VK_FORMAT_R8_UNORM) % 7)
         {
-            case 0 :
-            case 2 :
-            case 4 :
-            case 6 : traits.uint8_default = default_one ? std::numeric_limits<uint8_t>::max() : 0; break;
-            default : traits.int8_default = default_one ? std::numeric_limits<int8_t>::max() : 0; break;
+        case 0:
+        case 2:
+        case 4:
+        case 6: traits.uint8_default = default_one ? std::numeric_limits<uint8_t>::max() : 0; break;
+        default: traits.int8_default = default_one ? std::numeric_limits<int8_t>::max() : 0; break;
         }
 
         traits.size = traits.numComponents;
@@ -69,48 +73,47 @@ static FormatTraits computeFormatTraits(VkFormat format, bool default_one = true
     else if (VK_FORMAT_R16_UNORM <= format && format <= VK_FORMAT_R16G16B16A16_SFLOAT)
     {
         traits.numBitsPerComponent = 16;
-        traits.numComponents = 1 + (format - VK_FORMAT_R16_UNORM)/7;
+        traits.numComponents = 1 + (format - VK_FORMAT_R16_UNORM) / 7;
         traits.size = 2 * traits.numComponents;
 
-        switch((format - VK_FORMAT_R16_UNORM)%7)
+        switch ((format - VK_FORMAT_R16_UNORM) % 7)
         {
-            case 0 :
-            case 2 :
-            case 4 :
-            case 6 : traits.uint16_default = default_one ? std::numeric_limits<uint16_t>::max() : 0; break;
-            default : traits.int16_default = default_one ? std::numeric_limits<int16_t>::max() : 0; break;
+        case 0:
+        case 2:
+        case 4:
+        case 6: traits.uint16_default = default_one ? std::numeric_limits<uint16_t>::max() : 0; break;
+        default: traits.int16_default = default_one ? std::numeric_limits<int16_t>::max() : 0; break;
         }
     }
     else if (VK_FORMAT_R32_UINT <= format && format <= VK_FORMAT_R32G32B32A32_SFLOAT)
     {
         traits.numBitsPerComponent = 32;
-        traits.numComponents = 1 + (format - VK_FORMAT_R32_UINT)/3;
+        traits.numComponents = 1 + (format - VK_FORMAT_R32_UINT) / 3;
         traits.size = 4 * traits.numComponents;
 
-        switch((format - VK_FORMAT_R32_UINT)%3)
+        switch ((format - VK_FORMAT_R32_UINT) % 3)
         {
-            case 0 : traits.uint32_default = default_one ? std::numeric_limits<uint32_t>::max() : 0; break;
-            case 1 : traits.int32_default = default_one ? std::numeric_limits<int32_t>::max() : 0; break;
-            case 2 : traits.float_default = default_one ? 1.0f : 0.0f; break;
+        case 0: traits.uint32_default = default_one ? std::numeric_limits<uint32_t>::max() : 0; break;
+        case 1: traits.int32_default = default_one ? std::numeric_limits<int32_t>::max() : 0; break;
+        case 2: traits.float_default = default_one ? 1.0f : 0.0f; break;
         }
     }
     else if (VK_FORMAT_R64_UINT <= format && format <= VK_FORMAT_R64G64B64A64_SFLOAT)
     {
         traits.numBitsPerComponent = 64;
-        traits.numComponents = 1 + (format - VK_FORMAT_R64_UINT)/3;
+        traits.numComponents = 1 + (format - VK_FORMAT_R64_UINT) / 3;
         traits.size = 8 * traits.numComponents;
 
-        switch((format - VK_FORMAT_R64_UINT)%3)
+        switch ((format - VK_FORMAT_R64_UINT) % 3)
         {
-            case 0 : traits.uint64_default = default_one ? std::numeric_limits<uint64_t>::max() : 0; break;
-            case 1 : traits.int64_default = default_one ? std::numeric_limits<int64_t>::max() : 0; break;
-            case 2 : traits.float_default = default_one ? 1.0 : 0.0; break;
+        case 0: traits.uint64_default = default_one ? std::numeric_limits<uint64_t>::max() : 0; break;
+        case 1: traits.int64_default = default_one ? std::numeric_limits<int64_t>::max() : 0; break;
+        case 2: traits.float_default = default_one ? 1.0 : 0.0; break;
         }
     }
 
     return traits;
 }
-
 
 CopyAndReleaseImage::CopyAndReleaseImage(BufferInfo src, ImageInfo dest)
 {
@@ -127,7 +130,6 @@ CopyAndReleaseImage::~CopyAndReleaseImage()
     for (auto& copyData : completed) copyData.source.release();
     for (auto& copyData : pending) copyData.source.release();
 }
-
 
 CopyAndReleaseImage::CopyData::CopyData(BufferInfo src, ImageInfo dest, uint32_t numMipMapLevels)
 {
@@ -233,44 +235,44 @@ void CopyAndReleaseImage::copy(ref_ptr<Data> data, ImageInfo dest, uint32_t numM
 
         // set up a vec4 worth of default values for the type
         uint8_t default_ptr[32];
-        switch(targetTraits.numBitsPerComponent)
+        switch (targetTraits.numBitsPerComponent)
         {
-            case(8) :
-            {
-                uint8_t* ptr = default_ptr;
-                (*ptr++) = targetTraits.uint8_default;
-                (*ptr++) = targetTraits.uint8_default;
-                (*ptr++) = targetTraits.uint8_default;
-                (*ptr++) = targetTraits.uint8_default;
-                break;
-            }
-            case(16) :
-            {
-                uint16_t* ptr = reinterpret_cast<uint16_t*>(default_ptr);
-                (*ptr++) = targetTraits.uint16_default;
-                (*ptr++) = targetTraits.uint16_default;
-                (*ptr++) = targetTraits.uint16_default;
-                (*ptr++) = targetTraits.uint16_default;
-                break;
-            }
-            case(32) :
-            {
-                uint32_t* ptr = reinterpret_cast<uint32_t*>(default_ptr);
-                (*ptr++) = targetTraits.uint32_default;
-                (*ptr++) = targetTraits.uint32_default;
-                (*ptr++) = targetTraits.uint32_default;
-                (*ptr++) = targetTraits.uint32_default;
-                break;
-            }
-            case(64) :
-            {
-                uint64_t* ptr = reinterpret_cast<uint64_t*>(default_ptr);
-                (*ptr++) = targetTraits.uint64_default;
-                (*ptr++) = targetTraits.uint64_default;
-                (*ptr++) = targetTraits.uint64_default;
-                (*ptr++) = targetTraits.uint64_default;
-                break;
-            }
+        case (8):
+        {
+            uint8_t* ptr = default_ptr;
+            (*ptr++) = targetTraits.uint8_default;
+            (*ptr++) = targetTraits.uint8_default;
+            (*ptr++) = targetTraits.uint8_default;
+            (*ptr++) = targetTraits.uint8_default;
+            break;
+        }
+        case (16):
+        {
+            uint16_t* ptr = reinterpret_cast<uint16_t*>(default_ptr);
+            (*ptr++) = targetTraits.uint16_default;
+            (*ptr++) = targetTraits.uint16_default;
+            (*ptr++) = targetTraits.uint16_default;
+            (*ptr++) = targetTraits.uint16_default;
+            break;
+        }
+        case (32):
+        {
+            uint32_t* ptr = reinterpret_cast<uint32_t*>(default_ptr);
+            (*ptr++) = targetTraits.uint32_default;
+            (*ptr++) = targetTraits.uint32_default;
+            (*ptr++) = targetTraits.uint32_default;
+            (*ptr++) = targetTraits.uint32_default;
+            break;
+        }
+        case (64):
+        {
+            uint64_t* ptr = reinterpret_cast<uint64_t*>(default_ptr);
+            (*ptr++) = targetTraits.uint64_default;
+            (*ptr++) = targetTraits.uint64_default;
+            (*ptr++) = targetTraits.uint64_default;
+            (*ptr++) = targetTraits.uint64_default;
+            break;
+        }
         }
 
         uint32_t bytesFromSource = sourceTraits.size;
@@ -285,16 +287,16 @@ void CopyAndReleaseImage::copy(ref_ptr<Data> data, ImageInfo dest, uint32_t numM
         value_type* dest_ptr = reinterpret_cast<value_type*>(buffer_data);
 
         size_t valueCount = data->valueCount();
-        for(size_t i = 0; i< valueCount; ++i)
+        for (size_t i = 0; i < valueCount; ++i)
         {
             uint32_t s = 0;
-            for(; s < bytesFromSource; ++s)
+            for (; s < bytesFromSource; ++s)
             {
                 (*dest_ptr++) = *(src_ptr++);
             }
 
             value_type* src_default = default_ptr;
-            for(; s < bytesToTarget; ++s)
+            for (; s < bytesToTarget; ++s)
             {
                 (*dest_ptr++) = *(src_default++);
             }

--- a/src/vsg/commands/CopyAndReleaseImage.cpp
+++ b/src/vsg/commands/CopyAndReleaseImage.cpp
@@ -14,6 +14,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/commands/PipelineBarrier.h>
 #include <vsg/io/Options.h>
 
+// #include <iostream>
+
 using namespace vsg;
 
 struct FormatTraits
@@ -156,6 +158,11 @@ void CopyAndReleaseImage::add(BufferInfo src, ImageInfo dest, uint32_t numMipMap
 
 void CopyAndReleaseImage::copy(ref_ptr<Data> data, ImageInfo dest)
 {
+    copy(data, dest, vsg::computeNumMipMapLevels(data, dest.sampler));
+}
+
+void CopyAndReleaseImage::copy(ref_ptr<Data> data, ImageInfo dest, uint32_t numMipMapLevels)
+{
     if (!data) return;
     if (!stagingMemoryBufferPools) return;
 
@@ -176,6 +183,8 @@ void CopyAndReleaseImage::copy(ref_ptr<Data> data, ImageInfo dest)
 
     if (formatsCompatible)
     {
+        // std::cout<<"Compatible"<<std::endl;
+
         VkDeviceSize imageTotalSize = data->dataSize();
         VkDeviceSize alignment = std::max(VkDeviceSize(4), VkDeviceSize(data->valueSize()));
 
@@ -197,6 +206,8 @@ void CopyAndReleaseImage::copy(ref_ptr<Data> data, ImageInfo dest)
     }
     else
     {
+        // std::cout<<"Adapting"<<std::endl;
+
         auto sourceTraits = computeFormatTraits(sourceFormat);
         auto targetTraits = computeFormatTraits(targetFormat);
 
@@ -213,7 +224,7 @@ void CopyAndReleaseImage::copy(ref_ptr<Data> data, ImageInfo dest)
 
         if (!imageStagingMemory) return;
 
-        vsg::CopyAndReleaseImage::CopyData cd(stagingBufferInfo, dest, 1);
+        vsg::CopyAndReleaseImage::CopyData cd(stagingBufferInfo, dest, numMipMapLevels);
         cd.width = data->width();
         cd.height = data->height();
         cd.depth = data->depth();

--- a/src/vsg/commands/CopyAndReleaseImage.cpp
+++ b/src/vsg/commands/CopyAndReleaseImage.cpp
@@ -315,8 +315,10 @@ void CopyAndReleaseImage::CopyData::record(CommandBuffer& commandBuffer) const
 
 void CopyAndReleaseImage::record(CommandBuffer& commandBuffer) const
 {
-    for (auto& copyData : completed) copyData.source.release();
-    completed.clear();
+    for (auto& copyData : readyToClear) copyData.source.release();
+    readyToClear.clear();
+
+    readyToClear.swap(completed);
 
     for (auto& copyData : pending)
     {

--- a/src/vsg/commands/CopyAndReleaseImage.cpp
+++ b/src/vsg/commands/CopyAndReleaseImage.cpp
@@ -121,10 +121,10 @@ void CopyAndReleaseImage::CopyData::record(CommandBuffer& commandBuffer) const
     preCopyBarrier.subresourceRange.baseMipLevel = 0;
 
     vkCmdPipelineBarrier(commandBuffer,
-                            VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
-                            0, nullptr,
-                            0, nullptr,
-                            1, &preCopyBarrier);
+                         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                         0, nullptr,
+                         0, nullptr,
+                         1, &preCopyBarrier);
 
     std::vector<VkBufferImageCopy> regions;
 
@@ -187,7 +187,7 @@ void CopyAndReleaseImage::CopyData::record(CommandBuffer& commandBuffer) const
     }
 
     vkCmdCopyBufferToImage(commandBuffer, imageStagingBuffer->vk(commandBuffer.deviceID), vk_textureImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                            static_cast<uint32_t>(regions.size()), regions.data());
+                           static_cast<uint32_t>(regions.size()), regions.data());
 
     if (generatMipmaps)
     {
@@ -214,10 +214,10 @@ void CopyAndReleaseImage::CopyData::record(CommandBuffer& commandBuffer) const
             barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
 
             vkCmdPipelineBarrier(commandBuffer,
-                                VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
-                                0, nullptr,
-                                0, nullptr,
-                                1, &barrier);
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                                 0, nullptr,
+                                 0, nullptr,
+                                 1, &barrier);
 
             std::vector<VkImageBlit> blits(arrayLayers);
 
@@ -239,10 +239,10 @@ void CopyAndReleaseImage::CopyData::record(CommandBuffer& commandBuffer) const
             }
 
             vkCmdBlitImage(commandBuffer,
-                        vk_textureImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                        vk_textureImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                        static_cast<uint32_t>(blits.size()), blits.data(),
-                        VK_FILTER_LINEAR);
+                           vk_textureImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                           vk_textureImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                           static_cast<uint32_t>(blits.size()), blits.data(),
+                           VK_FILTER_LINEAR);
 
             barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
             barrier.newLayout = targetImageLayout;
@@ -250,10 +250,10 @@ void CopyAndReleaseImage::CopyData::record(CommandBuffer& commandBuffer) const
             barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
             vkCmdPipelineBarrier(commandBuffer,
-                                VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
-                                0, nullptr,
-                                0, nullptr,
-                                1, &barrier);
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
+                                 0, nullptr,
+                                 0, nullptr,
+                                 1, &barrier);
 
             if (mipWidth > 1) mipWidth /= 2;
             if (mipHeight > 1) mipHeight /= 2;
@@ -290,10 +290,10 @@ void CopyAndReleaseImage::CopyData::record(CommandBuffer& commandBuffer) const
         postCopyBarrier.subresourceRange.baseMipLevel = 0;
 
         vkCmdPipelineBarrier(commandBuffer,
-                                VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
-                                0, nullptr,
-                                0, nullptr,
-                                1, &postCopyBarrier);
+                             VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
+                             0, nullptr,
+                             0, nullptr,
+                             1, &postCopyBarrier);
     }
 }
 

--- a/src/vsg/commands/CopyAndReleaseImage.cpp
+++ b/src/vsg/commands/CopyAndReleaseImage.cpp
@@ -115,6 +115,11 @@ FormatTraits FormatTraits::get(VkFormat format, bool default_one)
     return traits;
 }
 
+CopyAndReleaseImage::CopyAndReleaseImage(ref_ptr<MemoryBufferPools> optional_stagingMemoryBufferPools) :
+    stagingMemoryBufferPools(optional_stagingMemoryBufferPools)
+{
+}
+
 CopyAndReleaseImage::~CopyAndReleaseImage()
 {
     for (auto& copyData : completed) copyData.source.release();

--- a/src/vsg/state/DescriptorImage.cpp
+++ b/src/vsg/state/DescriptorImage.cpp
@@ -143,11 +143,7 @@ void DescriptorImage::compile(Context& context)
 
                 if (image && image->data)
                 {
-                    auto stagingBufferInfo = copyDataToStagingBuffer(context, image->data);
-                    if (stagingBufferInfo)
-                    {
-                        context.commands.emplace_back(CopyAndReleaseImage::create(stagingBufferInfo, imageData, image->mipLevels));
-                    }
+                    context.copy(image->data, imageData, image->mipLevels);
                 }
             }
             else

--- a/src/vsg/state/DescriptorImage.cpp
+++ b/src/vsg/state/DescriptorImage.cpp
@@ -18,45 +18,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-/////////////////////////////////////////////////////////////////////////////////////////
-//
-// vsg::computeNumMipMapLevels
-//
-uint32_t vsg::computeNumMipMapLevels(const Data* data, const Sampler* sampler)
-{
-    uint32_t mipLevels = sampler != nullptr ? static_cast<uint32_t>(ceil(sampler->maxLod)) : 1;
-    if (mipLevels == 0)
-    {
-        mipLevels = 1;
-    }
-
-    // clamp the mipLevels so that its no larger than what the data dimensions support
-    uint32_t maxDimension = std::max({data->width(), data->height(), data->depth()});
-    while ((1u << (mipLevels - 1)) > maxDimension)
-    {
-        --mipLevels;
-    }
-
-    //mipLevels = 1;  // disable mipmapping
-
-    return mipLevels;
-}
-
-void ImageInfo::computeNumMipMapLevels()
-{
-    if (imageView && imageView->image && imageView->image->data)
-    {
-        auto image = imageView->image;
-        auto mipLevels = vsg::computeNumMipMapLevels(image->data, sampler);
-        image->mipLevels = mipLevels;
-        imageView->subresourceRange.levelCount = mipLevels;
-
-        const auto& mipmapOffsets = image->data->computeMipmapOffsets();
-        bool generatMipmaps = (mipLevels > 1) && (mipmapOffsets.size() <= 1);
-        if (generatMipmaps) image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // DescriptorImage

--- a/src/vsg/state/Image.cpp
+++ b/src/vsg/state/Image.cpp
@@ -93,6 +93,11 @@ Image::Image(ref_ptr<Data> in_data) :
         format = layout.format;
         mipLevels = static_cast<uint32_t>(mipmapOffsets.size());
         extent = VkExtent3D{width, height, depth};
+
+        // remap RGB to RGBA
+        if (format>=VK_FORMAT_R8G8B8_UNORM && format<=VK_FORMAT_B8G8R8_SRGB) format = static_cast<VkFormat>(format+14);
+        else if (format >= VK_FORMAT_R16G16B16_UNORM && format <= VK_FORMAT_R16G16B16_SFLOAT) format = static_cast<VkFormat>(format + 7);
+        else if (format >= VK_FORMAT_R32G32B32_UINT && format <= VK_FORMAT_R32G32B32_SFLOAT) format = static_cast<VkFormat>(format + 3);
     }
 }
 

--- a/src/vsg/state/Image.cpp
+++ b/src/vsg/state/Image.cpp
@@ -95,9 +95,12 @@ Image::Image(ref_ptr<Data> in_data) :
         extent = VkExtent3D{width, height, depth};
 
         // remap RGB to RGBA
-        if (format>=VK_FORMAT_R8G8B8_UNORM && format<=VK_FORMAT_B8G8R8_SRGB) format = static_cast<VkFormat>(format+14);
-        else if (format >= VK_FORMAT_R16G16B16_UNORM && format <= VK_FORMAT_R16G16B16_SFLOAT) format = static_cast<VkFormat>(format + 7);
-        else if (format >= VK_FORMAT_R32G32B32_UINT && format <= VK_FORMAT_R32G32B32_SFLOAT) format = static_cast<VkFormat>(format + 3);
+        if (format >= VK_FORMAT_R8G8B8_UNORM && format <= VK_FORMAT_B8G8R8_SRGB)
+            format = static_cast<VkFormat>(format + 14);
+        else if (format >= VK_FORMAT_R16G16B16_UNORM && format <= VK_FORMAT_R16G16B16_SFLOAT)
+            format = static_cast<VkFormat>(format + 7);
+        else if (format >= VK_FORMAT_R32G32B32_UINT && format <= VK_FORMAT_R32G32B32_SFLOAT)
+            format = static_cast<VkFormat>(format + 3);
     }
 }
 

--- a/src/vsg/state/ImageInfo.cpp
+++ b/src/vsg/state/ImageInfo.cpp
@@ -13,6 +13,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/Options.h>
 #include <vsg/state/ImageInfo.h>
 
+#include <algorithm>
+
 using namespace vsg;
 
 uint32_t vsg::computeNumMipMapLevels(const Data* data, const Sampler* sampler)

--- a/src/vsg/state/ImageInfo.cpp
+++ b/src/vsg/state/ImageInfo.cpp
@@ -1,0 +1,51 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/io/Options.h>
+#include <vsg/state/ImageInfo.h>
+
+using namespace vsg;
+
+uint32_t vsg::computeNumMipMapLevels(const Data* data, const Sampler* sampler)
+{
+    uint32_t mipLevels = sampler != nullptr ? static_cast<uint32_t>(ceil(sampler->maxLod)) : 1;
+    if (mipLevels == 0)
+    {
+        mipLevels = 1;
+    }
+
+    // clamp the mipLevels so that its no larger than what the data dimensions support
+    uint32_t maxDimension = std::max({data->width(), data->height(), data->depth()});
+    while ((1u << (mipLevels - 1)) > maxDimension)
+    {
+        --mipLevels;
+    }
+
+    //mipLevels = 1;  // disable mipmapping
+
+    return mipLevels;
+}
+
+void ImageInfo::computeNumMipMapLevels()
+{
+    if (imageView && imageView->image && imageView->image->data)
+    {
+        auto image = imageView->image;
+        auto mipLevels = vsg::computeNumMipMapLevels(image->data, sampler);
+        image->mipLevels = mipLevels;
+        imageView->subresourceRange.levelCount = mipLevels;
+
+        const auto& mipmapOffsets = image->data->computeMipmapOffsets();
+        bool generatMipmaps = (mipLevels > 1) && (mipmapOffsets.size() <= 1);
+        if (generatMipmaps) image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    }
+}

--- a/src/vsg/vk/Context.cpp
+++ b/src/vsg/vk/Context.cpp
@@ -124,6 +124,30 @@ ShaderCompiler* Context::getOrCreateShaderCompiler()
     return shaderCompiler;
 }
 
+void Context::copy(ref_ptr<Data> data, ImageInfo dest)
+{
+    if (!copyImageCmd)
+    {
+        copyImageCmd = CopyAndReleaseImage::create();
+        copyImageCmd->stagingMemoryBufferPools = stagingMemoryBufferPools;
+        commands.push_back(copyImageCmd);
+    }
+
+    copyImageCmd->copy(data, dest);
+}
+
+void Context::copy(ref_ptr<Data> data, ImageInfo dest, uint32_t numMipMapLevels)
+{
+    if (!copyImageCmd)
+    {
+        copyImageCmd = CopyAndReleaseImage::create();
+        copyImageCmd->stagingMemoryBufferPools = stagingMemoryBufferPools;
+        commands.push_back(copyImageCmd);
+    }
+
+    copyImageCmd->copy(data, dest, numMipMapLevels);
+}
+
 bool Context::record()
 {
     if (commands.empty() && buildAccelerationStructureCommands.empty()) return false;
@@ -220,4 +244,5 @@ void Context::waitForCompletion()
     }
 
     commands.clear();
+    copyImageCmd = nullptr;
 }

--- a/src/vsg/vk/Context.cpp
+++ b/src/vsg/vk/Context.cpp
@@ -128,8 +128,7 @@ void Context::copy(ref_ptr<Data> data, ImageInfo dest)
 {
     if (!copyImageCmd)
     {
-        copyImageCmd = CopyAndReleaseImage::create();
-        copyImageCmd->stagingMemoryBufferPools = stagingMemoryBufferPools;
+        copyImageCmd = CopyAndReleaseImage::create(stagingMemoryBufferPools);
         commands.push_back(copyImageCmd);
     }
 
@@ -140,8 +139,7 @@ void Context::copy(ref_ptr<Data> data, ImageInfo dest, uint32_t numMipMapLevels)
 {
     if (!copyImageCmd)
     {
-        copyImageCmd = CopyAndReleaseImage::create();
-        copyImageCmd->stagingMemoryBufferPools = stagingMemoryBufferPools;
+        copyImageCmd = CopyAndReleaseImage::create(stagingMemoryBufferPools);
         commands.push_back(copyImageCmd);
     }
 


### PR DESCRIPTION
To add use of RGB vsg::Data for texturing added automatic mapping of RGB formats to RGBA in ImageView/Image with staging buffer support integrated with CopyAndReleaseImage to make it easier to pass in texture data to be copied to the GPU.