### PR TITLE
Add macro vsg_add_cmake_support_files()

### DIFF
--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -343,18 +343,6 @@ if (glslang_FOUND)
     set(FIND_DEPENDENCY_GLSLANG "find_dependency(vsg_glslang)")
 endif()
 
-configure_file("${CMAKE_SOURCE_DIR}/src/vsg/vsgConfig.cmake.in" "${CMAKE_BINARY_DIR}/src/vsg/vsgConfig.cmake" @ONLY)
-
-# [==[
-install(EXPORT vsgTargets
-    FILE vsgTargets.cmake
-    NAMESPACE vsg::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vsg
+vsg_add_cmake_support_files(
+    CONFIG_TEMPLATE vsgConfig.cmake.in
 )
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file("${CMAKE_BINARY_DIR}/src/vsg/vsgConfigVersion.cmake" COMPATIBILITY SameMajorVersion)
-
-install(FILES "${CMAKE_BINARY_DIR}/src/vsg/vsgConfig.cmake" "${CMAKE_BINARY_DIR}/src/vsg/vsgConfigVersion.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vsg)
-
-# ]==]

--- a/vsgMacros.cmake
+++ b/vsgMacros.cmake
@@ -79,6 +79,65 @@ macro(vsg_setup_dir_vars)
 endmacro()
 
 #
+# create and install cmake support files
+#
+# available arguments:
+#
+#    CONFIG_TEMPLATE <file>   cmake template file for generating <prefix>Config.cmake file
+#    [PREFIX <prefix>]        prefix for generating file names (optional)
+#                             If not specified, ${PROJECT_NAME} is used
+#    [VERSION <version>]      version used for <prefix>ConfigVersion.cmake (optional)
+#                             If not specified, ${PROJECT_VERSION} is used
+#
+# The files maintained by this macro are
+#
+#    <prefix>Config.cmake
+#    <prefix>ConfigVersion.cmake
+#    <prefix>Targets*.cmake
+#
+macro(vsg_add_cmake_support_files)
+    set(options)
+    set(oneValueArgs CONFIG_TEMPLATE PREFIX)
+    set(multiValueArgs)
+    cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT ARGS_PREFIX)
+        set(ARGS_PREFIX ${PROJECT_NAME})
+    endif()
+    if(NOT ARGS_VERSION)
+        set(ARGS_VERSION ${PROJECT_VERSION})
+    endif()
+    set(CONFIG_FILE ${CMAKE_BINARY_DIR}/${ARGS_PREFIX}Config.cmake)
+    set(CONFIG_VERSION_FILE ${CMAKE_BINARY_DIR}/${ARGS_PREFIX}ConfigVersion.cmake)
+
+    if(NOT ARGS_CONFIG_TEMPLATE)
+        message(FATAL_ERROR "no template for generating <prefix>Config.cmake provided - use argument CONFIG_TEMPLATE <file>")
+    endif()
+    configure_file(${ARGS_CONFIG_TEMPLATE} ${CONFIG_FILE} @ONLY)
+
+    install(EXPORT ${ARGS_PREFIX}Targets
+        FILE ${ARGS_PREFIX}Targets.cmake
+        NAMESPACE ${ARGS_PREFIX}::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${ARGS_PREFIX}
+    )
+
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+        ${CONFIG_VERSION_FILE}
+        COMPATIBILITY SameMajorVersion
+        VERSION ${ARGS_VERSION}
+    )
+
+    install(
+        FILES
+            ${CONFIG_FILE}
+            ${CONFIG_VERSION_FILE}
+        DESTINATION
+            ${CMAKE_INSTALL_LIBDIR}/cmake/${ARGS_PREFIX}
+    )
+endmacro()
+
+#
 # add feature summary
 #
 macro(vsg_add_feature_summary)


### PR DESCRIPTION
## Description
This pr adds a new cmake macro for the central generation of cmake support files. This patch was inspired by https://github.com/vsg-dev/vsgXchange/issues/45.

## Type of change
- [x] Partial revision of the cmake build system to reduce maintenance effort

## How Has This Been Tested?
- [x] Compiled and installed VulkanSceneGraph with the patches from this pr applied
- [x]  Compiled and installed vsgXchange with a patch applied to use this new macro

**Test Configuration**:
* OS: OpenSUSE Linux openSUSE 15.2

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works