### PR TITLE
Traversal mask

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)
 
 project(VSG
-    VERSION 0.1.1
+    VERSION 0.1.2
     DESCRIPTION "VulkanSceneGraph library"
     LANGUAGES CXX
 )

--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -54,6 +54,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/nodes/Geometry.h>
 #include <vsg/nodes/Group.h>
 #include <vsg/nodes/LOD.h>
+#include <vsg/nodes/MaskGroup.h>
 #include <vsg/nodes/MatrixTransform.h>
 #include <vsg/nodes/Node.h>
 #include <vsg/nodes/PagedLOD.h>

--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -39,6 +39,7 @@ namespace vsg
     class DepthSorted;
     class Bin;
     class Switch;
+    class MaskGroup;
 
     // forward declare vulkan classes
     class Command;
@@ -234,6 +235,7 @@ namespace vsg
         virtual void apply(const DepthSorted&);
         virtual void apply(const Bin&);
         virtual void apply(const Switch&);
+        virtual void apply(const MaskGroup&);
 
         // Vulkan nodes
         virtual void apply(const Command&);

--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -116,6 +116,7 @@ namespace vsg
         ConstVisitor();
 
         uint32_t traversalMask = 0xffffffff;
+        uint32_t overrideMask = 0x0;
 
         virtual void apply(const Object&);
         virtual void apply(const Objects&);

--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -114,6 +114,8 @@ namespace vsg
     public:
         ConstVisitor();
 
+        uint32_t traversalMask = 0xffffffff;
+
         virtual void apply(const Object&);
         virtual void apply(const Objects&);
         virtual void apply(const External&);

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -39,6 +39,7 @@ namespace vsg
     class DepthSorted;
     class Bin;
     class Switch;
+    class MaskGroup;
 
     // forward declare vulkan classes
     class Command;
@@ -234,6 +235,7 @@ namespace vsg
         virtual void apply(DepthSorted&);
         virtual void apply(Bin&);
         virtual void apply(Switch&);
+        virtual void apply(MaskGroup&);
 
         // Vulkan nodes
         virtual void apply(Command&);

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -116,6 +116,7 @@ namespace vsg
         Visitor();
 
         uint32_t traversalMask = 0xffffffff;
+        uint32_t overrideMask = 0x0;
 
         virtual void apply(Object&);
         virtual void apply(Objects&);

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -114,6 +114,8 @@ namespace vsg
     public:
         Visitor();
 
+        uint32_t traversalMask = 0xffffffff;
+
         virtual void apply(Object&);
         virtual void apply(Objects&);
         virtual void apply(External&);

--- a/include/vsg/nodes/MaskGroup.h
+++ b/include/vsg/nodes/MaskGroup.h
@@ -1,0 +1,63 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/core/ref_ptr.h>
+
+#include <vsg/nodes/Node.h>
+
+#include <vector>
+
+namespace vsg
+{
+    /// MaskGroup node for toggling on/off recording of children used a logical and operation between visitor.traversalMask and child.mask
+    class VSG_DECLSPEC MaskGroup : public Inherit<Node, MaskGroup>
+    {
+    public:
+        MaskGroup(Allocator* allocator = nullptr);
+
+        struct Child
+        {
+            uint32_t mask = 0xffffff;
+            ref_ptr<Node> node;
+        };
+
+        using Children = std::vector<Child>;
+
+        template<class N, class V>
+        static void t_traverse(N& node, V& visitor)
+        {
+            for (auto& child : node.children)
+            {
+                if ((visitor.traversalMask & child.mask) != 0) child.node->accept(visitor);
+            }
+        }
+
+        void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
+        void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+
+        void read(Input& input) override;
+        void write(Output& output) const override;
+
+        Children children;
+
+        /// add a child to the back of the children list.
+        void addChild(uint32_t mask, ref_ptr<Node> child);
+
+    protected:
+        virtual ~MaskGroup();
+    };
+    VSG_type_name(vsg::MaskGroup);
+
+} // namespace vsg

--- a/include/vsg/nodes/MaskGroup.h
+++ b/include/vsg/nodes/MaskGroup.h
@@ -39,7 +39,7 @@ namespace vsg
         {
             for (auto& child : node.children)
             {
-                if ((visitor.traversalMask & child.mask) != 0) child.node->accept(visitor);
+                if ((visitor.traversalMask & (visitor.overrideMask | child.mask)) != 0) child.node->accept(visitor);
             }
         }
 

--- a/include/vsg/state/ColorBlendState.h
+++ b/include/vsg/state/ColorBlendState.h
@@ -22,6 +22,7 @@ namespace vsg
         using ColorBlendAttachments = std::vector<VkPipelineColorBlendAttachmentState>;
 
         ColorBlendState();
