### PR TITLE
Fix error: invalid conversion from 'std::thread::native_handle_type' {aka 'unsigned int'} to 'HANDLE' {aka 'void*'}

### DIFF
--- a/src/vsg/threading/Affinity.cpp
+++ b/src/vsg/threading/Affinity.cpp
@@ -46,7 +46,7 @@ static void win32_setAffinity(HANDLE tid, const vsg::Affinity& affinity)
 
 void vsg::setAffinity(std::thread& thread, const Affinity& affinity)
 {
-    win32_setAffinity(thread.native_handle(), affinity);
+    win32_setAffinity((HANDLE)thread.native_handle(), affinity);
 }
 
 void vsg::setAffinity(const Affinity& affinity)


### PR DESCRIPTION
## Description
The commit from this pr fixes a build error with MinGW gcc 
Fixes #324

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
The vsg library was build with this patch applied at https://build.opensuse.org/package/show/home:rhabacker:branches:games:mingw32/mingw32-libvsg

**Test Configuration**:
* Toolchain: MinGW gcc 
* SDK: vsg git master branch

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
