### PR TITLE
Add CollectResourceRequirements to DatabasePager

### DIFF
--- a/src/vsg/io/DatabasePager.cpp
+++ b/src/vsg/io/DatabasePager.cpp
@@ -355,6 +355,15 @@ void DatabasePager::start()
                             // compiling subgraph
                             if (subgraph)
                             {
+                                vsg::CollectResourceRequirements collectRequirements;
+                                subgraph->accept(collectRequirements);
+
+                                auto maxSets = collectRequirements.requirements.computeNumDescriptorSets();
+                                auto descriptorPoolSizes = collectRequirements.requirements.computeDescriptorPoolSizes();
+
+                                // brute force allocation of new DescrptorPool for this subgraph, TODO : need to preallocate large DescritorPoil for multiple loaded subgraphs
+                                if (descriptorPoolSizes.size() > 0) ct->context.descriptorPool = vsg::DescriptorPool::create(ct->context.device, maxSets, descriptorPoolSizes);
+
                                 subgraph->accept(*ct);
                                 nodesCompiled.emplace_back(plod);
                             }


### PR DESCRIPTION
Resubmission of previous PR (I got my branches in a mess).

Resource requirements are calculated and applied per DatabasePager request, specifically so that PagedLOD tiles can be loaded without previous knowledge of the number of tiles.

