### PR TITLE
build fix for android

### DIFF
--- a/src/vsg/platform/android/Android_Window.cpp
+++ b/src/vsg/platform/android/Android_Window.cpp
@@ -320,8 +320,7 @@ Android_Window::Android_Window(vsg::ref_ptr<WindowTraits> traits) :
 {
     _keyboard = new KeyboardMap;
 
-    //ANativeWindow* nativeWindow = *std::any_cast<ANativeWindow*>(&traits->nativeHandle);
-    ANativeWindow* nativeWindow = static_cast<ANativeWindow*>(traits->nativeWindow);
+    ANativeWindow* nativeWindow = std::any_cast<ANativeWindow*>(traits->nativeWindow);
 
     if (nativeWindow == nullptr)
     {
@@ -392,7 +391,7 @@ void Android_Window::resize()
     _extent2D.width = ANativeWindow_getWidth(_window);
     _extent2D.height = ANativeWindow_getHeight(_window);
 
-    LOG("resize event = wh: %d, %d", width, height);
+    LOG("resize event = wh: %d, %d", _extent2D.width, _extent2D.height);
 
     buildSwapchain();
 }


### PR DESCRIPTION
there is also a need to remove the call to pthread_setaffinity_np(thread_native_handle, sizeof(cpu_set_t), &cpuset) in src/vsg/threading/Affinity.cpp (line 126). That function does not exist in the NDK



Android build is broken in 3 places. This fixes 2 of them. The other one remains open as per Robert's request. He'll fix it.

I'm writing an application using VSG and I tested these changes to work fine in it. Without these changes, VSG doesn't build at all

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
