### PR TITLE
[ADDED] convenience constructor to create and bind a descriptor set

### DIFF
--- a/include/vsg/state/BindDescriptorSet.h
+++ b/include/vsg/state/BindDescriptorSet.h
@@ -105,6 +105,15 @@ namespace vsg
         {
         }
 
+        BindDescriptorSet(VkPipelineBindPoint in_bindPoint, PipelineLayout* in_pipelineLayout, uint32_t in_firstSet, const vsg::Descriptors& in_descriptors) :
+            Inherit(1 + in_firstSet),
+            pipelineBindPoint(in_bindPoint),
+            layout(in_pipelineLayout),
+            firstSet(in_firstSet),
+            descriptorSet(vsg::DescriptorSet::create(in_pipelineLayout->setLayouts[in_firstSet], in_descriptors))
+        {
+        }
+
         // vkCmdBindDescriptorSets settings
         VkPipelineBindPoint pipelineBindPoint; // TODO not currently serialized
         ref_ptr<PipelineLayout> layout;

--- a/src/vsg/io/tile.cpp
+++ b/src/vsg/io/tile.cpp
@@ -375,12 +375,11 @@ vsg::ref_ptr<vsg::Node> tile::createECEFTile(const vsg::dbox& tile_extents, vsg:
     // create texture image and associated DescriptorSets and binding
     auto texture = vsg::DescriptorImage::create(sampler, textureData, 0, 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 
-    auto descriptorSet = vsg::DescriptorSet::create(descriptorSetLayout, vsg::Descriptors{texture});
-    auto bindDescriptorSets = vsg::BindDescriptorSets::create(VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, vsg::DescriptorSets{descriptorSet});
+    auto bindDescriptorSet = vsg::BindDescriptorSet::create(VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, vsg::Descriptors{texture});
 
     // create StateGroup to bind any texture state
     auto scenegraph = vsg::StateGroup::create();
-    scenegraph->add(bindDescriptorSets);
+    scenegraph->add(bindDescriptorSet);
 
     // set up model transformation node
     auto transform = vsg::MatrixTransform::create(localToWorld); // VK_SHADER_STAGE_VERTEX_BIT
@@ -467,12 +466,11 @@ vsg::ref_ptr<vsg::Node> tile::createTextureQuad(const vsg::dbox& tile_extents, v
     // create texture image and associated DescriptorSets and binding
     auto texture = vsg::DescriptorImage::create(sampler, textureData, 0, 0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 
-    auto descriptorSet = vsg::DescriptorSet::create(descriptorSetLayout, vsg::Descriptors{texture});
-    auto bindDescriptorSets = vsg::BindDescriptorSets::create(VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, vsg::DescriptorSets{descriptorSet});
+    auto bindDescriptorSet = vsg::BindDescriptorSet::create(VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, vsg::Descriptors{texture});
 
     // create StateGroup to bind any texture state
     auto scenegraph = vsg::StateGroup::create();
-    scenegraph->add(bindDescriptorSets);
+    scenegraph->add(bindDescriptorSet);
 
     // set up model transformation node
     auto transform = vsg::MatrixTransform::create(); // VK_SHADER_STAGE_VERTEX_BIT


### PR DESCRIPTION
# Pull Request Template

## Description

Added convenience constructor to create and bind a descriptor set from vsg::Descriptors

Motivation is to avoid repeated specification of the firstSet parameter which may lead to mistakes and bugs

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Updated vsgExamples

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
