### PR TITLE
Folder Names for MSVC in vsgMacros

### DIFF
--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -257,7 +257,7 @@ macro(vsg_add_target_clang_format)
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT "Automated code format using clang-format"
         )
-        set_target_properties(clang-format-${PROJECT_NAME} PROPERTIES FOLDER ${PROJECT_NAME})
+        set_target_properties(clang-format-${PROJECT_NAME} PROPERTIES FOLDER "${PROJECT_NAME} Folder")
         add_dependencies(clang-format clang-format-${PROJECT_NAME})
     endif()
 endmacro()
@@ -284,7 +284,7 @@ macro(vsg_add_target_clobber)
             add_custom_target(clobber-${PROJECT_NAME}
                 COMMAND ${GIT_EXECUTABLE} -C ${PROJECT_SOURCE_DIR} clean -d -f -x
             )
-            set_target_properties(clobber-${PROJECT_NAME} PROPERTIES FOLDER ${PROJECT_NAME})
+            set_target_properties(clobber-${PROJECT_NAME} PROPERTIES FOLDER "${PROJECT_NAME} Folder")
             add_dependencies(clobber clobber-${PROJECT_NAME})
         endif()
     endif()
@@ -340,7 +340,7 @@ macro(vsg_add_target_cppcheck)
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             COMMENT "Static code analysis using cppcheck"
         )
-        set_target_properties(cppcheck PROPERTIES FOLDER ${PROJECT_NAME})
+        set_target_properties(cppcheck PROPERTIES FOLDER "${PROJECT_NAME} Folder")
         add_dependencies(cppcheck cppcheck-${PROJECT_NAME})
     endif()
 endmacro()
@@ -378,7 +378,7 @@ macro(vsg_add_target_docs)
             ${ARGS_FILES}
             COMMENT "Use doxygen to Generate html documentation"
         )
-        set_target_properties(docs PROPERTIES FOLDER ${PROJECT_NAME})
+        set_target_properties(docs PROPERTIES FOLDER "${PROJECT_NAME} Folder")
         add_dependencies(docs docs-${PROJECT_NAME})
     endif()
 endmacro()
@@ -405,7 +405,7 @@ macro(vsg_add_target_uninstall)
     add_custom_target(uninstall-${PROJECT_NAME}
         COMMAND ${CMAKE_COMMAND} -P ${DIR}/uninstall.cmake
     )
-    set_target_properties(uninstall-${PROJECT_NAME} PROPERTIES FOLDER ${PROJECT_NAME})
+    set_target_properties(uninstall-${PROJECT_NAME} PROPERTIES FOLDER "${PROJECT_NAME} Folder")
     add_dependencies(uninstall uninstall-${PROJECT_NAME})
 endmacro()
 


### PR DESCRIPTION
Folders names in vsgMacros.cmake now have the word Folder appended to it to prevent clashes with other projects of the same name.



# Pull Request Template


## Description
Changed all lines that look like the following
```
set_target_properties(clobber-${PROJECT_NAME} PROPERTIES FOLDER ${PROJECT_NAME})
```
to 

```
set_target_properties(clobber-${PROJECT_NAME} PROPERTIES FOLDER "${PROJECT_NAME} Folder")
```

Fixes #683 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Build and Install on Windows and Mac M1.



## Checklist:

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
