### PR TITLE
[ADDED] overridePipelineStates to vsg::View

### DIFF
--- a/include/vsg/viewer/View.h
+++ b/include/vsg/viewer/View.h
@@ -63,6 +63,9 @@ namespace vsg
         /// view dependent state used for positional state like lighting, texgen and clipping
         ref_ptr<ViewDependentState> viewDependentState;
 
+        /// override states for customization of graphics pipelines for this view
+        GraphicsPipelineStates overridePipelineStates;
+
     protected:
         virtual ~View();
     };

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -291,18 +291,17 @@ void CompileTraversal::apply(View& view)
         context->viewDependentState = view.viewDependentState.get();
         if (view.viewDependentState) view.viewDependentState->compile(*context);
 
+        auto previousOverridePipelineStates = context->overridePipelineStates;
+        auto previousDefaultPipelineStates = context->defaultPipelineStates;
+
         if (view.camera && view.camera->viewportState)
-        {
             context->defaultPipelineStates.emplace_back(view.camera->viewportState);
+        context->overridePipelineStates.insert(context->overridePipelineStates.end(), view.overridePipelineStates.begin(), view.overridePipelineStates.end());
 
-            view.traverse(*this);
+        view.traverse(*this);
 
-            context->defaultPipelineStates.pop_back();
-        }
-        else
-        {
-            view.traverse(*this);
-        }
+        context->defaultPipelineStates = previousDefaultPipelineStates;
+        context->overridePipelineStates = previousOverridePipelineStates;
     }
 }
 

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -95,6 +95,8 @@ void CompileTraversal::add(Window& window, ref_ptr<View> view, const ResourceReq
 
     if (renderPass->maxSamples != VK_SAMPLE_COUNT_1_BIT) context->overridePipelineStates.emplace_back(vsg::MultisampleState::create(renderPass->maxSamples));
 
+    context->overridePipelineStates.insert(context->overridePipelineStates.end(), view->overridePipelineStates.begin(), view->overridePipelineStates.end());
+
     auto viewportState = view->camera->viewportState;
     if (viewportState) context->defaultPipelineStates.emplace_back(viewportState);
 
@@ -116,6 +118,8 @@ void CompileTraversal::add(Framebuffer& framebuffer, ref_ptr<View> view, const R
     context->graphicsQueue = device->getQueue(queueFamily);
 
     if (renderPass->maxSamples != VK_SAMPLE_COUNT_1_BIT) context->overridePipelineStates.emplace_back(vsg::MultisampleState::create(renderPass->maxSamples));
+
+    context->overridePipelineStates.insert(context->overridePipelineStates.end(), view->overridePipelineStates.begin(), view->overridePipelineStates.end());
 
     auto viewportState = view->camera->viewportState;
     if (viewportState) context->defaultPipelineStates.emplace_back(viewportState);


### PR DESCRIPTION
# Pull Request Template

## Description

Added overridePipelineStates to vsg::View for configuring alternate rendering pathways like early-Z pass, shadow mapping, deferred shading etc.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Shadow mapping class in our application

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
