### PR TITLE
Avoid a bug introduced by Apple

### DIFF
--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -792,8 +792,8 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     [_window setDelegate:windowDelegate];
 
     [_window setTitle:[NSString stringWithUTF8String:traits->windowTitle.c_str()]];
-    [_window setAcceptsMouseMovedEvents:NO];
-    [_window setRestorable:NO];
+    [_window setAcceptsMouseMovedEvents:YES];
+    [_window setRestorable:YES];
     [_window setOpaque:YES];
     [_window setBackgroundColor:[NSColor whiteColor]];
 
@@ -836,7 +836,7 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     pos.y = ymax-std::clamp(traits->y,0,ymax);
     // show
     [_window setFrame:CGRectMake(pos.x, pos.y, [_window frame].size.width , [_window frame].size.height) display:YES];
-
+    
     //vsgMacOS::createApplicationMenus();
     [NSApp activateIgnoringOtherApps:YES];
     [_window makeKeyAndOrderFront:nil];


### PR DESCRIPTION
macOS 13 (Ventura). Imgui based programs ignore mouse activities in the gui after startup. Modified macOS window flags avoid this. So the gui work as expected after startup.

# Pull Request Template

## Description

With macOS 13 (Ventura), imGui based programs show a weird behavior. Mouse clicks are ignored unless a window move event occurs. Other projects like Sokol (https://github.com/floooh/sokol.git) don't have this problem. A look into their macOS windows code showed a difference in the windows properties.

Fixes # (issue)
Changed two lines in MacOS_Window.mm:
795:    [_window setAcceptsMouseMovedEvents:YES];
796:    [_window setRestorable:YES];

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: vsgimgui_example
- [x] Test B: chrono_vsg

**Test Configuration**:
* Firmware version:
* Hardware: MacStudio 2022
* Toolchain: Xcode 14.01
* SDK: macosx12.3

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
