### PR TITLE
Quat additions

### DIFF
--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -171,6 +171,17 @@ namespace vsg
     }
 
     template<typename T>
+    constexpr t_quat<T> operator*(const t_quat<T>& lhs, const t_quat<T>& rhs)
+    {
+        t_quat<T> q( rhs[3]*lhs[0] + rhs[0]*lhs[3] + rhs[1]*lhs[2] - rhs[2]*lhs[1],
+                rhs[3]*lhs[1] - rhs[0]*lhs[2] + rhs[1]*lhs[3] + rhs[2]*lhs[0],
+                rhs[3]*lhs[2] + rhs[0]*lhs[1] - rhs[1]*lhs[0] + rhs[2]*lhs[3],
+                rhs[3]*lhs[3] - rhs[0]*lhs[0] - rhs[1]*lhs[1] - rhs[2]*lhs[2] );
+
+        return q;
+    }
+
+    template<typename T>
     constexpr t_quat<T> operator*(const t_quat<T>& lhs, T rhs)
     {
         return t_quat<T>(lhs[0] * rhs, lhs[1] * rhs, lhs[2] * rhs, lhs[3] * rhs);

--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -170,6 +170,7 @@ namespace vsg
         return t_quat<T>(lhs[0] + rhs[0], lhs[1] + rhs[1], lhs[2] + rhs[2], lhs[3] + rhs[3]);
     }
 
+    // Rotate a quaternion by another quaternion
     template<typename T>
     constexpr t_quat<T> operator*(const t_quat<T>& lhs, const t_quat<T>& rhs)
     {
@@ -179,6 +180,21 @@ namespace vsg
                 rhs[3]*lhs[3] - rhs[0]*lhs[0] - rhs[1]*lhs[1] - rhs[2]*lhs[2] );
 
         return q;
+    }
+
+    // Rotate a vector by a quaternion
+    template<typename T>
+    constexpr t_vec3<T> operator*(const t_quat<T>& q, const t_vec3<T>& v)
+    {
+        // nVidia SDK implementation
+        t_vec3<T> uv, uuv;
+        t_vec3<T> qvec(v[0], v[1], v[2]);
+        uv = qvec ^ v;
+        uuv = qvec ^ uv;
+        T two;
+        uv *= ( two * v[3] );
+        uuv *= two;
+        return v + uv + uuv;
     }
 
     template<typename T>

--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -191,7 +191,7 @@ namespace vsg
         t_vec3<T> qvec(q[0], q[1], q[2]);
         uv = cross(qvec, v);
         uuv = cross(qvec, uv);
-        T two = 2.0;
+        T two(2.0);
         uv *= ( two * q[3] );
         uuv *= two;
         return v + uv + uuv;

--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -188,11 +188,11 @@ namespace vsg
     {
         // nVidia SDK implementation
         t_vec3<T> uv, uuv;
-        t_vec3<T> qvec(v[0], v[1], v[2]);
-        uv = qvec ^ v;
-        uuv = qvec ^ uv;
-        T two;
-        uv *= ( two * v[3] );
+        t_vec3<T> qvec(q[0], q[1], q[2]);
+        uv = cross(qvec, v);
+        uuv = cross(qvec, uv);
+        T two = 2.0;
+        uv *= ( two * q[3] );
         uuv *= two;
         return v + uv + uuv;
     }


### PR DESCRIPTION
Add 2 methods to Quat.

1) Quat * Quat
2) Rotate a vector by a quat

Both methods have been copied from OSG with minor changes to work with VSG. 

Tested by using both methods to turn a vector around multiple axes with the visual results being as expected.
