### PR TITLE
Add vsg:: identifier for calls outside vsg namespace

### DIFF
--- a/include/vsg/core/Value.h
+++ b/include/vsg/core/Value.h
@@ -28,9 +28,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/Output.h>
 
 #define VSG_value(N, T) \
-    using N = Value<T>; \
+    using N = vsg::Value<T>; \
     template<>          \
-    constexpr const char* type_name<N>() noexcept { return "vsg::" #N; }
+    constexpr const char* vsg::type_name<N>() noexcept { return "vsg::" #N; }
 
 namespace vsg
 {


### PR DESCRIPTION
User defined values can only be defined within vsg namespace. This PR allows users to define their own values outside of vsg namespace.

