### PR TITLE
Android_Window: Pass native window handle via WindowTraits::setValue

### DIFF
--- a/include/vsg/platform/android/Android_Window.h
+++ b/include/vsg/platform/android/Android_Window.h
@@ -60,6 +60,21 @@ namespace vsgAndroid
 
 
     /// Android_Window implements Android specific window creation, event handling and vulkan Surface setup.
+    ///
+    /// In order to initialise the window, an ANativeWindow* handle must be provided through WindowTraits,
+    /// provided via the value "nativeWindow".
+    ///
+    /// ```
+    /// // void android_main(struct android_app* app)
+    /// auto traits = vsg::WindowTraits::create();
+    /// traits->setValue("nativeWindow", app->window);
+    /// auto window = vsg::Window::create(traits);
+    /// ```
+    ///
+    /// This window handle may also be provided through WindowTraits::nativeWindow however due to
+    /// the way Android loads shared libraries this is likely to encounter duplicate typeinfo for
+    /// ANativeWindow, and as a result can throw a std::bad_any_cast on later NDK versions and some
+    /// system architectures.
     class Android_Window : public vsg::Inherit<vsg::Window, Android_Window>
     {
     public:

--- a/src/vsg/platform/android/Android_Window.cpp
+++ b/src/vsg/platform/android/Android_Window.cpp
@@ -322,14 +322,22 @@ Android_Window::Android_Window(vsg::ref_ptr<WindowTraits> traits) :
 {
     _keyboard = new KeyboardMap;
 
-    ANativeWindow* nativeWindow = std::any_cast<ANativeWindow*>(traits->nativeWindow);
-
-    if (nativeWindow == nullptr)
+    if( ! traits->getValue("nativeWindow", _window ) )
     {
-        throw Exception{"Error: vsg::Android_Window::Android_Window(...) failed to create Window, traits->nativeHandle is not a valid ANativeWindow.", VK_ERROR_INVALID_EXTERNAL_HANDLE};
+        vsg::log(vsg::Logger::LOGGER_WARN, "Value 'nativeWindow' not provided on WindowTraits object. Falling back to std::any_cast<ANativeWindow*> for Android window setup.");
     }
 
-    _window = nativeWindow;
+    if( _window == nullptr )
+    {
+        ANativeWindow* nativeWindow = std::any_cast<ANativeWindow*>(traits->nativeWindow);
+
+        if (nativeWindow == nullptr)
+        {
+            throw Exception{"Error: vsg::Android_Window::Android_Window(...) failed to create Window, traits->nativeHandle is not a valid ANativeWindow.", VK_ERROR_INVALID_EXTERNAL_HANDLE};
+        }
+
+        _window = nativeWindow;
+    }
 
     // we could get the width height from the window?
     uint32_t finalWidth = traits->width;


### PR DESCRIPTION
## Description

Changes the intended way of initialising Android_Window to pass the ANativeWindow* handle through `traits->setValue("nativeWindow")`

Required to fix window initialisation issues, and avoid using `std::any WindowTraits::nativeWindow` - Various issues with how Android loads shared libraries & generates typeinfo means the older std::any_cast is likely to fail.

Partial fix for https://github.com/vsg-dev/vsgExamples/issues/190

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Implementation is backwards compatible, no interfaces modified.
Android_Window class documentation updated, example applciation to follow shortly.

I've left the original implementation as a fallback, but don't think it can ever work going forward - It seems unlikely that newer Android NDK versions would change the typeinfo / linking approach again.


## How Has This Been Tested?

Ad hoc testing with WIP android example:  https://github.com/geefr/vsgExamples/blob/fix-android-example/examples/platform/vsgandroidnative/app/cpp/main.cpp#L52

Before changes a std::bad_any_cast is thrown during window init, after window initialises correctly.

