### PR TITLE
[FIXED] copy and paste errors in ComputeBounds::add(dsphere)

### DIFF
--- a/src/vsg/utils/ComputeBounds.cpp
+++ b/src/vsg/utils/ComputeBounds.cpp
@@ -284,19 +284,19 @@ void ComputeBounds::add(const dsphere& bs)
 {
     if (matrixStack.empty())
     {
-        bounds.add(bs.center.x - bs.radius, bs.center.y - bs.radius, bs.center.y - bs.radius);
-        bounds.add(bs.center.x + bs.radius, bs.center.y + bs.radius, bs.center.y + bs.radius);
+        bounds.add(bs.center.x - bs.radius, bs.center.y - bs.radius, bs.center.z - bs.radius);
+        bounds.add(bs.center.x + bs.radius, bs.center.y + bs.radius, bs.center.z + bs.radius);
     }
     else
     {
         auto& matrix = matrixStack.back();
-        bounds.add(matrix * dvec3(bs.center.x - bs.radius, bs.center.y - bs.radius, bs.center.y - bs.radius));
-        bounds.add(matrix * dvec3(bs.center.x + bs.radius, bs.center.y - bs.radius, bs.center.y - bs.radius));
-        bounds.add(matrix * dvec3(bs.center.x - bs.radius, bs.center.y + bs.radius, bs.center.y - bs.radius));
-        bounds.add(matrix * dvec3(bs.center.x + bs.radius, bs.center.y + bs.radius, bs.center.y - bs.radius));
-        bounds.add(matrix * dvec3(bs.center.x - bs.radius, bs.center.y - bs.radius, bs.center.y + bs.radius));
-        bounds.add(matrix * dvec3(bs.center.x + bs.radius, bs.center.y - bs.radius, bs.center.y + bs.radius));
-        bounds.add(matrix * dvec3(bs.center.x - bs.radius, bs.center.y + bs.radius, bs.center.y + bs.radius));
-        bounds.add(matrix * dvec3(bs.center.x + bs.radius, bs.center.y + bs.radius, bs.center.y + bs.radius));
+        bounds.add(matrix * dvec3(bs.center.x - bs.radius, bs.center.y - bs.radius, bs.center.z - bs.radius));
+        bounds.add(matrix * dvec3(bs.center.x + bs.radius, bs.center.y - bs.radius, bs.center.z - bs.radius));
+        bounds.add(matrix * dvec3(bs.center.x - bs.radius, bs.center.y + bs.radius, bs.center.z - bs.radius));
+        bounds.add(matrix * dvec3(bs.center.x + bs.radius, bs.center.y + bs.radius, bs.center.z - bs.radius));
+        bounds.add(matrix * dvec3(bs.center.x - bs.radius, bs.center.y - bs.radius, bs.center.z + bs.radius));
+        bounds.add(matrix * dvec3(bs.center.x + bs.radius, bs.center.y - bs.radius, bs.center.z + bs.radius));
+        bounds.add(matrix * dvec3(bs.center.x - bs.radius, bs.center.y + bs.radius, bs.center.z + bs.radius));
+        bounds.add(matrix * dvec3(bs.center.x + bs.radius, bs.center.y + bs.radius, bs.center.z + bs.radius));
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed copy and paste errors in ComputeBounds::add(dsphere)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested that scene is no longer culled incorrectly

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
