### PR TITLE
[ADDED] renderPass to RenderGraph

### DIFF
--- a/include/vsg/app/RenderGraph.h
+++ b/include/vsg/app/RenderGraph.h
@@ -41,7 +41,7 @@ namespace vsg
         ref_ptr<Framebuffer> framebuffer;
         ref_ptr<Window> window;
 
-        /// RenderPass to use passed to the vkCmdBeginRenderPass, either obtained from which of the framebuffer or window are active
+        /// RenderPass to use passed to the vkCmdBeginRenderPass, if renderPass is set it takes precedence, if not then either obtained from which of the framebuffer or window are active
         RenderPass* getRenderPass();
 
         /// Get the Exten2D of the attached Framebuffer or Window.
@@ -49,6 +49,9 @@ namespace vsg
 
         /// ReandingArea settings for VkRenderPassBeginInfo.renderArea passed to the vkCmdBeginRenderPass, usually maps the ViewportState's scissor
         VkRect2D renderArea;
+
+        /// RenderPass to use passed to the vkCmdBeginRenderPass in place of the framebuffer's or window's renderPass. renderPass must be compatible with the render pass used to create the window or framebuffer.
+        ref_ptr<RenderPass> renderPass;
 
         /// Buffer clearing settings for vkRrenderPassInfo.clearValueCount & vkRenderPassInfo.pClearValues passed to the vkCmdBeginRenderPass
         using ClearValues = std::vector<VkClearValue>;

--- a/src/vsg/app/RenderGraph.cpp
+++ b/src/vsg/app/RenderGraph.cpp
@@ -54,7 +54,11 @@ RenderGraph::RenderGraph(ref_ptr<Window> in_window, ref_ptr<View> in_view) :
 
 RenderPass* RenderGraph::getRenderPass()
 {
-    if (framebuffer)
+    if (renderPass)
+    {
+        return renderPass;
+    }
+    else if (framebuffer)
     {
         return framebuffer->getRenderPass();
     }
@@ -67,10 +71,10 @@ RenderPass* RenderGraph::getRenderPass()
 
 void RenderGraph::setClearValues(VkClearColorValue clearColor, VkClearDepthStencilValue clearDepthStencil)
 {
-    auto renderPass = getRenderPass();
-    if (!renderPass) return;
+    auto activeRenderPass = getRenderPass();
+    if (!activeRenderPass) return;
 
-    auto& attachments = renderPass->attachments;
+    auto& attachments = activeRenderPass->attachments;
     clearValues.resize(attachments.size());
     for (size_t i = 0; i < attachments.size(); ++i)
     {
@@ -124,6 +128,8 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
         renderPassInfo.renderPass = *(window->getRenderPass());
         renderPassInfo.framebuffer = *(window->framebuffer(imageIndex));
     }
+    if (renderPass)
+        renderPassInfo.renderPass = *(renderPass);
 
     renderPassInfo.renderArea = renderArea;
 
@@ -149,25 +155,25 @@ void RenderGraph::resized()
     if (!windowResizeHandler) return;
     if (!window && !framebuffer) return;
 
-    auto renderPass = getRenderPass();
-    if (!renderPass) return;
+    auto activeRenderPass = getRenderPass();
+    if (!activeRenderPass) return;
 
-    auto device = renderPass->device;
+    auto device = activeRenderPass->device;
 
     if (!windowResizeHandler->context) windowResizeHandler->context = vsg::Context::create(device);
 
     auto extent = getExtent();
 
     windowResizeHandler->context->commandPool = nullptr;
-    windowResizeHandler->context->renderPass = renderPass;
+    windowResizeHandler->context->renderPass = activeRenderPass;
     windowResizeHandler->renderArea = renderArea;
     windowResizeHandler->previous_extent = previous_extent;
     windowResizeHandler->new_extent = extent;
     windowResizeHandler->visited.clear();
 
-    if (renderPass->maxSamples != VK_SAMPLE_COUNT_1_BIT)
+    if (activeRenderPass->maxSamples != VK_SAMPLE_COUNT_1_BIT)
     {
-        windowResizeHandler->context->overridePipelineStates.emplace_back(vsg::MultisampleState::create(renderPass->maxSamples));
+        windowResizeHandler->context->overridePipelineStates.emplace_back(vsg::MultisampleState::create(activeRenderPass->maxSamples));
     }
 
     // make sure the device is idle before we recreate any Vulkan objects


### PR DESCRIPTION
# Pull Request Template

## Description

Added renderPass member to RenderGraph to support different renderPasses operating on the same framebuffer or window.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by running 3D scene render pass, storing the rendered image for screen-space raytracing purposes, then running GUI render pass on top of the 3D scene

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
