### PR TITLE
Device selection

### DIFF
--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -52,88 +52,40 @@ namespace vsg
         VkClearColorValue& clearColor() { return _clearColor; }
         const VkClearColorValue& clearColor() const { return _clearColor; }
 
-        VkSurfaceFormatKHR surfaceFormat()
-        {
-            if (!_device) _initDevice();
-            return _imageFormat;
-        }
+        VkSurfaceFormatKHR surfaceFormat();
 
-        VkFormat depthFormat()
-        {
-            if (!_device) _initDevice();
-            return _depthFormat;
-        }
+        VkFormat depthFormat();
 
         VkSampleCountFlagBits framebufferSamples() const { return _framebufferSamples; }
 
-        void setInstance(ref_ptr<Instance> instance) { _instance = instance; }
+        void setInstance(ref_ptr<Instance> instance);
         Instance* getInstance() { return _instance; }
-        Instance* getOrCreateInstance()
-        {
-            if (!_instance) _initInstance();
-            return _instance;
-        }
+        Instance* getOrCreateInstance();
 
-        void setSurface(ref_ptr<Surface> surface) { _surface = surface; }
+        void setSurface(ref_ptr<Surface> surface);
         Surface* getSurface() { return _surface; }
-        Surface* getOrCreateSurface()
-        {
-            if (!_surface) _initSurface();
-            return _surface;
-        }
+        Surface* getOrCreateSurface();
 
-        void setPhysicalDevice(ref_ptr<PhysicalDevice> physicalDevice) { _physicalDevice = physicalDevice; }
+        void setPhysicalDevice(ref_ptr<PhysicalDevice> physicalDevice);
         PhysicalDevice* getPhysicalDevice() { return _physicalDevice; }
-        PhysicalDevice* getOrCreatePhysicalDevice()
-        {
-            if (!_physicalDevice) _initDevice();
-            return _physicalDevice;
-        }
+        PhysicalDevice* getOrCreatePhysicalDevice();
 
-        void setDevice(ref_ptr<Device> device)
-        {
-            _device = device;
-            if (_device)
-            {
-                _physicalDevice = _device->getPhysicalDevice();
-                _initFormats();
-            }
-        }
+        void setDevice(ref_ptr<Device> device);
         Device* getDevice() { return _device; }
-        Device* getOrCreateDevice()
-        {
-            if (!_device) _initDevice();
-            return _device;
-        }
+        Device* getOrCreateDevice();
 
-        void setRenderPass(ref_ptr<RenderPass> renderPass) { _renderPass = renderPass; }
+        void setRenderPass(ref_ptr<RenderPass> renderPass);
         RenderPass* getRenderPass() { return _renderPass; }
-        RenderPass* getOrCreateRenderPass()
-        {
-            if (!_renderPass) _initRenderPass();
-            return _renderPass;
-        }
+        RenderPass* getOrCreateRenderPass();
 
         Swapchain* getSwapchain() { return _swapchain; }
-        Swapchain* getOrCreateSwapchain()
-        {
-            if (!_swapchain) _initSwapchain();
-            return _swapchain;
-        }
+        Swapchain* getOrCreateSwapchain();
 
         Image* getDepthImage() { return _depthImage; }
-        Image* getOrCreateDepthImage()
-        {
-            if (!_depthImage) _initSwapchain();
-            return _depthImage;
-        }
+        Image* getOrCreateDepthImage();
 
         ImageView* getDepthImageView() { return _depthImageView; }
-        ImageView* getOrCreateDepthImageView()
-        {
-            if (!_depthImageView) _initSwapchain();
-            return _depthImageView;
-        }
+        ImageView* getOrCreateDepthImageView();
 
         size_t numFrames() const { return _frames.size(); }
 

--- a/include/vsg/viewer/Window.h
+++ b/include/vsg/viewer/Window.h
@@ -66,6 +66,7 @@ namespace vsg
 
         VkSampleCountFlagBits framebufferSamples() const { return _framebufferSamples; }
 
+        void setInstance(ref_ptr<Instance> instance) { _instance = instance; }
         Instance* getInstance() { return _instance; }
         Instance* getOrCreateInstance()
         {
@@ -73,6 +74,7 @@ namespace vsg
             return _instance;
         }
 
+        void setSurface(ref_ptr<Surface> surface) { _surface = surface; }
         Surface* getSurface() { return _surface; }
         Surface* getOrCreateSurface()
         {
@@ -80,13 +82,7 @@ namespace vsg
             return _surface;
         }
 
