### PR TITLE
Fixed defines matching

### DIFF
--- a/src/vsg/utils/ShaderSet.cpp
+++ b/src/vsg/utils/ShaderSet.cpp
@@ -150,7 +150,8 @@ ref_ptr<ArrayState> ShaderSet::getSuitableArrayState(const std::set<std::string>
 {
     for (auto& definesArrayState : definesArrayStates)
     {
-        if (definesArrayState.defines == defines) return definesArrayState.arrayState;
+        bool includes = std::includes(defines.begin(), defines.end(), definesArrayState.defines.begin(), definesArrayState.defines.end());
+        if (includes) return definesArrayState.arrayState;
     }
 
     return {};


### PR DESCRIPTION
## Description

Changed the algorithm for matching defines and ArrayState.

Direct defines sets comparison leads to errors when using additional defines. For example.. when using the texture, instancing and displacement map at the same time, the set of defines will be: { "VSG_DIFFUSE_MAP", "VSG_DISPLACEMENT_MAP", "VSG_INSTANCE_POSITIONS" }, and the search for the desired ArrayState will fail. In the StateGroups generated using vsg::Builder, the ArrayState is not assigned when using an image and an offset map at the same time.

Fixes # (issue)

Fixed null state of the prototypeArrayState array when using an displacement map and a diffuse map (texture image) at the same stategroup.

The definesArrayStates needs to be sorted from more defines to fewer.

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Create mesh using vsgbuilder from the vsgExamples, specify image and displacement map.
Test ArrayState handling using vsgintersection example with generated mesh.
