### PR TITLE
In cmake macro vsg_add_target_clobber() add special handling for in-source builds

### DIFF
--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -251,14 +251,22 @@ endmacro()
 # add 'clobber' build target to clear all the non git registered files/directories
 #
 macro(vsg_add_target_clobber)
-    if (NOT TARGET clobber)
-        add_custom_target(clobber)
+    # in source builds does not support dependencies here
+    # see https://github.com/vsg-dev/VulkanSceneGraph/pull/566#issuecomment-1312496507
+    if (PROJECT_BINARY_DIR STREQUAL PROJECT_SOURCE_DIR)
+        add_custom_target(clobber
+            COMMAND git -C ${PROJECT_SOURCE_DIR} clean -d -f -x
+        )
+    else()
+        if (NOT TARGET clobber)
+            add_custom_target(clobber)
+        endif()
+        add_custom_target(clobber-${PROJECT_NAME}
+            COMMAND git -C ${PROJECT_SOURCE_DIR} clean -d -f -x
+        )
+        set_target_properties(clobber-${PROJECT_NAME} PROPERTIES FOLDER ${PROJECT_NAME})
+        add_dependencies(clobber clobber-${PROJECT_NAME})
     endif()
-    add_custom_target(clobber-${PROJECT_NAME}
-        COMMAND git -C ${PROJECT_SOURCE_DIR} clean -d -f -x
-    )
-    set_target_properties(clobber-${PROJECT_NAME} PROPERTIES FOLDER ${PROJECT_NAME})
-    add_dependencies(clobber clobber-${PROJECT_NAME})
 endmacro()
 
 #


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes the issue mentioned at https://github.com/vsg-dev/VulkanSceneGraph/pull/566#issuecomment-1312496507

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Tested with a local in source build

**Test Configuration**:
* OS: openSUSE Leap 15.4
* Toolchain: gcc

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
