### PR TITLE
RenderGraph: force to update viewports, scissors, renderArea and clears

### DIFF
--- a/include/vsg/viewer/RenderGraph.h
+++ b/include/vsg/viewer/RenderGraph.h
@@ -51,13 +51,16 @@ namespace vsg
         /// Subpass contents stetting passed to vkCmdBeginRenderPass
         VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE;
 
-        /// Callback used to automatically update viewports, scissor, renderAraa and clears when the window is resized.
+        /// Callback used to automatically update viewports, scissors, renderArea and clears when the window is resized.
         /// By default is null so no resize handling is done.
         ref_ptr<WindowResizeHandler> windowResizeHandler;
 
         /// window extent at previous frame, used to track window resizes
         const uint32_t invalid_dimension = std::numeric_limits<uint32_t>::max();
         mutable VkExtent2D previous_extent = VkExtent2D{invalid_dimension, invalid_dimension};
+
+        // force to update viewports, scissors, renderArea and clears
+        bool forceUpdate = false;
     };
     VSG_type_name(vsg::RenderGraph);
 

--- a/src/vsg/viewer/RenderGraph.cpp
+++ b/src/vsg/viewer/RenderGraph.cpp
@@ -85,7 +85,7 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
         {
             previous_extent = extent;
         }
-        else if (previous_extent.width != extent.width || previous_extent.height != extent.height)
+        else if (previous_extent.width != extent.width || previous_extent.height != extent.height || forceUpdate)
         {
             auto this_renderGraph = const_cast<RenderGraph*>(this);
 
@@ -107,6 +107,8 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
             resizeHandler.scale_rect(this_renderGraph->renderArea);
 
             previous_extent = extent;
+
+            this_renderGraph->forceUpdate = false;
         }
     }
 


### PR DESCRIPTION
Intention of these changes is to allow an user to force to update viewports, scissors, renderArea and clears. It is needed when user changes size of view otherwise new size is not applied.

Pseudo Code (event handler):

      auto width = _window->extent2D().width;
      auto height = _window->extent2D().height;
     
      _camera1->getViewportState()->set(0, 0, width, height);
      
      // nothing changed, view internally has new size but it's presented with old one
      
      // to solve this, force rendergraph to update views
      _renderGraph->forceUpdate = true;




