### PR TITLE
Add EVSG_value to create values external to vsg namespace

### DIFF
--- a/include/vsg/core/Value.h
+++ b/include/vsg/core/Value.h
@@ -32,6 +32,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     template<>          \
     constexpr const char* type_name<N>() noexcept { return "vsg::" #N; }
 
+// helper define for defining a Value external to the vsg namespace, note must be placed in global namespace.
+#define EVSG_value(N, T) \
+    using N = vsg::Value<T>; \
+    template<>          \
+    constexpr const char* vsg::type_name<N>() noexcept { return "vsg::" #N; }
+
 namespace vsg
 {
     template<typename T>


### PR DESCRIPTION
Update to PR 431 which was accepted then reverted.

Adds a new macro EVSG_value for use outside vsg namespace. This follows the pattern for VSG_type_name / EVSG_type_name.

