### PR TITLE
Fix build error with glslang > 11.11.0

### DIFF
--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -303,6 +303,23 @@ if (glslang_FOUND)
         set(EXTRA_DEFINES ${EXTRA_DEFINES} "GLSLANG_EShLangRayGenNV")
     endif()
 
+    if (NOT DEFINED GLSLANG_ResourceLimits_maxMeshViewCountEXT)
+        check_cxx_source_compiles("
+            #include <glslang/Include/ResourceLimits.h>
+
+            int main()
+            {
+                TBuiltInResource resource;
+                resource.maxMeshViewCountEXT = 0;
+                return 0;
+            }
+        " GLSLANG_ResourceLimits_maxMeshViewCountEXT)
+    endif()
+
+    if (GLSLANG_ResourceLimits_maxMeshViewCountEXT)
+        set(EXTRA_DEFINES ${EXTRA_DEFINES} "GLSLANG_ResourceLimits_maxMeshViewCountEXT")
+    endif()
+
     install(
         FILES vsg_glslangConfig.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vsg_glslang

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -269,6 +269,10 @@ if (glslang_FOUND)
         " GLSLANG_ResourceLimits_maxDualSourceDrawBuffersEXT)
     endif()
 
+    if (GLSLANG_ResourceLimits_maxDualSourceDrawBuffersEXT)
+        set(EXTRA_DEFINES ${EXTRA_DEFINES} "GLSLANG_ResourceLimits_maxDualSourceDrawBuffersEXT")
+    endif()
+
     if (NOT GLSLANG_EShLanguage_EShLangRayGen)
         check_cxx_source_compiles("
             #include <glslang/Public/ShaderLang.h>
@@ -297,11 +301,6 @@ if (glslang_FOUND)
         set(EXTRA_DEFINES ${EXTRA_DEFINES} "GLSLANG_EShLangRayGen")
     elseif (GLSLANG_EShLanguage_EShLangRayGenNV)
         set(EXTRA_DEFINES ${EXTRA_DEFINES} "GLSLANG_EShLangRayGenNV")
-    endif()
-
-    # check whether glslang/build_info.h exists
-    if (GLSLANG_ResourceLimits_maxDualSourceDrawBuffersEXT)
-        set(EXTRA_DEFINES ${EXTRA_DEFINES} "GLSLANG_ResourceLimits_maxDualSourceDrawBuffersEXT")
     endif()
 
     install(

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -257,7 +257,7 @@ if (glslang_FOUND)
     set(CMAKE_REQUIRED_INCLUDES ${glslang_INCLUDE_DIR})
 
     if (NOT GLSLANG_ResourceLimits_maxDualSourceDrawBuffersEXT)
-        check_cxx_source_runs("
+        check_cxx_source_compiles("
             #include <glslang/Include/ResourceLimits.h>
 
             int main()
@@ -270,7 +270,7 @@ if (glslang_FOUND)
     endif()
 
     if (NOT GLSLANG_EShLanguage_EShLangRayGen)
-        check_cxx_source_runs("
+        check_cxx_source_compiles("
             #include <glslang/Public/ShaderLang.h>
 
             int main()
@@ -282,7 +282,7 @@ if (glslang_FOUND)
     endif()
 
     if (NOT GLSLANG_EShLanguage_EShLangRayGenNV)
-        check_cxx_source_runs("
+        check_cxx_source_compiles("
             #include <glslang/Public/ShaderLang.h>
 
             int main()

--- a/src/vsg/utils/ResourceLimits.cpp
+++ b/src/vsg/utils/ResourceLimits.cpp
@@ -138,6 +138,18 @@ namespace glslang
         /* .maxTaskWorkGroupSizeZ_NV = */ 1,
         /* .maxMeshViewCountNV = */ 4,
 
+#ifdef GLSLANG_ResourceLimits_maxMeshViewCountEXT
+        /* .maxMeshOutputVerticesEXT= */ 1,
+        /* .maxMeshOutputPrimitivesEXT= */ 1,
+        /* .maxMeshWorkGroupSizeX_EXT= */ 1,
+        /* .maxMeshWorkGroupSizeY_EXT= */ 1,
+        /* .maxMeshWorkGroupSizeZ_EXT= */ 1,
+        /* .maxTaskWorkGroupSizeX_EXT= */ 1,
+        /* .maxTaskWorkGroupSizeY_EXT= */ 1,
+        /* .maxTaskWorkGroupSizeZ_EXT= */ 1,
+        /* .maxMeshViewCountEXT= */ 1,
+#endif
+
 #ifdef GLSLANG_ResourceLimits_maxDualSourceDrawBuffersEXT
         /*.maxDualSourceDrawBuffersEXT =*/1,
 #endif


### PR DESCRIPTION
## Description
Fixes a build error with glslang > 11.11.0 and contains a small simplification of checking variables of the TBuiltInResource class

Fixes # 512

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with a build from vsgFramework on a linux host

**Test Configuration**:
* OS: openSUSE Leap 15.3
* Toolchain: gcc 7.5

## Checklist:
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules (see https://github.com/vsg-dev/vsgFramework/pull/7)
