### PR TITLE
Add file system install related functions

### DIFF
--- a/include/vsg/io/FileSystem.h
+++ b/include/vsg/io/FileSystem.h
@@ -69,6 +69,39 @@ namespace vsg
     /// make a directory, return true if path already exists or full path has been created successfully, return false on failure.
     extern VSG_DECLSPEC bool makeDirectory(const Path& path);
 
+    /// returns the path and filename of the currently executed file
+    extern VSG_DECLSPEC Path executableFilePath(void);
+
+    /// returns the path of the currently executed file
+    extern VSG_DECLSPEC Path executablePath(void);
+
+    /** @brief returns the absolute path to the shared data installation directory at runtime
+     *
+     * The supported path layouts:
+     * <pre>
+     *   <root>/
+     *     <executable>
+     *     share/ [1]
+     *
+     *   <root>/
+     *     bin/
+     *       <executable>
+     *     share/ [1]
+     * </pre>
+     *
+     * @return path to shared data installation directory [1] or empty path in case of unsupported path layout
+     */
+    extern VSG_DECLSPEC Path sharedDataPath();
+
+    /** @brief returns the absolute path to the shared application data directory for the currently running application
+     *
+     * The directory name is constructed from the result of @ref sharedDataPath() and
+     * the simple file name of this application as returned by @ref simpleFilename().
+     *
+     * @return path or empty string in case directory layout does not match the expectations of @ref sharedDataPath()
+     */
+    extern VSG_DECLSPEC Path sharedAppDataPath();
+
     /** @} */
 
 } // namespace vsg

--- a/include/vsg/io/FileSystem.h
+++ b/include/vsg/io/FileSystem.h
@@ -18,6 +18,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/core/Object.h>
 
+/**
+ * @addtogroup FileSystem
+ * @{
+ */
+
 namespace vsg
 {
 
@@ -63,5 +68,7 @@ namespace vsg
 
     /// make a directory, return true if path already exists or full path has been created successfully, return false on failure.
     extern VSG_DECLSPEC bool makeDirectory(const Path& path);
+
+    /** @} */
 
 } // namespace vsg

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -338,8 +338,8 @@ set_property(TARGET vsg PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET vsg PROPERTY CXX_STANDARD 17)
 
 target_compile_definitions(vsg PRIVATE ${EXTRA_DEFINES})
