### PR TITLE
[ADDED] frameBuffer to CommandGraph

### DIFF
--- a/include/vsg/viewer/CommandGraph.h
+++ b/include/vsg/viewer/CommandGraph.h
@@ -30,6 +30,7 @@ namespace vsg
 
         // settings, configure at construction time
         ref_ptr<Window> window;
+        ref_ptr<Framebuffer> framebuffer;
         ref_ptr<Device> device;
         ref_ptr<Camera> camera;
 

--- a/src/vsg/traversals/CompileTraversal.cpp
+++ b/src/vsg/traversals/CompileTraversal.cpp
@@ -218,34 +218,48 @@ void CompileTraversal::apply(Geometry& geometry)
 
 void CompileTraversal::apply(CommandGraph& commandGraph)
 {
-    if (commandGraph.window)
+    uint32_t samples = VK_SAMPLE_COUNT_1_BIT;
+    vsg::RenderPass* renderpass = nullptr;
+    VkExtent2D renderArea{};
+    if (commandGraph.framebuffer)
     {
-        for (auto& context : contexts)
-        {
-            context->renderPass = commandGraph.window->getOrCreateRenderPass();
-
-            context->defaultPipelineStates.push_back(ViewportState::create(commandGraph.window->extent2D()));
-
-            if (commandGraph.window->framebufferSamples() != VK_SAMPLE_COUNT_1_BIT)
-            {
-                ref_ptr<MultisampleState> defaultMsState = MultisampleState::create(commandGraph.window->framebufferSamples());
-                context->overridePipelineStates.push_back(defaultMsState);
-            }
-
-            // save previous states to be restored after traversal
-            auto previousDefaultPipelineStates = context->defaultPipelineStates;
-            auto previousOverridePipelineStates = context->overridePipelineStates;
-
-            commandGraph.traverse(*this);
-
-            // restore previous values
-            context->defaultPipelineStates = previousDefaultPipelineStates;
-            context->overridePipelineStates = previousOverridePipelineStates;
-        }
+        samples = commandGraph.framebuffer->getRenderPass()->maxSamples;
+        renderpass = commandGraph.framebuffer->getRenderPass();
+        renderArea = {commandGraph.framebuffer->width(), commandGraph.framebuffer->height()};
+    }
+    else if (commandGraph.window)
+    {
+        samples = commandGraph.window->framebufferSamples();
+        renderpass = commandGraph.window->getOrCreateRenderPass();
+        renderArea = commandGraph.window->extent2D();
     }
     else
     {
         commandGraph.traverse(*this);
+        return;
+    }
+
+    for (auto& context : contexts)
+    {
+        context->renderPass = renderpass;
+
+        // save previous states to be restored after traversal
+        auto previousDefaultPipelineStates = context->defaultPipelineStates;
+        auto previousOverridePipelineStates = context->overridePipelineStates;
+
+        context->defaultPipelineStates.push_back(ViewportState::create(renderArea));
+
+        if (samples != VK_SAMPLE_COUNT_1_BIT)
+        {
+            ref_ptr<MultisampleState> defaultMsState = MultisampleState::create(commandGraph.window->framebufferSamples());
+            context->overridePipelineStates.push_back(defaultMsState);
+        }
+
+        commandGraph.traverse(*this);
+
+        // restore previous values
+        context->defaultPipelineStates = previousDefaultPipelineStates;
+        context->overridePipelineStates = previousOverridePipelineStates;
     }
 }
 

--- a/src/vsg/viewer/SecondaryCommandGraph.cpp
+++ b/src/vsg/viewer/SecondaryCommandGraph.cpp
@@ -120,7 +120,13 @@ void SecondaryCommandGraph::record(CommandBuffers& recordedCommandBuffers, ref_p
     inheritanceInfo.pipelineStatistics = pipelineStatistics;
     beginInfo.pInheritanceInfo = &inheritanceInfo;
 
-    if (window)
+    if (framebuffer)
+    {
+        inheritanceInfo.renderPass = *(framebuffer->getRenderPass());
+        inheritanceInfo.subpass = subpass;
+        inheritanceInfo.framebuffer = *framebuffer;
+    }
+    else if (window)
     {
         inheritanceInfo.renderPass = *(window->getRenderPass());
         inheritanceInfo.subpass = subpass;


### PR DESCRIPTION


## Description

Added frameBuffer to CommandGraph for use with compile contexts that don't have a window, like headless or offscreen command graphs

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Off screen secondary command graphs used for shadow mapping in our application

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
