### PR TITLE
Corrections for Multiview

### DIFF
--- a/src/vsg/viewer/RenderGraph.cpp
+++ b/src/vsg/viewer/RenderGraph.cpp
@@ -102,7 +102,8 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
 
             this_renderGraph->traverse(resizeHandler);
 
-            this_renderGraph->renderArea = resizeHandler.renderArea;
+            this_renderGraph->renderArea.extent = extent;
+
             previous_extent = extent;
         }
     }

--- a/src/vsg/viewer/WindowResizeHandler.cpp
+++ b/src/vsg/viewer/WindowResizeHandler.cpp
@@ -118,8 +118,6 @@ void WindowResizeHandler::apply(vsg::View& view)
         return;
     }
 
-    view.camera->getProjectionMatrix()->changeExtent(previous_extent, new_extent);
-
     auto viewportState = view.camera->getViewportState();
 
     size_t num_viewports = std::min(viewportState->viewports.size(), viewportState->scissors.size());
@@ -137,6 +135,8 @@ void WindowResizeHandler::apply(vsg::View& view)
         viewport.y = static_cast<float>(scissor.offset.y);
         viewport.width = static_cast<float>(scissor.extent.width);
         viewport.height = static_cast<float>(scissor.extent.height);
+
+        view.camera->getProjectionMatrix()->changeExtent(previous_extent, scissor.extent);
 
         if (renderAreaMatches)
         {


### PR DESCRIPTION
## Description

A few fixes that make the Multiview feature to work as expected in context of single vsg::RenderGraph.

**NOTE**: Unfortunately the change in "RenderGraph.cpp" screws up the multiview feature in case of **many** vsg::RenderGraph(s)