### PR TITLE
Add support to check minimum vulkan version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ if (VULKAN_SDK)
 endif()
 
 find_package(Vulkan REQUIRED)
+vsg_check_vulkan_min_version(162)
+
 find_package(Threads REQUIRED)
 
 if (NOT DEFINED glslang_FOUND)

--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -342,6 +342,26 @@ macro(vsg_add_target_uninstall)
 endmacro()
 
 #
+# check minimum version of Vulkan
+#
+# available arguments:
+#
+#    <min_version>      minimum required version e.g. 194
+#
+macro(vsg_check_vulkan_min_version _min_version)
+    if (Vulkan_FOUND)
+        set(VULKAN_CORE_H ${Vulkan_INCLUDE_DIRS}/vulkan/vulkan_core.h)
+        file(STRINGS  ${VULKAN_CORE_H} VulkanHeaderVersionLine REGEX "^#define VK_HEADER_VERSION ")
+        string(REGEX MATCHALL "[0-9]+" VulkanHeaderVersion "${VulkanHeaderVersionLine}")
+        message(STATUS "Detected VK_HEADER_VERSION is ${VulkanHeaderVersion}, in header ${VULKAN_CORE_H}")
+        if(${VulkanHeaderVersion} STRLESS ${_min_version})
+            message(FATAL_ERROR
+                "Found Vulkan but VK_HEADER_VERSION is below minimum required value of ${_min_version}")
+        endif()
+    endif()
+endmacro()
+
+#
 # add options for vsg and all packages depending on vsg
 #
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)

--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -358,6 +358,8 @@ macro(vsg_check_vulkan_min_version _min_version)
             message(FATAL_ERROR
                 "Found Vulkan but VK_HEADER_VERSION is below minimum required value of ${_min_version}")
         endif()
+    else()
+        message(FATAL_ERROR "Cannot check version because Vulkan was not found - use 'find_package(Vulkan REQUIRED)' to fix this")
     endif()
 endmacro()
 


### PR DESCRIPTION
## Description
Fixes https://github.com/vsg-dev/VulkanSceneGraph/issues/312

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
By using that macro in the VulkanSceneGraph repo and raising the min version to 199, which let cmake fail with a minimum related version failure.
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
