### PR TITLE
Window Position can be set now.

### DIFF
--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -797,8 +797,7 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     [_window setOpaque:YES];
     [_window setBackgroundColor:[NSColor whiteColor]];
 
-    //[_window setFrame:CGRectMake(pos.x, ymax - pos.y, [_window frame].size.width , [_window frame].size.height) display:NO]; 
-   
+    
     // create view
     _view = [[vsg_MacOS_NSView alloc] initWithVsgWindow:this];
     [_view setWantsBestResolutionOpenGLSurface:_traits->hdpi];

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -797,14 +797,14 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     [_window setOpaque:YES];
     [_window setBackgroundColor:[NSColor whiteColor]];
 
-    // set the lower left corner window position as offset from the lower left corner of the screen
+    // set the top left corner window position as offset from the top left corner of the screen
     NSPoint pos; 
     int xmax = [[NSScreen mainScreen] frame].size.width - [_window frame].size.width;
     int ymax = [[NSScreen mainScreen] frame].size.height - [_window frame].size.height;
     pos.x = std::clamp(traits->x,0,xmax);
     pos.y = std::clamp(traits->y,0,ymax);
-    [_window setFrame:CGRectMake(pos.x, pos.y, [_window frame].size.width , [_window frame].size.height) display:YES];    
-
+   [_window setFrame:CGRectMake(pos.x, ymax - pos.y, [_window frame].size.width , [_window frame].size.height) display:NO]; 
+   
     // create view
     _view = [[vsg_MacOS_NSView alloc] initWithVsgWindow:this];
     [_view setWantsBestResolutionOpenGLSurface:_traits->hdpi];

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -797,6 +797,14 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     [_window setOpaque:YES];
     [_window setBackgroundColor:[NSColor whiteColor]];
 
+    // set the lower left corner window position as offset from the lower left corner of the screen
+    NSPoint pos; 
+    int xmax = [[NSScreen mainScreen] frame].size.width - [_window frame].size.width;
+    int ymax = [[NSScreen mainScreen] frame].size.height - [_window frame].size.height;
+    pos.x = std::clamp(traits->x,0,xmax);
+    pos.y = std::clamp(traits->y,0,ymax);
+    [_window setFrame:CGRectMake(pos.x, pos.y, [_window frame].size.width , [_window frame].size.height) display:YES];    
+
     // create view
     _view = [[vsg_MacOS_NSView alloc] initWithVsgWindow:this];
     [_view setWantsBestResolutionOpenGLSurface:_traits->hdpi];

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -797,13 +797,7 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     [_window setOpaque:YES];
     [_window setBackgroundColor:[NSColor whiteColor]];
 
-    // set the top left corner window position as offset from the top left corner of the screen
-    NSPoint pos; 
-    int xmax = [[NSScreen mainScreen] frame].size.width - [_window frame].size.width;
-    int ymax = [[NSScreen mainScreen] frame].size.height - [_window frame].size.height;
-    pos.x = std::clamp(traits->x,0,xmax);
-    pos.y = std::clamp(traits->y,0,ymax);
-   [_window setFrame:CGRectMake(pos.x, ymax - pos.y, [_window frame].size.width , [_window frame].size.height) display:NO]; 
+    //[_window setFrame:CGRectMake(pos.x, ymax - pos.y, [_window frame].size.width , [_window frame].size.height) display:NO]; 
    
     // create view
     _view = [[vsg_MacOS_NSView alloc] initWithVsgWindow:this];
@@ -835,7 +829,15 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     _first_macos_timestamp = [[NSProcessInfo processInfo] systemUptime];
     _first_macos_time_point = vsg::clock::now();
 
+   // set the top left corner window position as offset from the top left corner of the screen
+    NSPoint pos;
+    int xmax = [[NSScreen mainScreen] frame].size.width - [_window frame].size.width;
+    int ymax = [[NSScreen mainScreen] frame].size.height - [_window frame].size.height;
+    pos.x = std::clamp(traits->x,0,xmax);
+    pos.y = ymax-std::clamp(traits->y,0,ymax);
     // show
+    [_window setFrame:CGRectMake(pos.x, pos.y, [_window frame].size.width , [_window frame].size.height) display:YES];
+
     //vsgMacOS::createApplicationMenus();
     [NSApp activateIgnoringOtherApps:YES];
     [_window makeKeyAndOrderFront:nil];


### PR DESCRIPTION
Window traits position (x,y) are now used to set the window position.

It is the distance between lower left corner of the screen and the lower left corner of the window.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] vsgbuilder, setting the x and y
- [x] chrono_vsg, setting per accessor method

**Test Configuration**:
* Firmware version: 7459.101.2
* Hardware: Apple iMac M1
* Toolchain: Apple Xcode 13.3
* SDK: Vulkan 1.3.204.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
