### PR TITLE
Fixing issue with window resizing and vkAcquireNextImageKHR eventuall…

### DIFF
--- a/src/vsg/viewer/Viewer.cpp
+++ b/src/vsg/viewer/Viewer.cpp
@@ -152,6 +152,14 @@ bool Viewer::acquireNextFrame()
     {
         if (!window->visible()) continue;
 
+        // This is a workaround to force resize without depending on vkAcquireNextImageKHR returning VK_ERROR_OUT_OF_DATE_KHR,
+        // because apparently it is not behaving consistently. Driver bug maybe?
+        if (window->getSwapchain() && (window->extent2D().width != window->getSwapchain()->getExtent().width ||
+                                       window->extent2D().height != window->getSwapchain()->getExtent().height))
+        {
+            window->resize();
+        }
+
         while ((result = window->acquireNextImage()) != VK_SUCCESS)
         {
             if (result == VK_ERROR_SURFACE_LOST_KHR ||


### PR DESCRIPTION
…y not returning VK_ERROR_OUT_OF_DATE_KHR.

# Pull Request Template

## Description

Apparently the behaviour of vkAcquireNextImageKHR is not consistent when window resizing happens, and sometimes it doesn't report VK_ERROR_OUT_OF_DATE_KHR. This forces window resizing without depending on vkAcquireNextImageKHR, just checking the current swapchain extent with the new resized extent.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Use vsgQt example vsgqtviewer, and make sure to run it with -d option. Resize the window drastically. You should see some vulkan errors being reported, basically complaining about the framebuffer size. You should also see visual artefacts caused by a corrupted framebuffer.

**Test Configuration**:
Tested on a Ubuntu 20.04, vsg 2a12449a305d9b1c1abf066174ae76b4bc0c3738, vsgQt b0eb106bf71fd0f561882a4af7d4df3366caf512, Qt 5.12.8, NVidia T500 (510.47.03 driver).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
