### PR TITLE
FIX: Respect event.handled flag in Trackball ButtonReleaseEvent.

### DIFF
--- a/src/vsg/viewer/Trackball.cpp
+++ b/src/vsg/viewer/Trackball.cpp
@@ -143,6 +143,8 @@ void Trackball::apply(ButtonPressEvent& buttonPress)
 
 void Trackball::apply(ButtonReleaseEvent& buttonRelease)
 {
+    if (buttonRelease.handled) return;
+
     if (supportsThrow) _thrown = _previousPointerEvent && (buttonRelease.time == _previousPointerEvent->time);
 
     _lastPointerEventWithinRenderArea = withinRenderArea(buttonRelease.x, buttonRelease.y);


### PR DESCRIPTION
# Pull Request Template

## Description
Mouse button release in the scene window not intended for the main VSG scene (eg IMGUI menu picks) will be processed by the VSG scene. For example, if you spin the scene, then click a menu, the scene stops spinning. This fix respects the event.handled flag and is copied from the ButtonPressEvent event in VSG.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
In my own application
