### PR TITLE
Link libatomic if required

### DIFF
--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CheckCXXSourceCompiles)
+
 # collect all the headers in the source directory
 file(GLOB HEADERS ${CMAKE_SOURCE_DIR}/include/vsg/*.h ${CMAKE_SOURCE_DIR}/include/vsg/*/*.h)
 

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -218,6 +218,20 @@ set(LIBRARIES PUBLIC
         Threads::Threads
 )
 
+# Check for std::atomic
+if(NOT MSVC AND NOT ANDROID AND NOT APPLE)
+  set(HAVE_CXX_ATOMIC_WITHOUT_LIB FALSE)
+  check_cxx_source_compiles("
+    #include <atomic>
+    std::atomic a;
+    int main() { return a; }"
+  HAVE_CXX_ATOMIC_WITHOUT_LIB)
+  if(NOT HAVE_CXX_ATOMIC_WITHOUT_LIB)
+    find_library(CXX_ATOMIC_LIBRARIES NAMES atomic atomic.so.1 libatomic.so.1 REQUIRED)
+    list(APPEND LIBRARIES ${CXX_ATOMIC_LIBRARIES})
+  endif()
+endif()
+
 if (glslang_FOUND)
     set(LIBRARIES ${LIBRARIES} PUBLIC ${glslang_LIBRARIES})
 


### PR DESCRIPTION

To resolve build error from #446 

Tested on pi 4, with 32 and 64-bit Raspbian, gcc 10.2.1.
(32-bit needs -latomic, 64-bit doesn't)

I haven't been able to test on other platforms yet. It should be okay but there's a lot of combinations..
* No impact on windows - not relevant
* Android excluded for now - I think the Android SDK takes care of this automatically, when the C++ runtime is selected
* I'm not sure if the check should be present for Apple, but it could be. Probably safest not to check for now, unless someone hits the same issue?
* I Haven't explicitly tested with Clang, but it should be a valid check there.
