### PR TITLE
Fix spontaneous crash during starting app in fullscreen mode on macOS.

### DIFF
--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -796,10 +796,6 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     [_window setRestorable:YES];
     [_window setOpaque:YES];
     [_window setBackgroundColor:[NSColor whiteColor]];
-    if (traits->fullscreen)
-    {
-        [_window toggleFullScreen:nil];
-    }
 
     
     // create view
@@ -812,6 +808,14 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     [_window setContentView:_view];
     _window.initialFirstResponder = _view;
     [_window makeFirstResponder:_view];
+
+    if (traits->fullscreen)
+    {
+        NSRect screenFrame = [[NSScreen mainScreen] frame];
+        [_window setBackgroundColor: NSColor.whiteColor];
+        [_window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
+        [_window toggleFullScreen:NSApp.delegate];
+    }
 
     auto devicePixelScale = _traits->hdpi ? [_window backingScaleFactor] : 1.0f;
     [_metalLayer setContentsScale:devicePixelScale];

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -812,7 +812,6 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     if (traits->fullscreen)
     {
         NSRect screenFrame = [[NSScreen mainScreen] frame];
-        [_window setBackgroundColor: NSColor.whiteColor];
         [_window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
         [_window toggleFullScreen:NSApp.delegate];
     }


### PR DESCRIPTION
## Description
Switch to fullscreen mode was done before view is initialised. As a result, app can spontaneously crash on start in method handleFrameSizeChange.

Fixes #640

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on local machine.

**Test Configuration**:
* OS: Mac OS Ventura
* HW: Apple Silicon (M1)
* Compiler: Apple clang version 14.0.0 (clang-1400.0.29.202)
* Target: arm64-apple-darwin22.1.0
* MoltenVK Vulkan SDK 1.3.231
* VulkanSceneGraph master

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
