### PR TITLE
[FIXED] invalid recycling of descriptor sets

### DIFF
--- a/include/vsg/state/DescriptorSet.h
+++ b/include/vsg/state/DescriptorSet.h
@@ -80,7 +80,6 @@ namespace vsg
             ref_ptr<DescriptorPool> _descriptorPool;
             ref_ptr<DescriptorSetLayout> _descriptorSetLayout;
             Descriptors _descriptors;
-            DescriptorPoolSizes _descriptorPoolSizes;
         };
 
     protected:

--- a/src/vsg/state/DescriptorSet.cpp
+++ b/src/vsg/state/DescriptorSet.cpp
@@ -99,9 +99,6 @@ DescriptorSet::Implementation::Implementation(DescriptorPool* descriptorPool, De
 {
     auto device = descriptorPool->getDevice();
 
-    _descriptorPoolSizes.clear();
-    descriptorSetLayout->getDescriptorPoolSizes(_descriptorPoolSizes);
-
     VkDescriptorSetLayout vkdescriptorSetLayout = descriptorSetLayout->vk(device->deviceID);
 
     VkDescriptorSetAllocateInfo descriptorSetAllocateInfo = {};


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed invalid reycling of descriptor sets that are incompatible according to VUID-VkWriteDescriptorSet-dstBinding-00315, VUID-VkWriteDescriptorSet-dstBinding-00316, VUID-VkWriteDescriptorSet-dstSet-00320, VUID-VkWriteDescriptorSet-dstArrayElement-00321. Removed now unused DescriptorSet::Implementation::_descriptorPoolSizes.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested scene that used to crash predictably in vkUpdateDescriptorSets

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
