### PR TITLE
Fix build on macOS for "stat64 is deprecated"

### DIFF
--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -116,6 +116,9 @@ FileType vsg::fileType(const Path& path)
 #if defined(_MSC_VER)
     struct __stat64 stbuf;
     if (_wstat64(path.c_str(), &stbuf) != 0) return FILE_NOT_FOUND;
+#elif defined(__APPLE__)
+    struct stat stbuf;
+    if (stat(path.c_str(), &stbuf) != 0) return FILE_NOT_FOUND;
 #else
     struct stat64 stbuf;
     if (stat64(path.c_str(), &stbuf) != 0 ) return FILE_NOT_FOUND;


### PR DESCRIPTION
## Description

stat64 is deprecated on macOS. It causes build failure on Apple Silicon based systems. stat should be used instead of stat64.

Fixes #637

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local machine build

**Test Configuration**:
* OS: Mac OS Ventura
* HW: Apple Silicon (M1)
* Compiler: Apple clang version 14.0.0 (clang-1400.0.29.202)
* Target: arm64-apple-darwin22.1.0
* MoltenVK Vulkan SDK 1.3.231

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
