### PR TITLE
Use Mask instead of uint32_t

### DIFF
--- a/include/vsg/nodes/Switch.h
+++ b/include/vsg/nodes/Switch.h
@@ -68,6 +68,6 @@ namespace vsg
     };
     VSG_type_name(vsg::Switch);
 
-    inline uint32_t boolToMask(bool enabled) { return enabled ? uint32_t(0xffffff) : uint32_t(0x0); }
+    inline Mask boolToMask(bool enabled) { return enabled ? MASK_ALL : MASK_OFF; }
 
 } // namespace vsg

--- a/src/vsg/nodes/Switch.cpp
+++ b/src/vsg/nodes/Switch.cpp
@@ -62,7 +62,7 @@ void Switch::addChild(bool enabled, ref_ptr<Node> child)
 
 void Switch::setAllChildren(bool enabled)
 {
-    uint32_t mask = boolToMask(enabled);
+    Mask mask = boolToMask(enabled);
     for (auto& child : children) child.mask = mask;
 }
 


### PR DESCRIPTION
A couple of uses were missed in the change from uint32_t to vsg::Mask (uint64_t) in Switch nodes, etc.


