### PR TITLE
Link to Android log library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 
 if (ANDROID)
     find_library(AndroidLib android)
+    find_library(AndroidLogLib log)
     if(CMAKE_SYSTEM_VERSION GREATER 24)
         find_library(AndroidNativeWindowLib nativewindow)
     endif()

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -275,9 +275,9 @@ if (ANDROID)
     set(SOURCES ${SOURCES} platform/android/Android_Window.cpp)
 
     if(CMAKE_SYSTEM_VERSION GREATER 24)
-        set(LIBRARIES ${LIBRARIES} PRIVATE ${AndroidLib} PRIVATE ${AndroidNativeWindowLib})
+        set(LIBRARIES ${LIBRARIES} PRIVATE ${AndroidLib} PRIVATE ${AndroidLogLib} PRIVATE ${AndroidNativeWindowLib})
     else()
-        set(LIBRARIES ${LIBRARIES} PRIVATE ${AndroidLib})
+        set(LIBRARIES ${LIBRARIES} PRIVATE ${AndroidLib} PRIVATE ${AndroidLogLib})
     endif()
 
 elseif (WIN32)


### PR DESCRIPTION
## Description
Fixes link errors on Android, combined with vulkan compatibility changes should result in a functional library.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- Only impact is to Android builds

## How Has This Been Tested?

Tested so far by building shared libs, for android platform 24 (oldest supporting vulkan) and newer. Unable to test vsgExamples/Android at this time.

Build command: `cmake -DCMAKE_INSTALL_PREFIX=../../install_android/armeabi-v7a -DCMAKE_TOOLCHAIN_FILE=~/Android/Sdk/ndk/24.0.8215888/build/cmake/android.toolchain.cmake -DANDROID_ABI=armeabi-v7a -DANDROID_PLATFORM=android-24 -DBUILD_SHARED_LIBS=ON ../`

