### PR TITLE
Removed deprecated read

### DIFF
--- a/include/vsg/io/spirv.h
+++ b/include/vsg/io/spirv.h
@@ -45,5 +45,4 @@ namespace vsg
     };
     VSG_type_name(vsg::spirv);
 
-} // namespace vsgXchange
-
+} // namespace vsg

--- a/include/vsg/io/spirv.h
+++ b/include/vsg/io/spirv.h
@@ -1,0 +1,49 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2021 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/io/ReaderWriter.h>
+
+#include <map>
+
+namespace vsg
+{
+
+    class VSG_DECLSPEC spirv : public Inherit<ReaderWriter, spirv>
+    {
+    public:
+        spirv();
+
+        ref_ptr<Object> read(const Path& filename, ref_ptr<const Options> options = {}) const override;
+
+        bool write(const Object* object, const Path& filename, ref_ptr<const Options> options = {}) const override;
+
+        bool getFeatures(Features& features) const override;
+
+    protected:
+    };
+    VSG_type_name(vsg::spirv);
+
+} // namespace vsgXchange
+

--- a/include/vsg/state/ShaderModule.h
+++ b/include/vsg/state/ShaderModule.h
@@ -22,28 +22,6 @@ namespace vsg
     // forward declare
     class Context;
 
-    template<typename T>
-    bool readFile(T& buffer, const std::string& filename)
-    {
-        std::ifstream fin(filename, std::ios::ate | std::ios::binary);
-        if (!fin.is_open()) return false;
-
-        size_t fileSize = fin.tellg();
-
-        using value_type = typename T::value_type;
-        size_t valueSize = sizeof(value_type);
-        size_t bufferSize = (fileSize + valueSize - 1) / valueSize;
-        buffer.resize(bufferSize);
-
-        fin.seekg(0);
-        fin.read(reinterpret_cast<char*>(buffer.data()), fileSize);
-        fin.close();
-
-        // buffer.size() * valueSize
-
-        return true;
-    }
-
     /// Settings passed to glsLang when compiling GLSL/HLSL shader source to SPIR-V
     /// Provides the values to pass to glsLang::TShader::setEnvInput, setEnvClient and setEnvTarget.
     class VSG_DECLSPEC ShaderCompileSettings : public Inherit<Object, ShaderCompileSettings>
@@ -99,8 +77,6 @@ namespace vsg
 
         void read(Input& input) override;
         void write(Output& output) const override;
-
-        static ref_ptr<ShaderModule> read(const std::string& filename);
 
         // compile the Vulkan object, context parameter used for Device
         void compile(Context& context);

--- a/include/vsg/state/ShaderModule.h
+++ b/include/vsg/state/ShaderModule.h
@@ -22,6 +22,28 @@ namespace vsg
     // forward declare
     class Context;
 
+    template<typename T>
+    bool readFile(T& buffer, const std::string& filename)
+    {
+        std::ifstream fin(filename, std::ios::ate | std::ios::binary);
+        if (!fin.is_open()) return false;
+
+        size_t fileSize = fin.tellg();
+
+        using value_type = typename T::value_type;
+        size_t valueSize = sizeof(value_type);
+        size_t bufferSize = (fileSize + valueSize - 1) / valueSize;
+        buffer.resize(bufferSize);
+
+        fin.seekg(0);
+        fin.read(reinterpret_cast<char*>(buffer.data()), fileSize);
+        fin.close();
+
+        // buffer.size() * valueSize
+
+        return true;
+    }
+
     /// Settings passed to glsLang when compiling GLSL/HLSL shader source to SPIR-V
     /// Provides the values to pass to glsLang::TShader::setEnvInput, setEnvClient and setEnvTarget.
     class VSG_DECLSPEC ShaderCompileSettings : public Inherit<Object, ShaderCompileSettings>

--- a/include/vsg/state/ShaderStage.h
+++ b/include/vsg/state/ShaderStage.h
@@ -37,7 +37,8 @@ namespace vsg
         std::string entryPointName;
         SpecializationConstants specializationConstants;
 
-        static ref_ptr<ShaderStage> read(VkShaderStageFlagBits stage, const std::string& entryPointName, const std::string& filename);
+        static ref_ptr<ShaderStage> read(VkShaderStageFlagBits stage, const std::string& entryPointName, const std::string& filename, ref_ptr<const Options> options = {});
+        static ref_ptr<ShaderStage> read(VkShaderStageFlagBits stage, const std::string& entryPointName, std::istream& fin, ref_ptr<const Options> options = {});
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/utils/Builder.h
+++ b/include/vsg/utils/Builder.h
@@ -16,6 +16,7 @@ namespace vsg
         bool instancce_colors_vec4 = true;
         bool instancce_positions_vec3 = false;
         ref_ptr<Data> image;
