### PR TITLE
Correct handling of WindowTraits::fullscreen flag on macOS

### DIFF
--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -796,6 +796,10 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     [_window setRestorable:YES];
     [_window setOpaque:YES];
     [_window setBackgroundColor:[NSColor whiteColor]];
+    if (traits->fullscreen)
+    {
+        [_window toggleFullScreen:nil];
+    }
 
     
     // create view


### PR DESCRIPTION
## Description

Handle WindowTraits::fullscreen flag on macOS

Fixes #640

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on local mac.

**Test Configuration**:
* OS: Mac OS Ventura
* HW: Apple Silicon (M1)
* Compiler: Apple clang version 14.0.0 (clang-1400.0.29.202)
* Target: arm64-apple-darwin22.1.0
* MoltenVK Vulkan SDK 1.3.231
* VulkanSceneGraph master

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
