### PR TITLE
paths is no longer required when using a findfilecallback

### DIFF
--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -209,27 +209,28 @@ Path vsg::findFile(const Path& filename, const Paths& paths)
 
 Path vsg::findFile(const Path& filename, const Options* options)
 {
-    if (options && !options->paths.empty())
+    if (options)
     {
         // if Options has a findFileCallback use it
         if (options->findFileCallback) return options->findFileCallback(filename, options);
 
-        // if appropriate use the filename directly if it exists.
-        if (options->checkFilenameHint == Options::CHECK_ORIGINAL_FILENAME_EXISTS_FIRST && fileExists(filename)) return filename;
+        if (!options->paths.empty())
+        {
+            // if appropriate use the filename directly if it exists.
+            if (options->checkFilenameHint == Options::CHECK_ORIGINAL_FILENAME_EXISTS_FIRST && fileExists(filename)) return filename;
 
-        // search for the file if the in the specific paths.
-        if (auto path = findFile(filename, options->paths); !path.empty()) return path;
+            // search for the file if the in the specific paths.
+            if (auto path = findFile(filename, options->paths); !path.empty()) return path;
 
-        // if appropriate use the filename directly if it exists.
-        if (options->checkFilenameHint == Options::CHECK_ORIGINAL_FILENAME_EXISTS_LAST && fileExists(filename))
-            return filename;
-        else
-            return {};
+            // if appropriate use the filename directly if it exists.
+            if (options->checkFilenameHint == Options::CHECK_ORIGINAL_FILENAME_EXISTS_LAST && fileExists(filename))
+                return filename;
+            else
+                return {};
+        }
     }
-    else
-    {
-        return fileExists(filename) ? filename : Path();
-    }
+
+    return fileExists(filename) ? filename : Path();
 }
 
 bool vsg::makeDirectory(const Path& path)


### PR DESCRIPTION
## Description

Fixes #380 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Tested local applications

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
