### PR TITLE
Fix Windows build with UNICODE defined

### DIFF
--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -285,9 +285,9 @@ Path vsg::executableFilePath()
     Path path;
 
 #if defined(WIN32)
-    char buf[PATH_MAX + 1];
-    DWORD result = GetModuleFileName(NULL, buf, sizeof(buf) - 1);
-    if (result && result < sizeof(buf))
+    TCHAR buf[PATH_MAX + 1];
+    DWORD result = GetModuleFileName(NULL, buf, std::size(buf) - 1);
+    if (result && result < std::size(buf))
         path = buf;
 #elif defined(__linux__)
     // TODO need to handle case where executable filename is longer than PATH_MAX

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -312,6 +312,16 @@ Win32_Window::Win32_Window(vsg::ref_ptr<WindowTraits> traits) :
 {
     _keyboard = new KeyboardMap;
 
+#ifdef UNICODE
+    std::wstring windowClass;
+    convert_utf(traits->windowClass, windowClass);
+    std::wstring windowTitle;
+    convert_utf(traits->windowTitle, windowTitle);
+#else
+    const auto& windowClass = traits->windowClass;
+    const auto& windowTitle = traits->windowTitle;
+#endif
+
     // register window class
     WNDCLASSEX wc;
     wc.cbSize = sizeof(WNDCLASSEX);
@@ -324,7 +334,7 @@ Win32_Window::Win32_Window(vsg::ref_ptr<WindowTraits> traits) :
     wc.hCursor = LoadCursor(NULL, IDC_ARROW);
     wc.hbrBackground = 0;
     wc.lpszMenuName = 0;
-    wc.lpszClassName = traits->windowClass.c_str();
+    wc.lpszClassName = windowClass.c_str();
     wc.hIconSm = 0;
 
     if (::RegisterClassEx(&wc) == 0)
@@ -379,7 +389,7 @@ Win32_Window::Win32_Window(vsg::ref_ptr<WindowTraits> traits) :
         {
             windowStyle |= WS_OVERLAPPEDWINDOW;
 
-            extendedStyle |= WS_EX_WINDOWEDGE | 
+            extendedStyle |= WS_EX_WINDOWEDGE |
                 WS_EX_APPWINDOW |
                 WS_EX_OVERLAPPEDWINDOW |
                 WS_EX_ACCEPTFILES |
@@ -402,7 +412,7 @@ Win32_Window::Win32_Window(vsg::ref_ptr<WindowTraits> traits) :
     }
 
     // create the window
-    _window = ::CreateWindowEx(extendedStyle, traits->windowClass.c_str(), traits->windowTitle.c_str(), windowStyle,
+    _window = ::CreateWindowEx(extendedStyle, windowClass.c_str(), windowTitle.c_str(), windowStyle,
                                windowRect.left, windowRect.top, windowRect.right - windowRect.left, windowRect.bottom - windowRect.top,
                                NULL, NULL, ::GetModuleHandle(NULL), NULL);
 


### PR DESCRIPTION
## Description

Fixes compilation on WIndows when UNICODE is defined. In this case, macros resolve to functions accepting wchar_t.
Changes made should be hopefully least invasive way to fix this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Defined additional compile definition `UNICODE` on Windows platform.
Master does not compile while PR does.

