### PR TITLE
Fix cmake features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,21 @@ endif()
 # this line needs to be after the call to setup_build_vars()
 configure_file("${VSG_SOURCE_DIR}/src/vsg/core/Version.h.in" "${VSG_VERSION_HEADER}")
 
+vsg_add_target_clang_format(
+    FILES
+        ${VSG_SOURCE_DIR}/include/vsg/*/*.h
+        ${VSG_SOURCE_DIR}/src/vsg/*/*.cpp
+)
+vsg_add_target_clobber()
+vsg_add_target_cppcheck(
+    SUPPRESSIONS_LIST
+        "${VSG_SOURCE_DIR}/cmake/cppcheck-suppression-list.txt"
+    FILES
+        ${CMAKE_SOURCE_DIR}/include/vsg/*/*.h
+        ${VSG_SOURCE_DIR}/src/vsg/*/*.cpp
+        -I ${VSG_SOURCE_DIR}/include/
+)
+vsg_add_target_uninstall()
 vsg_add_target_docs(
     FILES
         ${VSG_SOURCE_DIR}/include/vsg
@@ -80,23 +95,6 @@ if (${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
         COMMAND ${CMAKE_COMMAND} -P ${VSG_SOURCE_DIR}/cmake/build_all_h.cmake
     )
     set_target_properties(build_all_h PROPERTIES FOLDER "VulkanSceneGraph")
-
-    vsg_add_target_clobber()
-    vsg_add_target_uninstall()
-    vsg_add_target_cppcheck(
-        SUPPRESSIONS_LIST
-            "${VSG_SOURCE_DIR}/cmake/cppcheck-suppression-list.txt"
-        FILES
-            ${CMAKE_SOURCE_DIR}/include/vsg/*/*.h
-            ${VSG_SOURCE_DIR}/src/vsg/*/*.cpp
-            -I ${VSG_SOURCE_DIR}/include/
-    )
-
-    vsg_add_target_clang_format(
-        FILES
-            ${VSG_SOURCE_DIR}/include/vsg/*/*.h
-            ${VSG_SOURCE_DIR}/src/vsg/*/*.cpp
-    )
 
     vsg_add_option_maintainer(
         PREFIX VulkanSceneGraph

--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -331,9 +331,9 @@ endmacro()
 macro(vsg_add_target_uninstall)
     # we are running inside VulkanSceneGraph
     if (PROJECT_NAME STREQUAL "vsg")
-        # install file for client packages
-        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/uninstall.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/vsg)
         set(DIR ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+    elseif(vsg_DIR)
+        set(DIR ${vsg_DIR})
     else()
         set(DIR ${CMAKE_CURRENT_LIST_DIR})
     endif()

--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -234,12 +234,16 @@ macro(vsg_add_target_clang_format)
         foreach(EXCLUDE ${ARGS_EXCLUDES})
             list(REMOVE_ITEM FILES_TO_FORMAT ${EXCLUDE})
         endforeach()
-        add_custom_target(clang-format
+        if (NOT TARGET clang-format)
+            add_custom_target(clang-format)
+        endif()
+        add_custom_target(clang-format-${PROJECT_NAME}
             COMMAND ${CLANGFORMAT} -i ${FILES_TO_FORMAT}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT "Automated code format using clang-format"
         )
-        set_target_properties(clang-format PROPERTIES FOLDER ${PROJECT_NAME})
+        set_target_properties(clang-format-${PROJECT_NAME} PROPERTIES FOLDER ${PROJECT_NAME})
+        add_dependencies(clang-format clang-format-${PROJECT_NAME})
     endif()
 endmacro()
 
@@ -247,10 +251,14 @@ endmacro()
 # add 'clobber' build target to clear all the non git registered files/directories
 #
 macro(vsg_add_target_clobber)
-    add_custom_target(clobber
-        COMMAND git -C ${CMAKE_CURRENT_SOURCE_DIR} clean -d -f -x
+    if (NOT TARGET clobber)
+        add_custom_target(clobber)
+    endif()
+    add_custom_target(clobber-${PROJECT_NAME}
+        COMMAND git -C ${PROJECT_SOURCE_DIR} clean -d -f -x
     )
-    set_target_properties(clobber PROPERTIES FOLDER ${PROJECT_NAME})
+    set_target_properties(clobber-${PROJECT_NAME} PROPERTIES FOLDER ${PROJECT_NAME})
+    add_dependencies(clobber clobber-${PROJECT_NAME})
 endmacro()
 
 #
@@ -285,7 +293,10 @@ macro(vsg_add_target_cppcheck)
             set(SUPPRESSION_LIST "--suppressions-list=${ARGS_SUPPRESSIONS_LIST}")
         endif()
         set(CPPCHECK_EXTRA_OPTIONS "" CACHE STRING "additional commandline options to use when invoking cppcheck")
-        add_custom_target(cppcheck
+        if (NOT TARGET cppcheck)
+            add_custom_target(cppcheck)
+        endif()
+        add_custom_target(cppcheck-${PROJECT_NAME}
             COMMAND ${CPPCHECK} -j ${CPU_CORES} --quiet --enable=style --language=c++
                 ${CPPCHECK_EXTRA_OPTIONS}
                 ${SUPPRESSION_LIST}
@@ -294,6 +305,7 @@ macro(vsg_add_target_cppcheck)
             COMMENT "Static code analysis using cppcheck"
         )
         set_target_properties(cppcheck PROPERTIES FOLDER ${PROJECT_NAME})
+        add_dependencies(cppcheck cppcheck-${PROJECT_NAME})
     endif()
 endmacro()
 
@@ -315,13 +327,16 @@ macro(vsg_add_target_docs)
     if (DOXYGEN_FOUND)
         set(DOXYGEN_GENERATE_HTML YES)
         set(DOXYGEN_GENERATE_MAN NO)
-
+        if (NOT TARGET docs)
+            add_custom_target(docs)
+        endif()
         doxygen_add_docs(
-            docs
+            docs-${PROJECT_NAME}
             ${ARGS_FILES}
             COMMENT "Use doxygen to Generate html documentation"
         )
         set_target_properties(docs PROPERTIES FOLDER ${PROJECT_NAME})
+        add_dependencies(docs docs-${PROJECT_NAME})
     endif()
 endmacro()
 
@@ -337,10 +352,14 @@ macro(vsg_add_target_uninstall)
     else()
         set(DIR ${CMAKE_CURRENT_LIST_DIR})
     endif()
-    add_custom_target(uninstall
+    if (NOT TARGET uninstall)
+        add_custom_target(uninstall)
+    endif()
+    add_custom_target(uninstall-${PROJECT_NAME}
         COMMAND ${CMAKE_COMMAND} -P ${DIR}/uninstall.cmake
     )
-    set_target_properties(uninstall PROPERTIES FOLDER ${PROJECT_NAME})
+    set_target_properties(uninstall-${PROJECT_NAME} PROPERTIES FOLDER ${PROJECT_NAME})
+    add_dependencies(uninstall uninstall-${PROJECT_NAME})
 endmacro()
 
 #

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -456,6 +456,7 @@ install(TARGETS vsg ${INSTALL_TARGETS_DEFAULT_FLAGS})
 install(
     FILES
         "${VSG_SOURCE_DIR}/cmake/FindVulkan.cmake"
+        "${VSG_SOURCE_DIR}/cmake/uninstall.cmake"
         "${VSG_SOURCE_DIR}/cmake/vsgMacros.cmake"
     DESTINATION
         ${CMAKE_INSTALL_LIBDIR}/cmake/vsg


### PR DESCRIPTION
## Description
With the changes from this pull, the `vsg_add_target_xxx` macros now work again with the submodule/fetchcontent build mode.

This is achieved by creating a project-specific cmake target named `x-<project>` (e.g. `docs-vsg`) for each available x in vsg_add_target_x (currently `docs`, `cppcheck`, `clang-format`, `clobber` and 'uninstall') when `vsg_add_target_x()` is called and adding it as a dependency to a parent target named `x` (see [custem-target-deps.pdf](https://github.com/vsg-dev/VulkanSceneGraph/files/9971439/test.pdf) for an example)

To avoid possible conflicts with possibly already existing cmake targets like `docs`, `cppcheck`, `clang-format`, `clobber` and 'uninstall' when they are integrated as submodules into other projects, these parent targets are only created if they do not already exist.

Conversely, if a project already provides a cmake target e.g. named `docs` and builds the documentation with it, the documentation for included vsg[XXX] projects will also be built.

Fixes #565 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Building vsg and vsgXchange with associated changes 
- [x] running some vsg_add_target related target e.g. clang-format and doc
- [x] inspected the resulting cmake dependencies [custom-target-deps.pdf](https://github.com/vsg-dev/VulkanSceneGraph/files/9971439/test.pdf)

**Test Configuration**:
* OS: openSUSE Leap 15.4 x86_64
* Toolchain: gcc

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (pending, needs to be applied afterwards)

## Additional information

- Please note that the changes made by the dependent pull requests listed below are independent of this pull request
- intended for version 1.0.1