-        Device* getDevice() { return _device; }
-        Device* getOrCreateDevice()
-        {
-            if (!_device) _initDevice();
-            return _device;
-        }
-
+        void setPhysicalDevice(ref_ptr<PhysicalDevice> physicalDevice) { _physicalDevice = physicalDevice; }
         PhysicalDevice* getPhysicalDevice() { return _physicalDevice; }
         PhysicalDevice* getOrCreatePhysicalDevice()
         {
@@ -94,7 +90,23 @@ namespace vsg
             return _physicalDevice;
         }
 
-        void setRenderPass(RenderPass* renderPass) { _renderPass = renderPass; }
+        void setDevice(ref_ptr<Device> device)
+        {
+            _device = device;
+            if (_device)
+            {
+                _physicalDevice = _device->getPhysicalDevice();
+                _initFormats();
+            }
+        }
+        Device* getDevice() { return _device; }
+        Device* getOrCreateDevice()
+        {
+            if (!_device) _initDevice();
+            return _device;
+        }
+
+        void setRenderPass(ref_ptr<RenderPass> renderPass) { _renderPass = renderPass; }
         RenderPass* getRenderPass() { return _renderPass; }
         RenderPass* getOrCreateRenderPass()
         {

--- a/include/vsg/viewer/WindowTraits.h
+++ b/include/vsg/viewer/WindowTraits.h
@@ -64,6 +64,9 @@ namespace vsg
             // provide anisotropic filtering as standard.
             if (!deviceFeatures) deviceFeatures = vsg::DeviceFeatures::create();
             deviceFeatures->get().samplerAnisotropy = VK_TRUE;
+
+            // prefer discrete gpu over integrated gpu over virtual gpu
+            deviceTypePreferences = { VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU, VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU, VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU };
         }
 
         int32_t x = 0;
@@ -95,8 +98,10 @@ namespace vsg
         bool debugLayer = false;
         bool apiDumpLayer = false;
 
+        // device preferences
         vsg::Names instanceExtensionNames;
         vsg::Names deviceExtensionNames;
+        vsg::PhysicalDeviceTypes deviceTypePreferences;
         ref_ptr<DeviceFeatures> deviceFeatures;
 
         // Multisampling

--- a/include/vsg/viewer/WindowTraits.h
+++ b/include/vsg/viewer/WindowTraits.h
@@ -109,7 +109,6 @@ namespace vsg
         // be configured with the maximum requested value that is
         // supported by the device.
         VkSampleCountFlags samples = VK_SAMPLE_COUNT_1_BIT;
-        ref_ptr<Device> device;
 
         Window* shareWindow = nullptr;
 

--- a/include/vsg/vk/Instance.h
+++ b/include/vsg/vk/Instance.h
@@ -26,6 +26,7 @@ namespace vsg
     class Surface;
 
     using Names = std::vector<const char*>;
+    using PhysicalDeviceTypes = std::vector<VkPhysicalDeviceType>;
 
     extern VSG_DECLSPEC Names validateInstancelayerNames(const Names& names);
 
@@ -45,16 +46,16 @@ namespace vsg
         const PhysicalDevices& getPhysicalDevices() const { return _physicalDevices; }
 
         /// get a PhysicalDevice that supports the specified queueFlags, and presentation of specified surface if one is provided.
-        ref_ptr<PhysicalDevice> getPhysicalDevice(VkQueueFlags queueFlags) const;
+        ref_ptr<PhysicalDevice> getPhysicalDevice(VkQueueFlags queueFlags, const PhysicalDeviceTypes& deviceTypePreferences = {}) const;
 
         /// get a PhysicalDevice that supports the specified queueFlags, and presentation of specified surface if one is provided.
-        ref_ptr<PhysicalDevice> getPhysicalDevice(VkQueueFlags queueFlags, Surface* surface) const;
+        ref_ptr<PhysicalDevice> getPhysicalDevice(VkQueueFlags queueFlags, Surface* surface, const PhysicalDeviceTypes& deviceTypePreferences = {}) const;
 
         /// get a PhysicalDevice and queue family index that supports the specified queueFlags, and presentation of specified surface if one is provided.
-        std::pair<ref_ptr<PhysicalDevice>, int> getPhysicalDeviceAndQueueFamily(VkQueueFlags queueFlags) const;
+        std::pair<ref_ptr<PhysicalDevice>, int> getPhysicalDeviceAndQueueFamily(VkQueueFlags queueFlags, const PhysicalDeviceTypes& deviceTypePreferences = {}) const;
 
         /// get a PhysicalDevice and queue family index that supports the specified queueFlags, and presentation of specified surface if one is provided.
