### PR TITLE
Use cmake find_package support to find SPIRV-Tools and SPIRV-Tools-opt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        vulkan-version: [1.2.162.1, latest]
+        vulkan-version: [1.3.224.1, latest]
         build-shared: [OFF]
         include:
           - build-shared: ON
             os: windows-latest
-            vulkan-version: 1.2.162.1
+            vulkan-version: 1.3.224.1
     continue-on-error: ${{ matrix.vulkan-version == 'latest' }}
           
     steps:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,7 @@
 
 ## Optional dependenices
 
-* [glslang & SPIRV-Tools](https://github.com/KhronosGroup/glslang) are required when built-in GLSL -> SPIR-V (required by Vulkan) compilation is needed, such as when you need the VulkanSceneGraphs shader composition and compilation capailities. SPIRV-Tools is built as part of glslang but can be packaged separately on common linux distributions. VulkanSDK provides glslang. Unless you know you don't require them for your application we recommend building the VulkanSceneGraph with glslang and SPIRV-Tools.
+* [glslang & SPIRV-Tools](https://github.com/KhronosGroup/glslang) are required when built-in GLSL -> SPIR-V (required by Vulkan) compilation is needed, such as when you need the VulkanSceneGraphs shader composition and compilation capailities. SPIRV-Tools nowadays is packaged separately on common linux distributions, but can be build as part of glslang. VulkanSDK provides glslang. Unless you know you don't require them for your application we recommend building the VulkanSceneGraph with glslang and SPIRV-Tools.
 
 ---
 

--- a/src/vsg/vsg_glslangConfig.cmake
+++ b/src/vsg/vsg_glslangConfig.cmake
@@ -1,8 +1,8 @@
 #.rst:
-# Findglslang
+# vsg_glslangConfig.cmake
 # ----------
 #
-# Try to find glslang in the VulkanSDK
+# Try to find glslang, SPIRV-Tools and SPIRV-Tools-opt in the VulkanSDK
 #
 # IMPORTED Targets
 # ^^^^^^^^^^^^^^^^
@@ -18,6 +18,10 @@
 #   glslang_FOUND          - True if glslang was found
 #   glslang_INCLUDE_DIRS   - include directories for glslang
 #   glslang_LIBRARIES      - link against this library to use glslang
+#
+#  In case SPIRV tools packages with cmake support files are installed,
+#  additional cmake variables are defined with the 'SPIRV-Tools*_' prefix.
+#  See the named packages for details.
 #
 # The module will also define two cache variables::
 #
@@ -44,6 +48,9 @@ if (DEFINED ENV{VULKAN_SDK})
         set(ADDITIONAL_PATHS_LIBS "$ENV{VULKAN_SDK}/lib")
     endif()
 endif()
+
+find_package(SPIRV-Tools)
+find_package(SPIRV-Tools-opt)
 
 find_path(glslang_INCLUDE_DIR
     NAMES glslang/Public/ShaderLang.h


### PR DESCRIPTION
Newer versions of the above mentioned packages support cmake natively, which simplifies the inclusion of these packages.

See https://github.com/vsg-dev/vsgFramework/pull/7#issuecomment-1243386390

> It would be worth trying out your changes to the find_package
> glslang, spirv-tools and spirv-tools-opt as a PR against vsg-dev/VulkanSceneGraph so
> I can merge it as a branch so that others can test it out.

Note: glslang is not added because of missing features, see https://github.com/KhronosGroup/glslang/pull/3028 and https://github.com/KhronosGroup/glslang/pull/3027

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tested with a build from VulkanSceneGraph on a linux host

**Test Configuration**:
* OS: openSUSE Leap 15.3
* Toolchain: gcc 7.5

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
