### PR TITLE
[FIXED] invalid use of VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT

### DIFF
--- a/src/vsg/state/Image.cpp
+++ b/src/vsg/state/Image.cpp
@@ -74,8 +74,7 @@ Image::Image(ref_ptr<Data> in_data) :
             /* flags = VK_IMAGE_CREATE_1D_ARRAY_COMPATIBLE_BIT; // comment out as Vulkan headers don't yet provide this. */
             break;
         case (VK_IMAGE_VIEW_TYPE_2D_ARRAY):
-            imageType = VK_IMAGE_TYPE_3D;
-            flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
+            imageType = VK_IMAGE_TYPE_2D;
             arrayLayers = depth;
             depth = 1;
             break;


### PR DESCRIPTION

## Description

Fixed validation errors by removing unnecessary assignment of VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT. This flag is not used in any of Sascha Willem's vulkanexamples.

```
* VUID-VkImageViewCreateInfo-image-02724
If image is a 3D image created with VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT set, and viewType is VK_IMAGE_VIEW_TYPE_2D or VK_IMAGE_VIEW_TYPE_2D_ARRAY, subresourceRange.baseArrayLayer must be less than the depth computed from baseMipLevel and extent.depth specified in VkImageCreateInfo when image was created, according to the formula defined in Image Miplevel Sizing

[...]
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* https://github.com/siystar/vsgExamples/tree/test_2darray
* Application

```
Validation Error: [ VUID-vkCmdCopyBufferToImage-baseArrayLayer-00213 ] Object 0: handle = [..], type = VK_OBJECT_TYPE_IMAGE; | MessageID = [..] | vkCmdCopyBufferToImage(): pRegion[31] imageSubresource.baseArrayLayer is 31 and imageSubresource.layerCount is 1. For 3D images these must be 0 and 1, respectively. The Vulkan spec states: If {imageparam} is of type VK_IMAGE_TYPE_3D, for each element of pRegions, imageSubresource.baseArrayLayer must be 0 and imageSubresource.layerCount must be 1 (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-vkCmdCopyBufferToImage-baseArrayLayer-00213)
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
