### PR TITLE
Fixes for cmake install locations on x86_64 linux hosts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,16 @@ SET(CMAKE_RELEASE_POSTFIX "" CACHE STRING "add a postfix, usually empty on windo
 SET(CMAKE_RELWITHDEBINFO_POSTFIX "rd" CACHE STRING "add a postfix, usually empty on windows")
 SET(CMAKE_MINSIZEREL_POSTFIX "s" CACHE STRING "add a postfix, usually empty on windows")
 
+include(GNUInstallDirs)
+
+set(INSTALL_TARGETS_DEFAULT_FLAGS
+    EXPORT vsgTargets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
 if(WIN32)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_BINDIR})
     # set up local bin directory to place all binaries

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -229,7 +229,7 @@ if (glslang_FOUND)
 
     install(
         FILES vsg_glslangConfig.cmake
-        DESTINATION lib/cmake/vsg_glslang
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vsg_glslang
     )
 endif()
 
@@ -328,12 +328,7 @@ target_include_directories(vsg PUBLIC $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/includ
 target_link_libraries(vsg ${LIBRARIES})
 
 
-install(TARGETS vsg EXPORT vsgTargets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
-)
+install(TARGETS vsg ${INSTALL_TARGETS_DEFAULT_FLAGS})
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(vsg INTERFACE VSG_SHARED_LIBRARY)
@@ -354,12 +349,12 @@ configure_file("${CMAKE_SOURCE_DIR}/src/vsg/vsgConfig.cmake.in" "${CMAKE_BINARY_
 install(EXPORT vsgTargets
     FILE vsgTargets.cmake
     NAMESPACE vsg::
-    DESTINATION lib/cmake/vsg
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vsg
 )
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${CMAKE_BINARY_DIR}/src/vsg/vsgConfigVersion.cmake" COMPATIBILITY SameMajorVersion)
 
-install(FILES "${CMAKE_BINARY_DIR}/src/vsg/vsgConfig.cmake" "${CMAKE_BINARY_DIR}/src/vsg/vsgConfigVersion.cmake" DESTINATION lib/cmake/vsg)
+install(FILES "${CMAKE_BINARY_DIR}/src/vsg/vsgConfig.cmake" "${CMAKE_BINARY_DIR}/src/vsg/vsgConfigVersion.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vsg)
 
 # ]==]


### PR DESCRIPTION
## Description
The commit of these pull requests corrects the default installation locations on 64-bit Linux systems.
Fixes #301 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The binaries for the VulkanSceneGraph source code were created on the named host according to the build information from https://github.com/vsg-dev/VulkanSceneGraph#command-line-build-instructions and the list of installed files was checked: the expected locations are used
```
/usr/local/lib64/cmake/vsg_glslang/vsg_glslangConfig.cmake
...
/usr/local/lib64/libvsg.so.0.1.5
```

- [x] inspected installed file list

**Test Configuration**:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