-        std::tuple<ref_ptr<PhysicalDevice>, int, int> getPhysicalDeviceAndQueueFamily(VkQueueFlags queueFlags, Surface* surface) const;
+        std::tuple<ref_ptr<PhysicalDevice>, int, int> getPhysicalDeviceAndQueueFamily(VkQueueFlags queueFlags, Surface* surface, const PhysicalDeviceTypes& deviceTypePreferences = {}) const;
 
     protected:
         virtual ~Instance();

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -61,6 +61,96 @@ void Window::share(Window& window)
     _initFormats();
 }
 
+VkSurfaceFormatKHR Window::surfaceFormat()
+{
+    if (!_device) _initDevice();
+    return _imageFormat;
+}
+
+VkFormat Window::depthFormat()
+{
+    if (!_device) _initDevice();
+    return _depthFormat;
+}
+
+void Window::setInstance(ref_ptr<Instance> instance)
+{
+    _instance = instance;
+}
+
+Instance* Window::getOrCreateInstance()
+{
+    if (!_instance) _initInstance();
+    return _instance;
+}
+
+void Window::setSurface(ref_ptr<Surface> surface)
+{
+    _surface = surface;
+}
+
+Surface* Window::getOrCreateSurface()
+{
+    if (!_surface) _initSurface();
+    return _surface;
+}
+
+void Window::setPhysicalDevice(ref_ptr<PhysicalDevice> physicalDevice)
+{
+    _physicalDevice = physicalDevice;
+}
+
+PhysicalDevice* Window::getOrCreatePhysicalDevice()
+{
+    if (!_physicalDevice) _initDevice();
+    return _physicalDevice;
+}
+
+void Window::setDevice(ref_ptr<Device> device)
+{
+    _device = device;
+    if (_device)
+    {
+        _physicalDevice = _device->getPhysicalDevice();
+        _initFormats();
+    }
+}
+
+Device* Window::getOrCreateDevice()
+{
+    if (!_device) _initDevice();
+    return _device;
+}
+
+void Window::setRenderPass(ref_ptr<RenderPass> renderPass)
+{
+    _renderPass = renderPass;
+}
+
+RenderPass* Window::getOrCreateRenderPass()
+{
+    if (!_renderPass) _initRenderPass();
+    return _renderPass;
+}
+
+Swapchain* Window::getOrCreateSwapchain()
+{
+    if (!_swapchain) _initSwapchain();
+    return _swapchain;
+}
+
+Image* Window::getOrCreateDepthImage()
+{
+    if (!_depthImage) _initSwapchain();
+    return _depthImage;
+}
+
+ImageView* Window::getOrCreateDepthImageView()
+{
+    if (!_depthImageView) _initSwapchain();
+    return _depthImageView;
+}
+
 void Window::_initInstance()
 {
     if (_traits->device)

--- a/src/vsg/viewer/Window.cpp
+++ b/src/vsg/viewer/Window.cpp
@@ -142,11 +142,10 @@ void Window::_initDevice()
 
         vsg::Names deviceExtensions;
         deviceExtensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
-
         deviceExtensions.insert(deviceExtensions.end(), _traits->deviceExtensionNames.begin(), _traits->deviceExtensionNames.end());
 
         // set up device
-        auto [physicalDevice, queueFamily, presentFamily] = _instance->getPhysicalDeviceAndQueueFamily(_traits->queueFlags, _surface);
+        auto [physicalDevice, queueFamily, presentFamily] = _instance->getPhysicalDeviceAndQueueFamily(_traits->queueFlags, _surface, _traits->deviceTypePreferences);
         if (!physicalDevice || queueFamily < 0 || presentFamily < 0) throw Exception{"Error: vsg::Window::create(...) failed to create Window, no Vulkan PhysicalDevice supported.", VK_ERROR_INVALID_EXTERNAL_HANDLE};
 
         vsg::QueueSettings queueSettings{vsg::QueueSetting{queueFamily, {1.0}}, vsg::QueueSetting{presentFamily, {1.0}}};

--- a/src/vsg/vk/Instance.cpp
+++ b/src/vsg/vk/Instance.cpp
@@ -15,7 +15,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/Instance.h>
 #include <vsg/vk/PhysicalDevice.h>
 
-#include <iostream>
 #include <set>
 
 using namespace vsg;
@@ -61,7 +60,7 @@ Instance::Instance(const Names& instanceExtensions, const Names& layers, Allocat
     // application info
     VkApplicationInfo appInfo = {};
     appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    appInfo.pApplicationName = "Test";
+    appInfo.pApplicationName = "VulkanSceneGraph application";
     appInfo.pEngineName = "VulkanSceneGraph";
     appInfo.engineVersion = VK_MAKE_VERSION(0, 0, 0);
     appInfo.apiVersion = VK_API_VERSION_1_0;
@@ -112,40 +111,60 @@ Instance::~Instance()
     }
 }
 
