### PR TITLE
[FIXED] depthResolveAttachment to use LOAD_OP_DONT_CARE

### DIFF
--- a/src/vsg/vk/RenderPass.cpp
+++ b/src/vsg/vk/RenderPass.cpp
@@ -400,7 +400,7 @@ ref_ptr<RenderPass> vsg::createMultisampledRenderPass(Device* device, VkFormat i
         AttachmentDescription depthResolveAttachment = {};
         depthResolveAttachment.format = depthFormat;
         depthResolveAttachment.samples = VK_SAMPLE_COUNT_1_BIT;
-        depthResolveAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        depthResolveAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         depthResolveAttachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         depthResolveAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         depthResolveAttachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed depthResolveAttachment's loadOp to match the resolveAttachment's LOAD_OP_DONT_CARE.

The Vulkan spec states: "At the end of each subpass, multisample resolve operations read the subpass's depth/stencil attachment, and resolve the samples for each pixel to the same pixel location in the corresponding resolve attachment."

Because all pixels are written by the resolve operation, it's possible to enable LOAD_OP_DONT_CARE.

## How Has This Been Tested?

Tested a multisampled renderpass with requiresDepthRead=true

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
