### PR TITLE
Nonblocking compile

### DIFF
--- a/include/vsg/vk/Context.h
+++ b/include/vsg/vk/Context.h
@@ -135,8 +135,21 @@ namespace vsg
         void copy(ref_ptr<BufferInfo> src, ref_ptr<BufferInfo> dest);
 
         /// return true if there are commands that have been submitted
+        ///
+        /// record() needs to submit commands e.g., to upload textures into GPU memory, so the
+        /// scene graph compiled here cannot be recorded and rendered until those submissions are
+        /// complete. The sequence of the DatabasePager and Viewer operations mostly take care of
+        /// this: a sub scene graph isn't inserted into the main graph until compilation is
+        /// complete. We are not waiting (stalling) for completion, but the commands necessary to do
+        /// the rendering will have already been submitted before any commands from the main scene
+        /// graph. There does need to be synchronization between the compile commands and the main
+        /// rendering commands; that is normally provided by wait semaphores in the record
+        /// traversal.
+        ///
+        /// XXX If there are no semaphores there, then record() should signal one in its submission.
         bool record();
 
+        //// Returns immediately.
         void waitForCompletion();
 
         ref_ptr<MemoryBufferPools> deviceMemoryBufferPools;

--- a/include/vsg/vk/Fence.h
+++ b/include/vsg/vk/Fence.h
@@ -27,13 +27,17 @@ namespace vsg
         operator VkFence() const { return _vkFence; }
         VkFence vk() const { return _vkFence; }
 
-        VkResult wait(uint64_t timeout) const;
+        VkResult wait(uint64_t timeout);
 
         VkResult reset() const;
 
         VkResult status() const { return vkGetFenceStatus(*_device, _vkFence); }
-
-        bool hasDependencies() const { return (_dependentSemaphores.size() + _dependentCommandBuffers.size()) > 0; }
+        bool hasDependencies() const
+        {
+            return !(_dependentSemaphores.empty()
+                     && _dependentCommandBuffers.empty()
+                     && _actions.empty());
+        }
 
         void resetFenceAndDependencies();
 
@@ -42,7 +46,10 @@ namespace vsg
 
         Device* getDevice() { return _device; }
         const Device* getDevice() const { return _device; }
-
+        using action_container_type = std::list<FenceAction>;
+        void putActions(uint64_t in_submission, action_container_type& actions);
+        uint64_t submission;
+        action_container_type& actions() { return _actions; }
     protected:
         virtual ~Fence();
 
@@ -51,6 +58,7 @@ namespace vsg
         CommandBuffers _dependentCommandBuffers;
 
         ref_ptr<Device> _device;
+        action_container_type _actions;
     };
     VSG_type_name(vsg::Fence);
 

--- a/src/vsg/app/RecordAndSubmitTask.cpp
+++ b/src/vsg/app/RecordAndSubmitTask.cpp
@@ -126,6 +126,7 @@ VkResult RecordAndSubmitTask::finish(CommandBuffers& recordedCommandBuffers)
     if (recordedCommandBuffers.empty())
     {
         // nothing to do so return early
+        // XXX This is probably not the place to guarantee the frame rate.
         std::this_thread::sleep_for(std::chrono::milliseconds(16)); // sleep for 1/60th of a second
         return VK_SUCCESS;
     }


### PR DESCRIPTION
This makes the compile action non-blocking, relying instead on a new FenceAction to clean up after a compilation and on the semaphore waiting and signalling on the main graphics queue for synchronization of Vulkan objects. This makes a huge improvement to the problems reported in #783: the 100ms compile times mentioned for vsgCs are now .5ms (200x!), without making any effort to run compile actions in parallel.

I'm not sure this is quite ready for merge. There is a possible issue with headless rendering and synchronizing the compilation. I also haven't tested examples that use the database pager. However, I wanted to get the code out there for review and comment.