### PR TITLE
Create and install shared library with version on MinGW

### DIFF
--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -432,6 +432,9 @@ set_property(TARGET vsg PROPERTY VERSION ${VSG_VERSION_MAJOR}.${VSG_VERSION_MINO
 set_property(TARGET vsg PROPERTY SOVERSION ${VSG_SOVERSION})
 set_property(TARGET vsg PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET vsg PROPERTY CXX_STANDARD 17)
+if(MINGW)
+    set_property(TARGET vsg PROPERTY RUNTIME_OUTPUT_NAME vsg-${VSG_SOVERSION})
+endif()
 
 target_compile_definitions(vsg PRIVATE ${EXTRA_DEFINES})
 target_include_directories(vsg PUBLIC $<BUILD_INTERFACE:${VSG_SOURCE_DIR}/include> $<BUILD_INTERFACE:${VSG_BINARY_DIR}/include>)


### PR DESCRIPTION
## Description
In package-oriented distributions like openSUSE, shared libraries are usually installed with a version to better handle dependencies between packages.

The main rationale is to allow for two or more (incompatible) versions of a shared library, such as libfoo.so.1 and libfoo.so.2 to be independently selectively installable (and trackable by rpm) at the same time without causing package conflicts.

To achieve this also for MinGW based packages installed on a distribution, the shared library 'vsg' for this compiler is also created and installed with version. Since the name of the generated import library is not affected, there are no changes for dependent packages.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Did a build of vsg and depending packages with this commit applied at https://build.opensuse.org/package/show/home:rhabacker:branches:games:mingw32/mingw32-libvsg 

**Test Configuration**:
* Host: opensuse cloud build system
* Toolchain: mingw gcc 12
* SDK: mingw-header/runtime 10

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code