-ref_ptr<PhysicalDevice> Instance::getPhysicalDevice(VkQueueFlags queueFlags) const
+ref_ptr<PhysicalDevice> Instance::getPhysicalDevice(VkQueueFlags queueFlags, const PhysicalDeviceTypes& deviceTypePreferences) const
 {
-    for (auto& device : _physicalDevices)
+    for(size_t i = 0; i <= deviceTypePreferences.size(); ++i)
     {
-        if (auto family = device->getQueueFamily(queueFlags); (family >= 0)) return device;
+        for (auto& device : _physicalDevices)
+        {
+            if (i < deviceTypePreferences.size() && device->getProperties().deviceType != deviceTypePreferences[i]) continue;
+
+            if (auto family = device->getQueueFamily(queueFlags); (family >= 0)) return device;
+        }
     }
     return {};
 }
 
-ref_ptr<PhysicalDevice> Instance::getPhysicalDevice(VkQueueFlags queueFlags, Surface* surface) const
+ref_ptr<PhysicalDevice> Instance::getPhysicalDevice(VkQueueFlags queueFlags, Surface* surface, const PhysicalDeviceTypes& deviceTypePreferences) const
 {
-    for (auto& device : _physicalDevices)
+    for(size_t i = 0; i <= deviceTypePreferences.size(); ++i)
     {
-        if (auto [graphicsFamily, presentFamily] = device->getQueueFamily(queueFlags, surface); (graphicsFamily >= 0 && presentFamily >= 0)) return device;
+        for (auto& device : _physicalDevices)
+        {
+            if (i < deviceTypePreferences.size() && device->getProperties().deviceType != deviceTypePreferences[i]) continue;
+
+            if (auto [graphicsFamily, presentFamily] = device->getQueueFamily(queueFlags, surface); (graphicsFamily >= 0 && presentFamily >= 0)) return device;
+        }
     }
     return {};
 }
 
-std::pair<ref_ptr<PhysicalDevice>, int> Instance::getPhysicalDeviceAndQueueFamily(VkQueueFlags queueFlags) const
+std::pair<ref_ptr<PhysicalDevice>, int> Instance::getPhysicalDeviceAndQueueFamily(VkQueueFlags queueFlags, const PhysicalDeviceTypes& deviceTypePreferences) const
 {
-    for (auto& device : _physicalDevices)
+    for(size_t i = 0; i <= deviceTypePreferences.size(); ++i)
     {
-        if (auto family = device->getQueueFamily(queueFlags); family >= 0) return {device, family};
+        for (auto& device : _physicalDevices)
+        {
+            if (i < deviceTypePreferences.size() && device->getProperties().deviceType != deviceTypePreferences[i]) continue;
+
+            if (auto family = device->getQueueFamily(queueFlags); family >= 0) return {device, family};
+        }
     }
     return {{}, -1};
 }
 
-std::tuple<ref_ptr<PhysicalDevice>, int, int> Instance::getPhysicalDeviceAndQueueFamily(VkQueueFlags queueFlags, Surface* surface) const
+std::tuple<ref_ptr<PhysicalDevice>, int, int> Instance::getPhysicalDeviceAndQueueFamily(VkQueueFlags queueFlags, Surface* surface, const PhysicalDeviceTypes& deviceTypePreferences) const
 {
-    for (auto& device : _physicalDevices)
+    for(size_t i = 0; i <= deviceTypePreferences.size(); ++i)
     {
-        if (auto [graphicsFamily, presentFamily] = device->getQueueFamily(queueFlags, surface); (graphicsFamily >= 0 && presentFamily >= 0))
+        for (auto& device : _physicalDevices)
         {
-            return {device, graphicsFamily, presentFamily};
+            if (i < deviceTypePreferences.size() && device->getProperties().deviceType != deviceTypePreferences[i]) continue;
+
+            if (auto [graphicsFamily, presentFamily] = device->getQueueFamily(queueFlags, surface); (graphicsFamily >= 0 && presentFamily >= 0))
+            {
+                return {device, graphicsFamily, presentFamily};
+            }
         }
     }
     return {{}, -1, -1};


### PR DESCRIPTION
Introduced a new vsg::PhysicalDevice/vsg::Device selection mechanism based on a VkPhysicalDeviceType preference list, which can be used to select a preference of which GPU users want to use when creating a vsg::Window and associated PhysicalDevice/Device.  Default preference of dedicated, integrated then virtual GPU is provided by WindowTraits.
