### PR TITLE
Add shader source code when generating debug info

### DIFF
--- a/src/vsg/utils/ShaderCompiler.cpp
+++ b/src/vsg/utils/ShaderCompiler.cpp
@@ -212,6 +212,10 @@ bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::strin
         shader->setStrings(&str, 1);
 
         EShMessages messages = EShMsgDefault;
+        if (settings->generateDebugInfo )
+        {
+            messages = static_cast<EShMessages>(messages | EShMsgDebugInfo);
+        }
         bool parseResult = shader->parse(builtInResources, settings->defaultVersion, settings->forwardCompatible, messages);
 
         if (parseResult)


### PR DESCRIPTION
This didn't make it in #748

Unfortunately attaching the shader source needs to be done in an additional step.