### PR TITLE
Add RefPtr to Inherit class

### DIFF
--- a/include/vsg/core/Inherit.h
+++ b/include/vsg/core/Inherit.h
@@ -27,6 +27,9 @@ namespace vsg
     class Inherit : public ParentClass
     {
     public:
+         using RefPtr = ref_ptr<Subclass>;
+
+    public:
         template<typename... Args>
         Inherit(Args&&... args) :
             ParentClass(args...) {}


### PR DESCRIPTION
## Description

What do you think about adding some syntactic sugar to `Inherit` class to allow using `vsg::CLASS::RefPtr` instead of `vsg::ref_ptr<vsg::CLASS>`?

## Type of change

- [x] New feature (non-breaking change which adds functionality)