+        ColorBlendState(const ColorBlendState& cbs);
         ColorBlendState(const ColorBlendAttachments& colorBlendAttachments);
 
         /// VkPipelineColorBlendStateCreateInfo settings

--- a/include/vsg/traversals/CompileTraversal.h
+++ b/include/vsg/traversals/CompileTraversal.h
@@ -37,6 +37,7 @@ namespace vsg
 
         struct BinDetails
         {
+            uint32_t viewTraversalIndex = 0;
             std::set<int32_t> indices;
             std::set<const Bin*> bins;
         };

--- a/include/vsg/traversals/RecordTraversal.h
+++ b/include/vsg/traversals/RecordTraversal.h
@@ -57,6 +57,8 @@ namespace vsg
         std::size_t sizeofObject() const noexcept override { return sizeof(RecordTraversal); }
         const char* className() const noexcept override { return type_name<RecordTraversal>(); }
 
+        uint32_t traversalMask = 0xffffffff;
+
         State* getState() { return _state; }
 
         void setFrameStamp(FrameStamp* fs);

--- a/include/vsg/traversals/RecordTraversal.h
+++ b/include/vsg/traversals/RecordTraversal.h
@@ -58,6 +58,7 @@ namespace vsg
         const char* className() const noexcept override { return type_name<RecordTraversal>(); }
 
         uint32_t traversalMask = 0xffffffff;
+        uint32_t overrideMask = 0x0;
 
         State* getState() { return _state; }
 