+target_compile_definitions(vsg PRIVATE CMAKE_INSTALL_DATADIR=\"${CMAKE_INSTALL_DATADIR}\")
 target_include_directories(vsg PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
-
 
 target_link_libraries(vsg ${LIBRARIES})
 

--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -19,11 +19,27 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #    include <io.h>
 //	 cctype is needed for tolower()
 #    include <cctype>
+#    include <windows.h>
+
+#ifdef _MSC_VER
+#ifndef PATH_MAX
+#define PATH_MAX MAX_PATH
+#endif
+#endif
+
 #else
 #    include <errno.h>
 #    include <sys/stat.h>
 #    include <unistd.h>
 #endif
+
+#ifdef __APPLE__
+#    include <libgen.h>
+#    include <mach-o/dyld.h>
+#    include <TargetConditionals.h>
+#endif
+
+#include <limits.h>
 
 #include <iostream>
 
@@ -277,4 +293,89 @@ bool vsg::makeDirectory(const Path& path)
     }
 
     return true;
+}
+
+Path vsg::executableFilePath(void)
+{
+    Path path;
+    char buf[PATH_MAX+1];
+
+#if defined(WIN32)
+    DWORD result = GetModuleFileName(NULL, buf, sizeof(buf)-1);
+    if (result && result < sizeof(buf))
+        path = buf;
+#elif defined(__linux__)
+    ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf)-1);
+    if (len != -1)
+        path = buf;
+#elif defined(__APPLE__)
+#if TARGET_OS_MAC
+    char realPathName[PATH_MAX+1];
+    uint32_t size = (uint32_t)sizeof(buf);
+
+    if(!_NSGetExecutablePath(buf, &size))
+    {
+        realpath(buf, realPathName);
+        path = realPathName;
+    }
+#elif TARGET_IPHONE_SIMULATOR
+    // iOS, tvOS, or watchOS Simulator
+    // Not currently implemented
+#elif TARGET_OS_MACCATALYST
+    // Mac's Catalyst (ports iOS API into Mac, like UIKit).
+    // Not currently implemented
+#elif TARGET_OS_IPHONE
+    // iOS, tvOS, or watchOS device
+    // Not currently implemented
+#else
+#   error "Unknown Apple platform"
+#endif
+#elif defined(__ANDROID__)
+    // Not currently implemented
+#endif
+    return path;
+}
+
+Path vsg::executablePath(void)
+{
+    return vsg::filePath(executableFilePath());
+}
+
+Path vsg::sharedDataPath()
+{
+    Path path;
+
+#if defined(WIN32) || defined(__linux__)
+    path = executablePath();
+    if (path.empty())
+        return {};
+    auto sharePath = concatPaths(path, std::string(CMAKE_INSTALL_DATADIR));
+    if (fileExists(sharePath))
+        return sharePath;
+    path = vsg::filePath(path);
+    sharePath = concatPaths(path, std::string(CMAKE_INSTALL_DATADIR));
+    if (fileExists(sharePath))
+        return sharePath;
+#elif defined(__APPLE__)
+    // Not currently implemented
+#elif defined(__ANDROID__)
+    // Not currently implemented
+#endif
+    return {};
+}
+
+Path vsg::sharedAppDataPath()
+{
+#if defined(WIN32) || defined(__linux__)
+    Path appName = simpleFilename(executableFilePath());
+    Path appDataDir = sharedDataPath();
+    if (appDataDir.empty())
+        return {};
+    return concatPaths(sharedDataPath(), appName);
+#elif defined(__APPLE__)
+    // Not currently implemented
+#elif defined(__ANDROID__)
+    // Not currently implemented
+#endif
+    return {};
 }


### PR DESCRIPTION
## Description

With this merge request some installation related functions are added to the vsg FileSystem module. They will be used for example by vsgvr to find installed model files.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I used the following test case to verify that the functions returns the expected values.

```
$ cat test.cpp
#include <iostream>

#include <vsg/io/FileSystem.h>

int main()
{
    vsg::Path path;
    path = vsg::executableFilePath();
    std::cout << path << std::endl;
    path = vsg::executablePath();
    std::cout << path << std::endl;
    path = vsg::sharedDataPath();
    std::cout << path << std::endl;
    path = vsg::sharedAppDataPath();
    std::cout << path << std::endl;
    return 0;
}
```
Linux
```
$ cd ~/src
$ git clone https://github.com/vsg-dev/VulkanSceneGraph.git
$ mkdir VulkanSceneGraph-build
$ cd VulkanSceneGraph-build
$ cmake ../VulkanSceneGraph
$ make
g++ -o bin/test test.cpp -I../VulkanSceneGraph/include  -lvsg -Llib
$ mkdir share
$ LD_LIBRARY_PATH=$PWD/lib ./bin/test
/home/xxx/src/VulkanSceneGraph-build/bin/test
/home/xxx/src/VulkanSceneGraph-build/bin
/home/xxx/src/VulkanSceneGraph-build/share
/home/xxx/src/VulkanSceneGraph-build/share/test
```
Windows
```
cd ~/src
$ mkdir VulkanSceneGraph-mingw32-build
$ cd VulkanSceneGraph-mingw32-build
$ mingw32-cmake ../VulkanSceneGraph
$ make
$ i686-w64-mingw32-g++ -o bin/test test.cpp -I../VulkanSceneGraph/include  -lvsg -Llib
$ mkdir share
$ wine bin/test.exe
Z:\home\xxx\src\VulkanSceneGraph-mingw32-build\bin\test.exe
Z:\home\xxx\src\VulkanSceneGraph-mingw32-build\bin
Z:\home\xxx\src\VulkanSceneGraph-mingw32-build\share
Z:\home\xxx\src\VulkanSceneGraph-mingw32-build\share\test
```

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works -> see above
- [ ] New and existing unit tests pass locally with my changes -> needs advice where to add related unit test as vsgExamples only contains code examples