### PR TITLE
[FIXED] -Wunused-but-set-variable warnings

### DIFF
--- a/src/vsg/app/Viewer.cpp
+++ b/src/vsg/app/Viewer.cpp
@@ -465,17 +465,13 @@ void Viewer::setupThreading()
 
     stopThreading();
 
-    // check how valid tasks and command graphs there are.
+    // check how many valid tasks there are.
     uint32_t numValidTasks = 0;
-    size_t numCommandGraphs = 0;
-    size_t numEarlyTransferTasks = 0;
     for (auto& task : recordAndSubmitTasks)
     {
         if (!task->commandGraphs.empty())
         {
             ++numValidTasks;
-            numCommandGraphs += task->commandGraphs.size();
-            if (task->earlyTransferTask) ++numEarlyTransferTasks;
         }
     }
 

--- a/src/vsg/io/DatabasePager.cpp
+++ b/src/vsg/io/DatabasePager.cpp
@@ -251,7 +251,6 @@ void DatabasePager::updateSceneGraph(FrameStamp* frameStamp, CompileResult& cr)
         }
 
         auto& activeList = pagedLODContainer->activeList;
-        uint32_t switchedCount = 0;
         for (uint32_t index = activeList.head; index != 0;)
         {
             auto& element = elements[index];
@@ -260,7 +259,6 @@ void DatabasePager::updateSceneGraph(FrameStamp* frameStamp, CompileResult& cr)
             if (!element.plod->highResActive(frameCount))
             {
                 // debug("   active to inactive ", index);
-                ++switchedCount;
                 pagedLODContainer->inactive(element.plod.get());
             }
         }

--- a/src/vsg/state/BufferInfo.cpp
+++ b/src/vsg/state/BufferInfo.cpp
@@ -163,9 +163,7 @@ bool vsg::createBufferAndTransferData(Context& context, const BufferInfoList& bu
     auto deviceID = context.deviceID;
 
     ref_ptr<BufferInfo> deviceBufferInfo;
-    size_t numBuffersAssigned = 0;
     size_t numBuffersRequired = 0;
-    size_t numNoData = 0;
     bool containsMultipleParents = false;
     for (auto& bufferInfo : bufferInfoList)
     {
@@ -175,14 +173,6 @@ bool vsg::createBufferAndTransferData(Context& context, const BufferInfoList& bu
             {
                 ++numBuffersRequired;
             }
-            else
-            {
-                ++numBuffersAssigned;
-            }
-        }
-        else
-        {
-            ++numNoData;
         }
 
         if (bufferInfo->parent)


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed -Wunused-but-set-variable warnings

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