--- a/include/vsg/viewer/View.h
+++ b/include/vsg/viewer/View.h
@@ -30,7 +30,7 @@ namespace vsg
         template<class N, class V>
         static void t_accept(N& node, V& visitor)
         {
-            if ((visitor.traversalMask & node.mask) == 0) return;
+            if ((visitor.traversalMask & (visitor.overrideMask | node.mask)) == 0) return;
 
             uint32_t cached_traversalMask = visitor.traversalMask;
 

--- a/include/vsg/viewer/View.h
+++ b/include/vsg/viewer/View.h
@@ -27,11 +27,34 @@ namespace vsg
 
         View(ref_ptr<Camera> in_camera, ref_ptr<Node> in_scenegraph = {});
 
+        template<class N, class V>
+        static void t_accept(N& node, V& visitor)
+        {
+            if ((visitor.traversalMask & node.mask) == 0) return;
+
+            uint32_t cached_traversalMask = visitor.traversalMask;
+
+            visitor.traversalMask = visitor.traversalMask & node.mask;
+
+            visitor.apply(node);
+
+            visitor.traversalMask = cached_traversalMask;
+        }
+
+        void accept(Visitor& visitor) override { t_accept(*this, visitor); }
+        void accept(ConstVisitor& visitor) const override { t_accept(*this, visitor); }
+        void accept(RecordTraversal& visitor) const override { t_accept(*this, visitor); }
+
         /// camera controls the viewport state and projection and view matrices
         ref_ptr<Camera> camera;
 
         /// viewID is automatically assigned by Viewer::compile()
         uint32_t viewID = 0;
+
+        /// mask that controls traversal of the View's subgraph
+        /// View is visted if the (visitor.traversalMask & view.mask) != 0,
+        /// and when it is visited the visitor.traversalMask is &'ed with the mask to give the traversalMask to use in the subgraph.
+        uint32_t mask = 0xffffff;
 
         /// bins
         std::vector<ref_ptr<Bin>> bins;

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     nodes/DepthSorted.cpp
     nodes/Bin.cpp
     nodes/Switch.cpp
+    nodes/MaskGroup.cpp
 
     commands/BindIndexBuffer.cpp
     commands/BindVertexBuffers.cpp

--- a/src/vsg/core/ConstVisitor.cpp
+++ b/src/vsg/core/ConstVisitor.cpp
@@ -477,6 +477,10 @@ void ConstVisitor::apply(const Switch& value)
 {
     apply(static_cast<const Node&>(value));
 }
+void ConstVisitor::apply(const MaskGroup& value)
+{
+    apply(static_cast<const Node&>(value));
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/vsg/core/Visitor.cpp
+++ b/src/vsg/core/Visitor.cpp
@@ -477,6 +477,10 @@ void Visitor::apply(Switch& value)
 {
     apply(static_cast<Node&>(value));
 }
+void Visitor::apply(MaskGroup& value)
+{
+    apply(static_cast<Node&>(value));
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/vsg/io/ObjectFactory.cpp
+++ b/src/vsg/io/ObjectFactory.cpp
@@ -171,6 +171,7 @@ ObjectFactory::ObjectFactory()
     VSG_REGISTER_create(vsg::Bin);
     VSG_REGISTER_create(vsg::DepthSorted);
     VSG_REGISTER_create(vsg::Switch);
+    VSG_REGISTER_create(vsg::MaskGroup);
 
     // vulkan objects
     VSG_REGISTER_create(vsg::BindGraphicsPipeline);

--- a/src/vsg/nodes/MaskGroup.cpp
+++ b/src/vsg/nodes/MaskGroup.cpp
@@ -1,0 +1,57 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/nodes/MaskGroup.h>
+
+#include <vsg/io/Input.h>
+#include <vsg/io/Options.h>
+#include <vsg/io/Output.h>
+
+using namespace vsg;
+
+MaskGroup::MaskGroup(Allocator* allocator) :
+    Inherit(allocator)
+{
+}
+
+MaskGroup::~MaskGroup()
+{
+}
+
+void MaskGroup::read(Input& input)
+{
+    Node::read(input);
+
+    children.resize(input.readValue<uint32_t>("NumChildren"));
+    for (auto& child : children)
+    {
+        input.read("mask", child.mask);
+        input.readObject("node", child.node);
+    }
+}
+
+void MaskGroup::write(Output& output) const
+{
+    Node::write(output);
+
+    output.writeValue<uint32_t>("NumChildren", children.size());
+    for (auto& child : children)
+    {
+        output.write("mask", child.mask);
+        output.writeObject("node", child.node);
+    }
+}
+
+void MaskGroup::addChild(uint32_t mask, ref_ptr<Node> child)
+{
+    children.push_back(Child{mask, child});
+}

--- a/src/vsg/state/ColorBlendState.cpp
+++ b/src/vsg/state/ColorBlendState.cpp
@@ -31,6 +31,15 @@ ColorBlendState::ColorBlendState()
     attachments.push_back(colorBlendAttachment);
 }
 
+ColorBlendState::ColorBlendState(const ColorBlendState& cbs) :
+    Inherit(cbs),
+    logicOpEnable(cbs.logicOpEnable),
+    logicOp(cbs.logicOp),
+    attachments(cbs.attachments),
+    blendConstants{cbs.blendConstants[0], cbs.blendConstants[1], cbs.blendConstants[2], cbs.blendConstants[3]}
+{
+}
+
 ColorBlendState::ColorBlendState(const ColorBlendAttachments& colorBlendAttachments) :
     attachments(colorBlendAttachments)
 {

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -150,7 +150,7 @@ void CollectDescriptorStats::apply(const View& view)
     }
     else
     {
-        binStack.push(BinDetails{views.size()});
+        binStack.push(BinDetails{static_cast<uint32_t>(views.size())});
     }
 
     view.traverse(*this);

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -150,7 +150,7 @@ void CollectDescriptorStats::apply(const View& view)
     }
     else
     {
-        binStack.push(BinDetails{static_cast<uint32_t>(views.size())});
+        binStack.push(BinDetails{static_cast<uint32_t>(views.size()),{},{}});
     }
 
     view.traverse(*this);

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -144,7 +144,14 @@ void CollectDescriptorStats::apply(const Descriptor& descriptor)
 
 void CollectDescriptorStats::apply(const View& view)
 {
-    binStack.push(BinDetails{});
+    if (auto itr = views.find(&view); itr != views.end())
+    {
+        binStack.push(itr->second);
+    }
+    else
+    {
+        binStack.push(BinDetails{views.size()});
+    }
 
     view.traverse(*this);
 

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -246,8 +246,10 @@ void Viewer::compile(BufferPreferences bufferPreferences)
         auto queueFamily = physicalDevice->getQueueFamily(VK_QUEUE_GRAPHICS_BIT); // TODO : could we just use transfer bit?
 
         deviceResource.compile = new vsg::CompileTraversal(device, bufferPreferences);
+        deviceResource.compile->overrideMask = 0xffffffff;
         deviceResource.compile->context.commandPool = vsg::CommandPool::create(device, queueFamily, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
         deviceResource.compile->context.graphicsQueue = device->getQueue(queueFamily);
+
 
         if (descriptorPoolSizes.size() > 0) deviceResource.compile->context.descriptorPool = vsg::DescriptorPool::create(device, maxSets, descriptorPoolSizes);
     }

--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -255,11 +255,10 @@ void Viewer::compile(BufferPreferences bufferPreferences)
     }
 
     // assign the viewID's to each View
-    uint32_t viewID = 0;
     for (auto& [const_view, binDetails] : views)
     {
         auto view = const_cast<View*>(const_view);
-        view->viewID = viewID++;
+        view->viewID = binDetails.viewTraversalIndex;
 
         for (auto& binNumber : binDetails.indices)
         {


### PR DESCRIPTION
Added vsg::RecordTraversal::traversalMask, vsg::VIew::mask and vsg::MaskGroup nodes to enable control of traversals using traverasl/node masks.