### PR TITLE
[FIXED] nullptr dereference in CompileTraversal::apply(CommandGraph&)

### DIFF
--- a/src/vsg/app/CompileTraversal.cpp
+++ b/src/vsg/app/CompileTraversal.cpp
@@ -247,7 +247,7 @@ void CompileTraversal::apply(CommandGraph& commandGraph)
 
             if (samples != VK_SAMPLE_COUNT_1_BIT)
             {
-                mergeGraphicsPipelineStates(context->overridePipelineStates, MultisampleState::create(commandGraph.window->framebufferSamples()));
+                mergeGraphicsPipelineStates(context->overridePipelineStates, MultisampleState::create(static_cast<VkSampleCountFlagBits>(samples)));
             }
 
             commandGraph.traverse(*this);


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed nullptr dereference in CompileTraversal for multisampled command graphs without a window assigned

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested that vsgheadless no longer crashes with --use-ec --msaa

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
