### PR TITLE
Request discard

### DIFF
--- a/src/vsg/app/CompileManager.cpp
+++ b/src/vsg/app/CompileManager.cpp
@@ -133,13 +133,13 @@ CompileResult CompileManager::compile(ref_ptr<Object> object, ContextSelectionFu
         {
             if (contextSelection(*context)) contexts.push_back(context);
         }
+
+        compileTraversal->contexts.swap(contexts);
     }
     else
     {
         contexts = compileTraversal->contexts;
     }
-
-    compileTraversal->contexts.swap(contexts);
 
     for (auto& context : compileTraversal->contexts)
     {
@@ -166,7 +166,7 @@ CompileResult CompileManager::compile(ref_ptr<Object> object, ContextSelectionFu
 
     compileTraversals->add(compileTraversal);
 
-    compileTraversal->contexts.swap(contexts);
+    // compileTraversal->contexts.swap(contexts);
 
     result.result = VK_SUCCESS;
     return result;

--- a/src/vsg/io/DatabasePager.cpp
+++ b/src/vsg/io/DatabasePager.cpp
@@ -257,7 +257,7 @@ void DatabasePager::request(ref_ptr<PagedLOD> plod)
 
 void DatabasePager::requestDiscarded(PagedLOD* plod)
 {
-    //std::scoped_lock<std::mutex> lock(pendingPagedLODMutex);
+    std::scoped_lock<std::mutex> lock(pendingPagedLODMutex);
     //plod->pending = nullptr;
     plod->requestCount.exchange(0);
     plod->requestStatus.exchange(PagedLOD::NoRequest);

--- a/src/vsg/io/DatabasePager.cpp
+++ b/src/vsg/io/DatabasePager.cpp
@@ -196,6 +196,7 @@ void DatabasePager::start()
                     // compile plod
                     if (auto result = databasePager.compileManager->compile(subgraph))
                     {
+                        std::scoped_lock<std::mutex> lock(databasePager.pendingPagedLODMutex);
                         plod->requestStatus.exchange(PagedLOD::MergeRequest);
 
                         // move to the merge queue;


### PR DESCRIPTION
Regarding issue https://github.com/vsg-dev/VulkanSceneGraph/issues/490 and https://github.com/vsg-dev/VulkanSceneGraph/issues/632.

I'm wondering if a tile/node is being discarded while DatabasePager is trying to compile it?? Several crashes pointed in this direction, but I haven't got the traces to show it.

I've made the changes in this PR and don't think I've seen the same crash since, however it is occasional and I found it difficult to reliably repeat. One change is to reinstate a commented out lock. The other is to add a similar lock.

If you have a reliable way to recreate the crash then it's worth a try - just a suggestion.

Roland
