### PR TITLE
Convert LineSegmentIntersector::Intersection to derive from vsg::Object

### DIFF
--- a/include/vsg/traversals/LineSegmentIntersector.h
+++ b/include/vsg/traversals/LineSegmentIntersector.h
@@ -33,25 +33,38 @@ namespace vsg
         LineSegmentIntersector(const dvec3& s, const dvec3& e, ref_ptr<ArrayState> initialArrayData = {});
         LineSegmentIntersector(const Camera& camera, int32_t x, int32_t y, ref_ptr<ArrayState> initialArrayData = {});
 
-        struct Intersection
+        class Intersection : public Inherit<Object, Intersection>
         {
-            dvec3 localIntersection;
-            dvec3 worldIntersection;
-            double ratio = 0.0;
+            public:
+                Intersection(){}
+                
+                Intersection(dvec3 in_localIntersection, dvec3 in_worldIntersection, double in_ratio, dmat4 in_localToWord, NodePath in_nodePath, DataList in_arrays, IndexRatios in_indexRatios) :
+                    localIntersection(in_localIntersection),
+                    worldIntersection(in_worldIntersection),
+                    ratio(in_ratio),
+                    localToWord(in_localToWord),
+                    nodePath(in_nodePath),
+                    arrays(in_arrays),
+                    indexRatios(in_indexRatios)
+                    {}
 
-            dmat4 localToWord;
-            NodePath nodePath;
-            DataList arrays;
-            IndexRatios indexRatios;
+                dvec3 localIntersection;
+                dvec3 worldIntersection;
+                double ratio = 0.0;
 
-            // return true if Intersection is valid
-            operator bool() const { return !nodePath.empty(); }
+                dmat4 localToWord;
+                NodePath nodePath;
+                DataList arrays;
+                IndexRatios indexRatios;
+
+                // return true if Intersection is valid
+                operator bool() const { return !nodePath.empty(); }
         };
 
-        using Intersections = std::vector<Intersection>;
+        using Intersections = std::vector<ref_ptr<Intersection>>;
         Intersections intersections;
 
-        void add(const dvec3& intersection, double ratio, const IndexRatios& indexRatios);
+        ref_ptr<Intersection> add(const dvec3& coord, double ratio, const IndexRatios& indexRatios);
 
         void pushTransform(const Transform& transform) override;
         void popTransform() override;

--- a/src/vsg/traversals/LineSegmentIntersector.cpp
+++ b/src/vsg/traversals/LineSegmentIntersector.cpp
@@ -163,17 +163,23 @@ LineSegmentIntersector::LineSegmentIntersector(const Camera& camera, int32_t x, 
     _lineSegmentStack.push_back(LineSegment{world_near, world_far});
 }
 
-void LineSegmentIntersector::add(const dvec3& intersection, double ratio, const IndexRatios& indexRatios)
+ref_ptr<LineSegmentIntersector::Intersection> LineSegmentIntersector::add(const dvec3& coord, double ratio, const IndexRatios& indexRatios)
 {
+    ref_ptr<Intersection> intersection;
     if (_matrixStack.empty())
     {
-        intersections.emplace_back(Intersection{intersection, intersection, ratio, {}, _nodePath, arrayStateStack.back()->arrays, indexRatios});
+        dmat4 m;
+        intersection = Intersection::create(coord, coord, ratio, m, _nodePath, arrayStateStack.back()->arrays, indexRatios);
+        intersections.emplace_back(intersection);
     }
     else
     {
         auto& localToWorld = _matrixStack.back();
-        intersections.emplace_back(Intersection{intersection, localToWorld * intersection, ratio, localToWorld, _nodePath, arrayStateStack.back()->arrays, indexRatios});
+        intersection = Intersection::create(coord, localToWorld * coord, ratio, localToWorld, _nodePath, arrayStateStack.back()->arrays, indexRatios);
+        intersections.emplace_back(intersection);
     }
+
+    return intersection;
 }
 
 void LineSegmentIntersector::pushTransform(const Transform& transform)


### PR DESCRIPTION
This PR is the successor to PR 426.

The suggestion in PR 426 was to use the built in meta value functionality of vsg::Object to pass application specific data for intersections from LineSegmentIntersector. This isn't possible per intersection because each Intersection is held in a simple structure and not derived from vsg::Object. This PR converts LineSegmentIntersector::Intersection to be derived from vsg::Object set that the meta value function can be used.

Note that add() now returns a ref_ptr to the Intersection so that user values can be added afterward.

The main change for users is that Intersection members are now accessed via -> instead of dot.

The result can be used like this:

```
void PtInstanceGeom::accept(vsg::ConstVisitor& visitor) const
{
    if (auto v = dynamic_cast<LineIntersector*>(&visitor))
    {
            // We need to test if we have intersected a point
            for(int32_t index = 0; index < _pts->size(); index++)
            {
                vsg::dvec3 pt(_pts->at(index));
                if(v->intersects(vsg::dsphere(pt, 5.0)))
                {
                    auto is = v->add(pt, 0.0, {});
                    is->setValue("id", _ids[index]);
                }
            }
    }
    else
    {
        traverse(visitor);
    }
}
```
