### PR TITLE
#515 Fix C-Linkage warning on MacOS

### DIFF
--- a/src/vsg/core/Version.cpp
+++ b/src/vsg/core/Version.cpp
@@ -17,7 +17,7 @@ extern "C"
 
     VsgVersion vsgGetVersion()
     {
-        VsgVersion version;
+        VsgVersion version{};
         version.major = VSG_VERSION_MAJOR;
         version.minor = VSG_VERSION_MINOR;
         version.patch = VSG_VERSION_PATCH;

--- a/src/vsg/core/Version.h.in
+++ b/src/vsg/core/Version.h.in
@@ -31,10 +31,10 @@ extern "C"
 
     struct VsgVersion
     {
-        unsigned int major = 0;
-        unsigned int minor = 0;
-        unsigned int patch = 0;
-        unsigned int soversion = 0;
+        unsigned int major;
+        unsigned int minor;
+        unsigned int patch;
+        unsigned int soversion;
     };
 
     extern VSG_DECLSPEC struct VsgVersion vsgGetVersion();


### PR DESCRIPTION
Fixes #515 

## Description

C-Linkage does not like initialising the values of the struct to 0, to work around this, we initialise with {} in Version.cpp

