### PR TITLE
Fix warning: declaration of ‘value’ shadows a member of ‘vsg::CommandLine’ [-Wshadow]

### DIFF
--- a/include/vsg/utils/CommandLine.h
+++ b/include/vsg/utils/CommandLine.h
@@ -236,7 +236,7 @@ namespace vsg
 
     // specialize matching of bool parameters
     template<>
-    inline bool CommandLine::read(const std::string& match, bool& value)
+    inline bool CommandLine::read(const std::string& match, bool& v)
     {
         for (int i = 1; i < *_argc; ++i)
         {
@@ -246,9 +246,9 @@ namespace vsg
                 ++i;
 
                 // match any parameters
-                if (!read(i, value))
+                if (!read(i, v))
                 {
-                    value = true;
+                    v = true;
                 }
 
                 remove(start, i - start);


### PR DESCRIPTION
## Description

Fixes #652

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] by a local build of vsg 

**Test Configuration**:
* Toolchain: g++  7.5.0
* SDK : vulkan version 1.3.231.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
