### PR TITLE
Add option for cmake variable BUILD_SHARED_LIBS to make it more visible

### DIFF
--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -335,3 +335,8 @@ macro(vsg_add_target_uninstall)
         COMMAND ${CMAKE_COMMAND} -P ${DIR}/uninstall.cmake
     )
 endmacro()
+
+#
+# add options for vsg and all packages depending on vsg
+#
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)


### PR DESCRIPTION
## Description
The cmake variable BUILD_SHARED_LIBS is used to enable shared mode library creation. To make it more visible and able to be set by ccmake and IDE's, an associated cmake option is added with these mr.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
## How Has This Been Tested?
Opened a related cmake build with ccmake and qtcreator.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
