### PR TITLE
Add option for source-level shader debugging in RenderDoc

### DIFF
--- a/include/vsg/io/Options.h
+++ b/include/vsg/io/Options.h
@@ -89,6 +89,7 @@ namespace vsg
         ///     "text" will substitute for vsg::createTextShaderSet()
         std::map<std::string, ref_ptr<ShaderSet>> shaderSets;
 
+        bool shaderSourceDebugging = false;
     protected:
         virtual ~Options();
     };

--- a/include/vsg/state/ShaderModule.h
+++ b/include/vsg/state/ShaderModule.h
@@ -50,6 +50,7 @@ namespace vsg
         SpirvTarget target = SPIRV_1_0;
         bool forwardCompatible = false;
         std::set<std::string> defines;
+        bool sourceDebugging = false;
 
         int compare(const Object& rhs_object) const override;
 

--- a/include/vsg/utils/ShaderSet.h
+++ b/include/vsg/utils/ShaderSet.h
@@ -76,7 +76,7 @@ namespace vsg
     {
     public:
         ShaderSet();
-        explicit ShaderSet(const ShaderStages& in_stages);
+        explicit ShaderSet(const ShaderStages& in_stages, ref_ptr<ShaderCompileSettings> in_hints = {});
 
         /// base ShaderStages that other variants as based on.
         ShaderStages stages;
@@ -88,6 +88,7 @@ namespace vsg
         std::set<std::string> optionalDefines;
         GraphicsPipelineStates defaultGraphicsPipelineStates;
 
+        ref_ptr<ShaderCompileSettings> defaultShaderHints;
         /// variants of the rootShaderModule compiled for different combinations of ShaderCompileSettings
         std::map<ref_ptr<ShaderCompileSettings>, ShaderStages, DereferenceLess> variants;
 

--- a/src/vsg/io/Options.cpp
+++ b/src/vsg/io/Options.cpp
@@ -44,7 +44,8 @@ Options::Options(const Options& options) :
     mapRGBtoRGBAHint(options.mapRGBtoRGBAHint),
     sceneCoordinateConvention(options.sceneCoordinateConvention),
     formatCoordinateConventions(options.formatCoordinateConventions),
-    shaderSets(options.shaderSets)
+    shaderSets(options.shaderSets),
+    shaderSourceDebugging(options.shaderSourceDebugging)
 {
     getOrCreateAuxiliary();
     // copy any meta data.
@@ -147,6 +148,7 @@ bool Options::readOptions(CommandLine& arguments)
 
     if (arguments.read("--file-cache", fileCache)) read = true;
     if (arguments.read("--extension-hint", extensionHint)) read = true;
+    if (arguments.read("--shader-source-debugging", shaderSourceDebugging)) read = true;
 
     return read;
 }

--- a/src/vsg/io/glsl.cpp
+++ b/src/vsg/io/glsl.cpp
@@ -54,7 +54,12 @@ ref_ptr<Object> glsl::createShader(const Path& found_filename, std::string& sour
         source = insertIncludes(source, prependPathToOptionsIfRequired(found_filename, options));
     }
 
-    auto sm = ShaderModule::create(source);
+    auto settings = ShaderCompileSettings::create();
+    if (options->shaderSourceDebugging)
+    {
+        settings->sourceDebugging = true;
+    }
+    auto sm = ShaderModule::create(source, settings);
 
     if (stageFlagBits != VK_SHADER_STAGE_ALL)
     {

--- a/src/vsg/state/ShaderModule.cpp
+++ b/src/vsg/state/ShaderModule.cpp
@@ -36,6 +36,7 @@ int ShaderCompileSettings::compare(const Object& rhs_object) const
     if ((result = compare_value(defaultVersion, rhs.defaultVersion))) return result;
     if ((result = compare_value(target, rhs.target))) return result;
     if ((result = compare_value(forwardCompatible, rhs.forwardCompatible))) return result;
+    if ((result = compare_value(sourceDebugging, rhs.sourceDebugging))) return result;
     return compare_container(defines, rhs.defines);
 }
 
@@ -47,6 +48,7 @@ void ShaderCompileSettings::read(Input& input)
     input.read("defaultVersion", defaultVersion);
     input.readValue<int>("target", target);
     input.read("forwardCompatible", forwardCompatible);
+    input.read("sourceDebugging", sourceDebugging);
 
     input.readValues("defines", defines);
 }
