### PR TITLE
handle carriage return when compiling shaders

### DIFF
--- a/src/vsg/vk/ShaderCompiler.cpp
+++ b/src/vsg/vk/ShaderCompiler.cpp
@@ -317,7 +317,7 @@ std::string ShaderCompiler::combineSourceAndDefines(const std::string& source, c
 
     // trim trailing spaces/tabs/newlines
     auto trimTrailing = [](std::string& str) {
-        size_t endpos = str.find_last_not_of(" \t\n");
+        size_t endpos = str.find_last_not_of(" \t\r\n");
         if (endpos != std::string::npos)
         {
             str = str.substr(0, endpos + 1);


### PR DESCRIPTION
## Description

Handle carriage returns when compiling shaders

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Hardware: Windows 10 x64
* Toolchain: MSVC 2019 16.11.5
* SDK: Vulkan 1.2.182.0

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
