### PR TITLE
Add creating a line to class Builder

### DIFF
--- a/include/vsg/utils/Builder.h
+++ b/include/vsg/utils/Builder.h
@@ -90,7 +90,7 @@ namespace vsg
     VSG_type_name(vsg::GeometryInfo);
 
     /// Builder class that creates subgraphs that can render primitive geometries.
-    /// Supported shapes are Box, Capsule, Cone, Cylinder, Disk, Quad, Sphere and HeightField.
+    /// Supported shapes are Box, Capsule, Cone, Cylinder, Disk, Line, Quad, Sphere and HeightField.
     /// Uses GeometryInfo and StateInfo to guide the geometry position/size and rendering state.
     class VSG_DECLSPEC Builder : public Inherit<Object, Builder>
     {
@@ -105,6 +105,7 @@ namespace vsg
         ref_ptr<Node> createCone(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
         ref_ptr<Node> createCylinder(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
         ref_ptr<Node> createDisk(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
+        ref_ptr<Node> createLine(const GeometryInfo& info, const StateInfo& stateInfo = {});
         ref_ptr<Node> createQuad(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
         ref_ptr<Node> createSphere(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
         ref_ptr<Node> createHeightField(const GeometryInfo& info = {}, const StateInfo& stateInfo = {});
@@ -126,6 +127,7 @@ namespace vsg
         GeometryMap _capsules;
         GeometryMap _cones;
         GeometryMap _cylinders;
+        GeometryMap _lines;
         GeometryMap _quads;
         GeometryMap _spheres;
         GeometryMap _heightfields;


### PR DESCRIPTION
## Description
The commit from this merge request add a method to the class vsg::Builder to draw a line similar to the other available primitives.

Fixes vsg-dev/osg2vsg#63 (partial)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Compiled vsgbuilder from the vsgExample project after added drawing line support

**Test Configuration**:
* Hardware: GTX-1070
* Toolchain: g++ 7
* SDK: Vulkan 1.3.231

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] Any dependent changes have been merged and published in downstream modules (pending, see https://github.com/vsg-dev/vsgExamples/pull/197)