@@ -59,6 +61,7 @@ void ShaderCompileSettings::write(Output& output) const
     output.write("defaultVersion", defaultVersion);
     output.writeValue<int>("target", target);
     output.write("forwardCompatible", forwardCompatible);
+    output.write("sourceDebugging", sourceDebugging);
 
     output.writeValues("defines", defines);
 }

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -58,7 +58,7 @@ GraphicsPipelineConfigurator::GraphicsPipelineConfigurator(ref_ptr<ShaderSet> in
     if (!multisampleState) multisampleState = vsg::MultisampleState::create();
     if (!depthStencilState) depthStencilState = vsg::DepthStencilState::create();
 
-    shaderHints = vsg::ShaderCompileSettings::create();
+    shaderHints = vsg::ShaderCompileSettings::create(*shaderSet->defaultShaderHints);
 }
 
 void GraphicsPipelineConfigurator::reset()

--- a/src/vsg/utils/ShaderCompiler.cpp
+++ b/src/vsg/utils/ShaderCompiler.cpp
@@ -212,6 +212,10 @@ bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::strin
         shader->setStrings(&str, 1);
 
         EShMessages messages = EShMsgDefault;
+        if (vsg_shader->module->hints->sourceDebugging)
+        {
+            messages = static_cast<EShMessages>(messages | EShMsgDebugInfo);
+        }
         bool parseResult = shader->parse(builtInResources, settings->defaultVersion, settings->forwardCompatible, messages);
 
         if (parseResult)
@@ -267,6 +271,12 @@ bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::strin
             std::string warningsErrors;
             spv::SpvBuildLogger logger;
             glslang::SpvOptions spvOptions;
+            if (vsg_shader->module->hints && vsg_shader->module->hints->sourceDebugging)
+            {
+                spvOptions.generateDebugInfo = true;
+                spvOptions.emitNonSemanticShaderDebugInfo = true;
+                spvOptions.emitNonSemanticShaderDebugSource = true;
+            }
             glslang::GlslangToSpv(*(program->getIntermediate((EShLanguage)eshl_stage)), vsg_shader->module->code, &logger, &spvOptions);
         }
     }

--- a/src/vsg/utils/ShaderSet.cpp
+++ b/src/vsg/utils/ShaderSet.cpp
@@ -82,13 +82,22 @@ int DefinesArrayState::compare(const DefinesArrayState& rhs) const
     return compare_pointer(arrayState, rhs.arrayState);
 }
 
-ShaderSet::ShaderSet()
+ShaderSet::ShaderSet() :
+    defaultShaderHints(ShaderCompileSettings::create())
 {
 }
 
-ShaderSet::ShaderSet(const ShaderStages& in_stages) :
+ShaderSet::ShaderSet(const ShaderStages& in_stages, ref_ptr<ShaderCompileSettings> in_hints) :
     stages(in_stages)
 {
+    if (in_hints)
+    {
+        defaultShaderHints = in_hints;
+    }
+    else
+    {
+        defaultShaderHints = ShaderCompileSettings::create();
+    }
 }
 
 ShaderSet::~ShaderSet()
@@ -227,6 +236,7 @@ void ShaderSet::read(Input& input)
     Object::read(input);
 
     input.readObjects("stages", stages);
+    input.readObject("defaultShaderHints", defaultShaderHints);
 
     auto num_attributeBindings = input.readValue<uint32_t>("attributeBindings");
     attributeBindings.resize(num_attributeBindings);
@@ -289,6 +299,7 @@ void ShaderSet::write(Output& output) const
     Object::write(output);
 
     output.writeObjects("stages", stages);
+    output.writeObject("defaultShaderHints", defaultShaderHints);
 
     output.writeValue<uint32_t>("attributeBindings", attributeBindings.size());
     for (auto& binding : attributeBindings)


### PR DESCRIPTION
This allows a user who is creating their own shader sets to do source-level debugging of the shaders. This doesn't work for the builtin VSG shader sets, and can't unless they too are compiled with debugging enabled.

This is useful and pretty cool as well. See https://youtu.be/Fja4lT508cA for a demo of source-level shader debugging.