### PR TITLE
Check that angle between animation up vectors is valid

### DIFF
--- a/src/vsg/viewer/Trackball.cpp
+++ b/src/vsg/viewer/Trackball.cpp
@@ -438,7 +438,7 @@ void Trackball::apply(FrameEvent& frame)
                 _lookAt->center = mix(_startLookAt->center, _endLookAt->center, r);
 
                 double angle = acos(dot(_startLookAt->up, _endLookAt->up) / (length(_startLookAt->up) * length(_endLookAt->up)));
-                if (angle != 0.0)
+                if (angle > 1.0e-6)
                 {
                     auto rotation = vsg::rotate(angle * r, normalize(cross(_startLookAt->up, _endLookAt->up)));
                     _lookAt->up = rotation * _startLookAt->up;


### PR DESCRIPTION
If you call trackball->setViewpoint(lookAt) with the same up vector as the current value of up vector, then the angle calculation intermittently returns nan or 0.0. Current code only checks if angle != 0.0, with nan taking the code path for valid (non-parallel) angles. This change instead checks for angle > 1.0e-6 to ensure the angle is valid.

Checked on Kubuntu 22.04.
