### PR TITLE
Phong lighting

### DIFF
--- a/src/vsg/utils/shaders/assimp_phong_frag.cpp
+++ b/src/vsg/utils/shaders/assimp_phong_frag.cpp
@@ -166,8 +166,8 @@ void main()
         // ambient lights
         for(int i = 0; i<numAmbientLights; ++i)
         {
-            vec4 ambient_color = lightData.values[index++];
-            color += ambient_color.rgb * ambient_color.a;
+            vec4 lightColor = lightData.values[index++];
+            color.rgb += ambientColor.rgb * lightColor.rgb * ambientColor.a;
         }
     }
 

--- a/src/vsg/utils/shaders/assimp_phong_frag.cpp
+++ b/src/vsg/utils/shaders/assimp_phong_frag.cpp
@@ -179,11 +179,11 @@ void main()
             vec4 lightColor = lightData.values[index++];
             vec3 direction = -lightData.values[index++].xyz;
             float diff = max(dot(direction, nd), 0.0);
-            color.rgb += (diffuseColor.rgb * lightColor.rgb) * (diff * lightColor.a);
+            color.rgb += (diffuseColor.rgb * lightColor.rgb) * (diff * diffuseColor.a);
             if (diff > 0.0)
             {
                 vec3 halfDir = normalize(direction + vd);
-                color.rgb += specularColor.rgb * (pow(max(dot(halfDir, nd), 0.0), shininess) * lightColor.a);
+                color.rgb += specularColor.rgb * (pow(max(dot(halfDir, nd), 0.0), shininess) * diffuseColor.a);
             }
         }
     }


### PR DESCRIPTION
Phong shader was applying ambient light value directly without modifying it by the material alpha, leading to overly bright scenes.

The diffuse light calculations multiply by the light alpha instead of the (vertex colour * material) alpha. I think it should be the later - please check.

Note that I haven't looked at the other shaders as I'm only familiar with Phong.


