### PR TITLE
[FIXED] missing nullptr check

### DIFF
--- a/src/vsg/app/RecordTraversal.cpp
+++ b/src/vsg/app/RecordTraversal.cpp
@@ -434,7 +434,7 @@ void RecordTraversal::apply(const View& view)
     {
         setProjectionAndViewMatrix(view.camera->projectionMatrix->transform(), view.camera->viewMatrix->transform());
 
-        if (view.camera->viewportState && _viewDependentState->viewportData)
+        if (_viewDependentState && _viewDependentState->viewportData && view.camera->viewportState)
         {
             auto& viewportData = _viewDependentState->viewportData;
             auto& viewports = view.camera->viewportState->viewports;
@@ -453,13 +453,9 @@ void RecordTraversal::apply(const View& view)
                 }
             }
         }
+    }
 
-        view.traverse(*this);
-    }
-    else
-    {
-        view.traverse(*this);
-    }
+    view.traverse(*this);
 
     for (auto& bin : view.bins)
     {


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed incomplete guards for `_viewDependentState == nullptr` in `RecordTraversal::apply(View&)` 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested that nullptr viewDependentState      (https://github.com/vsgopenmw-dev/vsgopenmw/blob/master/components/view/shadow.cpp#L68) no longer crashes the VSG   

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
