### PR TITLE
[FIXED] DescriptorPool crash

### DIFF
--- a/src/vsg/vk/DescriptorPool.cpp
+++ b/src/vsg/vk/DescriptorPool.cpp
@@ -73,6 +73,12 @@ ref_ptr<DescriptorSet::Implementation> DescriptorPool::allocateDescriptorSet(Des
         }
     }
 
+    if (_availableDescriptorSet ==  _reclingList.size())
+    {
+        //vsg::debug(" DescriptorPool is exhausted and no compatible descriptor sets to recycle");
+        return {};
+    }
+
     size_t matches = 0;
     for (auto& [type, descriptorCount] : descriptorPoolSizes)
     {


### PR DESCRIPTION
## Description

Fixed DescriptorPool crash when the pool is exhausted and existing descriptor sets can't be recycled

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

https://github.com/siystar/vsgExamples/tree/test_descriptorpool

```
Unable to allocate 1 descriptorSets from VkDescriptorPool
0x66a000000066a[]. This pool only has 0 descriptorSets remaining"
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