+        ref_ptr<Data> displacementMap;
 
         bool operator<(const StateInfo& rhs) const
         {
@@ -26,17 +27,18 @@ namespace vsg
             VSG_COMPARE_PARAMETERS(wireframe, rhs.wireframe)
             VSG_COMPARE_PARAMETERS(instancce_colors_vec4, rhs.instancce_colors_vec4)
             VSG_COMPARE_PARAMETERS(instancce_positions_vec3, rhs.instancce_positions_vec3)
-            return image < rhs.image;
+            VSG_COMPARE_PARAMETERS(image, rhs.image)
+            return displacementMap < rhs.displacementMap;
         }
     };
 
     struct GeometryInfo
     {
-        vec3 position = {0.0, 0.0, 0.0};
+        vec3 position = {0.0f, 0.0f, 0.0f};
         vec3 dx = {1.0f, 0.0f, 0.0f};
         vec3 dy = {0.0f, 1.0f, 0.0f};
         vec3 dz = {0.0f, 0.0f, 1.0f};
-        vec4 color = {1.0, 1.0, 1.0, 1.0};
+        vec4 color = {1.0f, 1.0f, 1.0f, 1.0f};
         mat4 transform;
 
         /// used for instancing
@@ -75,6 +77,7 @@ namespace vsg
         ref_ptr<Node> createDisk(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
         ref_ptr<Node> createQuad(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
         ref_ptr<Node> createSphere(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
+        ref_ptr<Node> createHeightField(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
 
     private:
 
@@ -84,12 +87,24 @@ namespace vsg
         uint32_t _maxNumTextures = 0;
         ref_ptr<CompileTraversal> _compile;
 
+        struct DescriptorKey
+        {
+            ref_ptr<Data> image;
+            ref_ptr<Data> displacementMap;
+
+            bool operator<(const DescriptorKey& rhs) const
+            {
+                VSG_COMPARE_PARAMETERS(image, rhs.image);
+                return displacementMap < rhs.displacementMap;
+            }
+        };
+
         struct StateSettings
         {
             ref_ptr<DescriptorSetLayout> descriptorSetLayout;
             ref_ptr<PipelineLayout> pipelineLayout;
             ref_ptr<BindGraphicsPipeline> bindGraphicsPipeline;
-            std::map<ref_ptr<Data>, ref_ptr<BindDescriptorSets>> textureDescriptorSets;
+            std::map<DescriptorKey, ref_ptr<BindDescriptorSets>> textureDescriptorSets;
         };
 
         std::map<StateInfo, StateSettings> _stateMap;
@@ -108,6 +123,7 @@ namespace vsg
         GeometryMap _cylinders;
         GeometryMap _quads;
         GeometryMap _spheres;
+        GeometryMap _heightfields;
 
         // used for comparisons
         mat4 identity;

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -102,6 +102,7 @@ set(SOURCES
     io/ObjectFactory.cpp
     io/ReaderWriter.cpp
     io/VSG.cpp
+    io/spirv.cpp
     io/read.cpp
     io/write.cpp
 

--- a/src/vsg/io/read.cpp
+++ b/src/vsg/io/read.cpp
@@ -12,6 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/io/ObjectCache.h>
 #include <vsg/io/VSG.h>
+#include <vsg/io/spirv.h>
 #include <vsg/io/read.h>
 
 #include <vsg/threading/OperationThreads.h>
@@ -30,14 +31,21 @@ ref_ptr<Object> vsg::read(const Path& filename, ref_ptr<const Options> options)
             }
         }
 
-        auto ext = vsg::fileExtension(filename);
+        auto ext = vsg::lowerCaseFileExtension(filename);
+
         if (ext == "vsga" || ext == "vsgt" || ext == "vsgb")
         {
             VSG rw;
             return rw.read(filename, options);
         }
+        else if (ext == "spv")
+        {
+            spirv rw;
+            return rw.read(filename, options);
+        }
         else
         {
+            // no means of loading file
             return {};
         }
     };

--- a/src/vsg/io/read.cpp
+++ b/src/vsg/io/read.cpp
@@ -12,8 +12,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/io/ObjectCache.h>
 #include <vsg/io/VSG.h>
-#include <vsg/io/spirv.h>
 #include <vsg/io/read.h>
+#include <vsg/io/spirv.h>
 
 #include <vsg/threading/OperationThreads.h>
 

--- a/src/vsg/io/spirv.cpp
+++ b/src/vsg/io/spirv.cpp
@@ -1,0 +1,99 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2020 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/io/spirv.h>
+#include <vsg/state/ShaderStage.h>
+#include <vsg/vk/ShaderCompiler.h>
+
+#include <iostream>
+
+using namespace vsg;
+
+template<typename T>
+bool readFile(T& buffer, const std::string& filename)
+{
+    std::ifstream fin(filename, std::ios::ate | std::ios::binary);
+    if (!fin.is_open()) return false;
+
+    size_t fileSize = fin.tellg();
+
+    using value_type = typename T::value_type;
+    size_t valueSize = sizeof(value_type);
+    size_t bufferSize = (fileSize + valueSize - 1) / valueSize;
+    buffer.resize(bufferSize);
+
+    fin.seekg(0);
+    fin.read(reinterpret_cast<char*>(buffer.data()), fileSize);
+    fin.close();
+
+    // buffer.size() * valueSize
+
+    return true;
+}
+
+spirv::spirv()
+{
+}
+
+vsg::ref_ptr<vsg::Object> spirv::read(const vsg::Path& filename, vsg::ref_ptr<const vsg::Options> options) const
+{
+    auto ext = vsg::lowerCaseFileExtension(filename);
+    if (ext == "spv")
+    {
+        vsg::Path found_filename = vsg::findFile(filename, options);
+        if (found_filename.empty()) return {};
+
+        vsg::ShaderModule::SPIRV spirv_module;
+        readFile(spirv_module, found_filename);
+
+        auto sm = vsg::ShaderModule::create(spirv_module);
+        return sm;
+    }
+    return vsg::ref_ptr<vsg::Object>();
+}
+
+bool spirv::write(const vsg::Object* object, const vsg::Path& filename, vsg::ref_ptr<const vsg::Options> /*options*/) const
+{
+    auto ext = vsg::lowerCaseFileExtension(filename);
+    if (ext == "spv")
+    {
+        const vsg::ShaderStage* ss = dynamic_cast<const vsg::ShaderStage*>(object);
+        const vsg::ShaderModule* sm = ss ? ss->module.get() : dynamic_cast<const vsg::ShaderModule*>(object);
+        if (sm)
+        {
+            if (sm->code.empty())
+            {
+                vsg::ShaderCompiler sc;
+                if (!sc.compile(vsg::ref_ptr<vsg::ShaderStage>(const_cast<vsg::ShaderStage*>(ss))))
+                {
+                    std::cout << "spirv::write() Failed compile tp spv." << std::endl;
+                    return false;
+                }
+            }
+
+            if (!sm->code.empty())
+            {
+                std::ofstream fout(filename);
+                fout.write(reinterpret_cast<const char*>(sm->code.data()), sm->code.size() * sizeof(vsg::ShaderModule::SPIRV::value_type));
+                fout.close();
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool spirv::getFeatures(Features& features) const
+{
+    features.extensionFeatureMap["spv"] = static_cast<vsg::ReaderWriter::FeatureMask>(vsg::ReaderWriter::READ_FILENAME | vsg::ReaderWriter::WRITE_FILENAME);
+    return true;
+}

--- a/src/vsg/state/ShaderModule.cpp
+++ b/src/vsg/state/ShaderModule.cpp
@@ -80,19 +80,6 @@ ShaderModule::~ShaderModule()
 {
 }
 
-ref_ptr<ShaderModule> ShaderModule::read(const std::string& filename)
-{
-    SPIRV buffer;
-    if (readFile(buffer, filename))
-    {
-        return ShaderModule::create(buffer);
-    }
-    else
-    {
-        throw Exception{"Error: vsg::ShaderModule::read(..) failed to read shader file.", VK_INCOMPLETE};
-    }
-}
-
 void ShaderModule::read(Input& input)
 {
     Object::read(input);

--- a/src/vsg/state/ShaderStage.cpp
+++ b/src/vsg/state/ShaderStage.cpp
@@ -55,8 +55,15 @@ ShaderStage::~ShaderStage()
 
 ref_ptr<ShaderStage> ShaderStage::read(VkShaderStageFlagBits stage, const std::string& entryPointName, const std::string& filename, ref_ptr<const Options> options)
 {
-    auto st = vsg::read_cast<vsg::ShaderStage>(filename, options);
-    if (!st) return {};
+    auto object = vsg::read(filename, options);
+    if (!object) return {};
+
+    auto st = object.cast<vsg::ShaderStage>();
+    if (!st)
+    {
+        auto sm = object.cast<vsg::ShaderModule>();
+        return ShaderStage::create_if(sm.valid(), stage, entryPointName, sm);
+    }
 
     st->stage = stage;
     st->entryPointName = entryPointName;
@@ -65,8 +72,15 @@ ref_ptr<ShaderStage> ShaderStage::read(VkShaderStageFlagBits stage, const std::s
 
 ref_ptr<ShaderStage> ShaderStage::read(VkShaderStageFlagBits stage, const std::string& entryPointName, std::istream& fin, ref_ptr<const Options> options)
 {
-    auto st = vsg::read_cast<vsg::ShaderStage>(fin, options);
-    if (!st) return {};
+    auto object = vsg::read(fin, options);
+    if (!object) return {};
+
+    auto st = object.cast<vsg::ShaderStage>();
+    if (!st)
+    {
+        auto sm = object.cast<vsg::ShaderModule>();
+        return ShaderStage::create_if(sm.valid(), stage, entryPointName, sm);
+    }
 
     st->stage = stage;
     st->entryPointName = entryPointName;

--- a/src/vsg/state/ShaderStage.cpp
+++ b/src/vsg/state/ShaderStage.cpp
@@ -11,6 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/io/Options.h>
+#include <vsg/io/read.h>
 #include <vsg/state/ShaderStage.h>
 #include <vsg/traversals/CompileTraversal.h>
 
@@ -52,9 +53,24 @@ ShaderStage::~ShaderStage()
 {
 }
 
-ref_ptr<ShaderStage> ShaderStage::read(VkShaderStageFlagBits in_stage, const std::string& in_entryPointName, const std::string& filename)
+ref_ptr<ShaderStage> ShaderStage::read(VkShaderStageFlagBits stage, const std::string& entryPointName, const std::string& filename, ref_ptr<const Options> options)
 {
-    return ShaderStage::create(in_stage, in_entryPointName, ShaderModule::read(filename));
+    auto st = vsg::read_cast<vsg::ShaderStage>(filename, options);
+    if (!st) return {};
+
+    st->stage = stage;
+    st->entryPointName = entryPointName;
+    return st;
+}
+
+ref_ptr<ShaderStage> ShaderStage::read(VkShaderStageFlagBits stage, const std::string& entryPointName, std::istream& fin, ref_ptr<const Options> options)
+{
+    auto st = vsg::read_cast<vsg::ShaderStage>(fin, options);
+    if (!st) return {};
+
+    st->stage = stage;
+    st->entryPointName = entryPointName;
+    return st;
 }
 
 void ShaderStage::read(Input& input)

--- a/src/vsg/utils/Builder.cpp
+++ b/src/vsg/utils/Builder.cpp
@@ -1470,8 +1470,10 @@ ref_ptr<Node> Builder::createHeightField(const GeometryInfo& info, const StateIn
     auto positions = info.positions;
     if (positions)
     {
-        if (positions->size()>=1) instanceCount = positions->size();
-        else positions = {};
+        if (positions->size() >= 1)
+            instanceCount = positions->size();
+        else
+            positions = {};
     }
 
     auto colors = info.colors;
@@ -1485,7 +1487,7 @@ ref_ptr<Node> Builder::createHeightField(const GeometryInfo& info, const StateIn
     auto dx = info.dx;
     auto dy = info.dy;
     auto dz = info.dz;
-    auto origin = info.position - (dx + dy)*0.5f;
+    auto origin = info.position - (dx + dy) * 0.5f;
 
     unsigned int num_columns = 2;
     unsigned int num_rows = 2;
@@ -1495,14 +1497,12 @@ ref_ptr<Node> Builder::createHeightField(const GeometryInfo& info, const StateIn
         num_columns = stateInfo.displacementMap->width();
         num_rows = stateInfo.displacementMap->height();
 
-        if (num_columns<2) num_columns = 2;
-        if (num_rows<2) num_rows = 2;
+        if (num_columns < 2) num_columns = 2;
+        if (num_rows < 2) num_rows = 2;
     }
 
     unsigned int num_vertices = num_columns * num_rows;
-    unsigned int num_indices = (stateInfo.wireframe) ?
-        (4 * num_columns * num_rows - 2*(num_columns + num_rows)) :
-        (num_rows-1) * (num_rows-1)*6;
+    unsigned int num_indices = (stateInfo.wireframe) ? (4 * num_columns * num_rows - 2 * (num_columns + num_rows)) : (num_rows - 1) * (num_rows - 1) * 6;
 
     auto normal = normalize(dz);
 
@@ -1520,7 +1520,8 @@ ref_ptr<Node> Builder::createHeightField(const GeometryInfo& info, const StateIn
         for (unsigned int c = 0; c < num_columns; ++c)
         {
             unsigned int vi = left_i + c;
-            float tx = float(c) / float(num_columns - 1);;
+            float tx = float(c) / float(num_columns - 1);
+            ;
             vertices->set(vi, origin + dx * tx + dy * ty);
             normals->set(vi, normal);
             texcoords->set(vi, vec2(float(c) / float(num_columns - 1), t_origin + t_scale * ty));
@@ -1543,7 +1544,7 @@ ref_ptr<Node> Builder::createHeightField(const GeometryInfo& info, const StateIn
 
         for (unsigned int c = 0; c < num_columns; ++c)
         {
-            for (unsigned int r = 0; r < num_rows-1; ++r)
+            for (unsigned int r = 0; r < num_rows - 1; ++r)
             {
                 unsigned vi = num_columns * r + c;
                 indices->set(i++, vi);
@@ -1571,7 +1572,6 @@ ref_ptr<Node> Builder::createHeightField(const GeometryInfo& info, const StateIn
             }
         }
     }
-
 
     if (info.transform != identity)
     {

--- a/src/vsg/utils/Builder.cpp
+++ b/src/vsg/utils/Builder.cpp
@@ -48,6 +48,9 @@ ref_ptr<BindDescriptorSets> Builder::_createDescriptorSet(const StateInfo& state
     if (textureData)
     {
         auto sampler = Sampler::create();
+        sampler->addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler->addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+
         auto texture = DescriptorImage::create(sampler, textureData, 0, 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
         descriptors.push_back(texture);
     }
@@ -55,6 +58,9 @@ ref_ptr<BindDescriptorSets> Builder::_createDescriptorSet(const StateInfo& state
     if (displacementMap)
     {
         auto sampler = Sampler::create();
+        sampler->addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        sampler->addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+
         auto texture = DescriptorImage::create(sampler, displacementMap, 6, 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
         descriptors.push_back(texture);
     }
@@ -238,7 +244,9 @@ void Builder::transform(const mat4& matrix, ref_ptr<vec3Array> vertices, ref_ptr
 
 vec3 Builder::y_texcoord(const StateInfo& info) const
 {
-    if (info.image && info.image->getLayout().origin == Origin::TOP_LEFT)
+
+    if ((info.image && info.image->getLayout().origin == Origin::TOP_LEFT) ||
+        (info.displacementMap && info.displacementMap->getLayout().origin == Origin::TOP_LEFT))
     {
         return {1.0f, -1.0f, 0.0f};
     }
@@ -1499,7 +1507,8 @@ ref_ptr<Node> Builder::createHeightField(const GeometryInfo& info, const StateIn
 
     for (unsigned int r = 0; r < num_rows; ++r)
     {
-        float ty = t_origin + t_scale * float(r) / float(num_rows - 1);
+        //float ty = t_origin + t_scale * float(r) / float(num_rows - 1);
+        float ty = float(r) / float(num_rows - 1);
         unsigned int left_i = r * num_columns;
 
         for (unsigned int c = 0; c < num_columns; ++c)
@@ -1508,7 +1517,7 @@ ref_ptr<Node> Builder::createHeightField(const GeometryInfo& info, const StateIn
             float tx = float(c) / float(num_columns - 1);;
             vertices->set(vi, origin + dx * tx + dy * ty);
             normals->set(vi, normal);
-            texcoords->set(vi, vec2(float(c) / float(num_columns - 1), ty));
+            texcoords->set(vi, vec2(float(c) / float(num_columns - 1), t_origin + t_scale * ty));
         }
     }
 

--- a/src/vsg/utils/shaders/assimp_vert.cpp
+++ b/src/vsg/utils/shaders/assimp_vert.cpp
@@ -12,12 +12,16 @@ Root id=1 vsg::ShaderStage
     Source "#version 450
 #extension GL_ARB_separate_shader_objects : enable
 
-#pragma import_defines (VSG_INSTANCE_POSITIONS)
+#pragma import_defines (VSG_INSTANCE_POSITIONS, VSG_DISPLACEMENT_MAP)
 
 layout(push_constant) uniform PushConstants {
     mat4 projection;
     mat4 modelView;
 } pc;
+
+#ifdef VSG_DISPLACEMENT_MAP
+layout(binding = 6) uniform sampler2D displacementMap;
+#endif
 
 layout(location = 0) in vec3 vsg_Vertex;
 layout(location = 1) in vec3 vsg_Normal;
@@ -41,6 +45,10 @@ out gl_PerVertex{ vec4 gl_Position; };
 void main()
 {
     vec4 vertex = vec4(vsg_Vertex, 1.0);
+
+#ifdef VSG_DISPLACEMENT_MAP
+    vertex.xyz = vertex.xyz + vsg_Normal * texture(displacementMap, vsg_TexCoord0.st).s;
+#endif
 
 #ifdef VSG_INSTANCE_POSITIONS
    vertex.xyz = vertex.xyz + vsg_position;

--- a/src/vsg/utils/shaders/assimp_vert.cpp
+++ b/src/vsg/utils/shaders/assimp_vert.cpp
@@ -48,27 +48,30 @@ void main()
     vec4 normal = vec4(vsg_Normal, 0.0);
 
 #ifdef VSG_DISPLACEMENT_MAP
+    // TODO need to pass as as uniform or per instance attributes
     vec3 scale = vec3(1.0, 1.0, 1.0);
 
     vertex.xyz = vertex.xyz + vsg_Normal * (texture(displacementMap, vsg_TexCoord0.st).s * scale.z);
 
-    float delta = 0.01;
+    float s_delta = 0.01;
     float width = 0.0;
 
-    float s_left = max(vsg_TexCoord0.s - delta, 0.0);
-    float s_right = min(vsg_TexCoord0.s + delta, 1.0);
+    float s_left = max(vsg_TexCoord0.s - s_delta, 0.0);
+    float s_right = min(vsg_TexCoord0.s + s_delta, 1.0);
     float t_center = vsg_TexCoord0.t;
-    float delta_left_right = s_right - s_left;
-    float dz_left_right = texture(displacementMap, vec2(s_right, t_center)).s - texture(displacementMap, vec2(s_left, t_center)).s;
+    float delta_left_right = (s_right - s_left) * scale.x;
+    float dz_left_right = (texture(displacementMap, vec2(s_right, t_center)).s - texture(displacementMap, vec2(s_left, t_center)).s) * scale.z;
 
-    float t_bottom = max(vsg_TexCoord0.t - delta, 0.0);
-    float t_top = min(vsg_TexCoord0.t + delta, 1.0);
+    // TODO need to handle different origins of displacementMap vs diffuseMap etc,
+    float t_delta = s_delta;
+    float t_bottom = max(vsg_TexCoord0.t - t_delta, 0.0);
+    float t_top = min(vsg_TexCoord0.t + t_delta, 1.0);
     float s_center = vsg_TexCoord0.s;
-    float delta_bottom_top = t_top - t_bottom;
-    float dz_bottom_top = texture(displacementMap, vec2(s_center, t_top)).s - texture(displacementMap, vec2(s_center, t_bottom)).s;
+    float delta_bottom_top = (t_top - t_bottom) * scale.y;
+    float dz_bottom_top = (texture(displacementMap, vec2(s_center, t_top)).s - texture(displacementMap, vec2(s_center, t_bottom)).s) * scale.z;
 
     vec3 dx = normalize(vec3(delta_left_right, 0.0, dz_left_right));
-    vec3 dy = normalize(vec3(0.0, delta_bottom_top, dz_bottom_top));
+    vec3 dy = normalize(vec3(0.0, delta_bottom_top, -dz_bottom_top));
     vec3 dz = normalize(cross(dx, dy));
 
     normal.xyz = normalize(dx * vsg_Normal.x + dy * vsg_Normal.y + dz * vsg_Normal.z);


### PR DESCRIPTION
Restructured the vsg::ShaderStage::read(.) so it utlizes the standard vsg::read(..) mechanism,
Moved spirv ReaderWriter from vsgXchange into core VSG to enable reading of .spv shaders without vsgXchange.