### PR TITLE
Include vsgMacros.cmake in client packages by default

### DIFF
--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -6,7 +6,6 @@
 if(NOT _vsg_macros_included)
     message(STATUS "Reading 'vsg_...' macros from ${CMAKE_CURRENT_LIST_DIR}/vsgMacros.cmake - look there for documentation")
     set(_vsg_macros_included 1)
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 endif()
 
 #

--- a/src/vsg/vsgConfig.cmake.in
+++ b/src/vsg/vsgConfig.cmake.in
@@ -18,3 +18,4 @@ else()
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/vsgTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/vsgMacros.cmake")


### PR DESCRIPTION
## Description
With this commit, vsgMacros.cmake is included by cmake by default after calling find_package(vsg) in a vsg-dependent project, making the associated macros available by default and thus eliminating the need to include a local copy of vsgMacros.cmake.
See at https://groups.google.com/g/vsg-users/c/-hjyXrDHXZA/m/t1RCJgc5AQAJ

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Applied to local copies of the git-repos from the vsg-dev namespace and performed a build in "single package" mode and with vsgFrameworks.

**Test Configuration**:
* openSUSE Leap 15.4
* Toolchain: gcc-11

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (pending)
