### PR TITLE
Add missing member functions for VertexDraw

### DIFF
--- a/include/vsg/state/ArrayState.h
+++ b/include/vsg/state/ArrayState.h
@@ -72,6 +72,7 @@ namespace vsg
         void apply(const InputAssemblyState& ias) override;
 
         void apply(const Geometry& geometry) override;
+        void apply(const VertexDraw& vid) override;
         void apply(const VertexIndexDraw& vid) override;
         void apply(const BindVertexBuffers& bvb) override;
         void apply(const BufferInfo& bufferInfo) override;

--- a/include/vsg/utils/ComputeBounds.h
+++ b/include/vsg/utils/ComputeBounds.h
@@ -40,6 +40,7 @@ namespace vsg
         void apply(const Transform& transform) override;
         void apply(const MatrixTransform& transform) override;
         void apply(const Geometry& geometry) override;
+        void apply(const VertexDraw& vid) override;
         void apply(const VertexIndexDraw& vid) override;
         void apply(const BindVertexBuffers& bvb) override;
         void apply(const BindIndexBuffer& bib) override;

--- a/include/vsg/utils/Intersector.h
+++ b/include/vsg/utils/Intersector.h
@@ -38,6 +38,7 @@ namespace vsg
         void apply(const PagedLOD& plod) override;
         void apply(const CullNode& cn) override;
 
+        void apply(const VertexDraw& vid) override;
         void apply(const VertexIndexDraw& vid) override;
         void apply(const Geometry& geometry) override;
 

--- a/src/vsg/state/ArrayState.cpp
+++ b/src/vsg/state/ArrayState.cpp
@@ -15,6 +15,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/io/Options.h>
 #include <vsg/maths/sample.h>
 #include <vsg/nodes/Geometry.h>
+#include <vsg/nodes/VertexDraw.h>
 #include <vsg/nodes/VertexIndexDraw.h>
 #include <vsg/state/ArrayState.h>
 #include <vsg/state/BindDescriptorSet.h>
@@ -78,6 +79,11 @@ void ArrayState::apply(const InputAssemblyState& ias)
 void ArrayState::apply(const vsg::Geometry& geometry)
 {
     applyArrays(geometry.firstBinding, geometry.arrays);
+}
+
+void ArrayState::apply(const vsg::VertexDraw& vid)
+{
+    applyArrays(vid.firstBinding, vid.arrays);
 }
 
 void ArrayState::apply(const vsg::VertexIndexDraw& vid)

--- a/src/vsg/utils/ComputeBounds.cpp
+++ b/src/vsg/utils/ComputeBounds.cpp
@@ -20,6 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/nodes/Geometry.h>
 #include <vsg/nodes/MatrixTransform.h>
 #include <vsg/nodes/StateGroup.h>
+#include <vsg/nodes/VertexDraw.h>
 #include <vsg/nodes/VertexIndexDraw.h>
 #include <vsg/text/Text.h>
 #include <vsg/text/TextGroup.h>
@@ -89,6 +90,14 @@ void ComputeBounds::apply(const vsg::Geometry& geometry)
     {
         command->accept(*this);
     }
+}
+
+void ComputeBounds::apply(const vsg::VertexDraw& vid)
+{
+    auto& arrayState = *arrayStateStack.back();
+    arrayState.apply(vid);
+
+    applyDraw(vid.firstVertex, vid.vertexCount, vid.firstInstance, vid.instanceCount);
 }
 
 void ComputeBounds::apply(const vsg::VertexIndexDraw& vid)

--- a/src/vsg/utils/Intersector.cpp
+++ b/src/vsg/utils/Intersector.cpp
@@ -22,6 +22,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/nodes/PagedLOD.h>
 #include <vsg/nodes/StateGroup.h>
 #include <vsg/nodes/Transform.h>
+#include <vsg/nodes/VertexDraw.h>
 #include <vsg/nodes/VertexIndexDraw.h>
 #include <vsg/state/GraphicsPipeline.h>
 #include <vsg/utils/Intersector.h>
@@ -118,6 +119,18 @@ void Intersector::apply(const CullNode& cn)
     PushPopNode ppn(_nodePath, &cn);
 
     if (intersects(cn.bound)) cn.traverse(*this);
+}
+
+void Intersector::apply(const VertexDraw& vid)
+{
+    auto& arrayState = *arrayStateStack.back();
+    arrayState.apply(vid);
+    if (!arrayState.vertices) return;
+
+
+    PushPopNode ppn(_nodePath, &vid);
+
+    intersectDraw(vid.firstVertex, vid.vertexCount, vid.firstInstance, vid.instanceCount);
 }
 
 void Intersector::apply(const VertexIndexDraw& vid)


### PR DESCRIPTION
ComputeBounds wasn't working for VertexDraw nodes.
