### PR TITLE
[FIXED] invalid recycling of descriptor sets

### DIFF
--- a/include/vsg/state/DescriptorSet.h
+++ b/include/vsg/state/DescriptorSet.h
@@ -80,7 +80,6 @@ namespace vsg
             ref_ptr<DescriptorPool> _descriptorPool;
             ref_ptr<DescriptorSetLayout> _descriptorSetLayout;
             Descriptors _descriptors;
-            DescriptorPoolSizes _descriptorPoolSizes;
         };
 
     protected:

--- a/src/vsg/state/DescriptorSet.cpp
+++ b/src/vsg/state/DescriptorSet.cpp
@@ -99,9 +99,6 @@ DescriptorSet::Implementation::Implementation(DescriptorPool* descriptorPool, De
 {
     auto device = descriptorPool->getDevice();
 
-    _descriptorPoolSizes.clear();
-    descriptorSetLayout->getDescriptorPoolSizes(_descriptorPoolSizes);
-
     VkDescriptorSetLayout vkdescriptorSetLayout = descriptorSetLayout->vk(device->deviceID);
 
     VkDescriptorSetAllocateInfo descriptorSetAllocateInfo = {};

--- a/src/vsg/vk/DescriptorPool.cpp
+++ b/src/vsg/vk/DescriptorPool.cpp
@@ -57,14 +57,11 @@ ref_ptr<DescriptorSet::Implementation> DescriptorPool::allocateDescriptorSet(Des
         return {};
     }
 
-    DescriptorPoolSizes descriptorPoolSizes;
-    descriptorSetLayout->getDescriptorPoolSizes(descriptorPoolSizes);
-
     for (auto itr = _recyclingList.begin(); itr != _recyclingList.end(); ++itr)
     {
-        if (vsg::compare_value_container(descriptorPoolSizes, (*itr)->_descriptorPoolSizes) == 0)
+        auto dsi = *itr;
+        if (dsi->_descriptorSetLayout.get() == descriptorSetLayout || compare_value_container(dsi->_descriptorSetLayout->bindings, descriptorSetLayout->bindings) == 0)
         {
-            auto dsi = *itr;
             dsi->_descriptorPool = this;
             _recyclingList.erase(itr);
             --_availableDescriptorSet;
@@ -78,6 +75,9 @@ ref_ptr<DescriptorSet::Implementation> DescriptorPool::allocateDescriptorSet(Des
         //debug("The only available vkDescriptorSets associated with DescriptorPool are in the recyclingList, but none are compatible.");
         return {};
     }
+
+    DescriptorPoolSizes descriptorPoolSizes;
+    descriptorSetLayout->getDescriptorPoolSizes(descriptorPoolSizes);
 
     size_t matches = 0;
     for (auto& [type, descriptorCount] : descriptorPoolSizes)


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed invalid recycling of descriptor sets by adding a value compare of descriptorSetLayout.

Reusing descriptor sets allocated with a differently defined layout is practically impossible due to various Vulkan requirements. Most importantly, when binding descriptor sets, the descriptor set layout in the pipeline layout must be the same as, or identically defined as, the layout that the bound descriptor set was allocated with (VUID-vkCmdBindDescriptorSets-pDescriptorSets-00358).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested scene that used to crash predictably in vkUpdateDescriptorSets

Tested with cout statement that descriptor set recycling still works at all

Tested that vsgExamples modification no longer triggers invalid recycling

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
