### PR TITLE
[FIXED] vkCreateRenderPass2KHR support

### DIFF
--- a/include/vsg/vk/Device.h
+++ b/include/vsg/vk/Device.h
@@ -58,6 +58,8 @@ namespace vsg
         const Extensions* getExtensions() const { return _extensions.get(); }
 
         /// get the address of specified function using vkGetDeviceProcAddr
+        /// for core commands beyond the apiVersion specified in vsg::Instance creation, vkGetDeviceProcAddr may return a non-nullptr function pointer, though the function pointer must not be called.
+        /// for extension commands, vkGetDeviceProcAddr will always return nullptr if the extension is not enabled in vsg::Device creation.
         template<typename T>
         bool getProcAddr(T& procAddress, const char* pName, const char* pNameFallback = nullptr) const
         {
@@ -67,6 +69,9 @@ namespace vsg
             if (pNameFallback) procAddress = reinterpret_cast<T>(vkGetDeviceProcAddr(_device, pNameFallback));
             return (procAddress);
         }
+
+        /// device-level core functionality can be used if both VkInstance and VkPhysicalDevice support the Vulkan version that provides it.
+        bool supportsApiVersion(uint32_t version) const;
 
     protected:
         virtual ~Device();

--- a/include/vsg/vk/PhysicalDevice.h
+++ b/include/vsg/vk/PhysicalDevice.h
@@ -75,6 +75,9 @@ namespace vsg
         /// Call vkEnumerateDeviceExtensionProperties to enumerate extension properties.
         std::vector<VkExtensionProperties> enumerateDeviceExtensionProperties(const char* pLayerName = nullptr);
 
+        /// return true if the extension is supported by physicalDevice
+        bool supportsDeviceExtension(const char* extensionName);
+
     protected:
         // use Instance::getDevice(..) to create PhysicalDevice
         PhysicalDevice(Instance* instance, VkPhysicalDevice device);

--- a/src/vsg/vk/Device.cpp
+++ b/src/vsg/vk/Device.cpp
@@ -18,8 +18,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/Extensions.h>
 
 #include <cstring>
-#include <string>
-#include <algorithm>
 #include <set>
 
 using namespace vsg;

--- a/src/vsg/vk/Device.cpp
+++ b/src/vsg/vk/Device.cpp
@@ -18,6 +18,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/vk/Extensions.h>
 
 #include <cstring>
+#include <string>
+#include <algorithm>
 #include <set>
 
 using namespace vsg;
@@ -110,14 +112,8 @@ Device::Device(PhysicalDevice* physicalDevice, const QueueSettings& queueSetting
 
 #if defined(__APPLE__)
     // MacOS requires "VK_KHR_portability_subset" to be a requested extension if the PhysicalDevice supported it.
-    auto extensionProperties = _physicalDevice->enumerateDeviceExtensionProperties();
-    for (auto& extensionProperty : extensionProperties)
-    {
-        if (std::strncmp(extensionProperty.extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME, VK_MAX_EXTENSION_NAME_SIZE) == 0)
-        {
-            deviceExtensions.push_back(extensionProperty.extensionName);
-        }
-    }
+    if (_physicalDevice->supportsDeviceExtension(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        deviceExtensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 #endif
 
     VkDeviceCreateInfo createInfo = {};
@@ -191,4 +187,9 @@ ref_ptr<Queue> Device::getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex)
     warn("Device::getQueue(", queueFamilyIndex, ", ", queueIndex, ") failled to find any suitable Queue.");
 
     return {};
+}
+
+bool Device::supportsApiVersion(uint32_t version) const
+{
+    return getInstance()->apiVersion >= version && _physicalDevice->getProperties().apiVersion >= version;
 }

--- a/src/vsg/vk/Extensions.cpp
+++ b/src/vsg/vk/Extensions.cpp
@@ -47,7 +47,10 @@ Extensions::Extensions(Device* device)
     device->getProcAddr(vkResetQueryPool, "vkResetQueryPool", "vkResetQueryPoolEXT");
 
     // VK_KHR_create_renderpass2
-    device->getProcAddr(vkCreateRenderPass2, "vkCreateRenderPass2", "vkCreateRenderPass2KHR");
+    if (device->supportsApiVersion(VK_API_VERSION_1_2))
+        device->getProcAddr(vkCreateRenderPass2, "vkCreateRenderPass2");
+    else if (device->getPhysicalDevice()->supportsDeviceExtension(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME))
+        device->getProcAddr(vkCreateRenderPass2, "vkCreateRenderPass2KHR");
 
     // VK_KHR_ray_tracing
     device->getProcAddr(vkCreateAccelerationStructureKHR, "vkCreateAccelerationStructureKHR");

--- a/src/vsg/vk/PhysicalDevice.cpp
+++ b/src/vsg/vk/PhysicalDevice.cpp
@@ -103,3 +103,14 @@ std::vector<VkExtensionProperties> PhysicalDevice::enumerateDeviceExtensionPrope
     vkEnumerateDeviceExtensionProperties(_device, pLayerName, &propertyCount, extensionProperties.data());
     return extensionProperties;
 }
+
+bool PhysicalDevice::supportsDeviceExtension(const char* extensionName)
+{
+    auto extensionProperties = enumerateDeviceExtensionProperties();
+    for (auto& extensionProperty : extensionProperties)
+    {
+        if (std::strncmp(extensionProperty.extensionName, extensionName, VK_MAX_EXTENSION_NAME_SIZE) == 0)
+            return true;
+    }
+    return false;
+}

--- a/src/vsg/vk/RenderPass.cpp
+++ b/src/vsg/vk/RenderPass.cpp
@@ -13,6 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/Exception.h>
 #include <vsg/core/ScratchMemory.h>
 #include <vsg/io/Options.h>
+#include <vsg/io/Logger.h>
 #include <vsg/vk/Extensions.h>
 #include <vsg/vk/RenderPass.h>
 
@@ -39,13 +40,11 @@ RenderPass::RenderPass(Device* in_device, const Attachments& in_attachments, con
     maxSamples(computeMaxSamples(in_attachments))
 {
     auto scratchMemory = ScratchMemory::create(1024);
-
-    // vkCreateRenderPass2 is only supported in Vulkan 1.2 and later.
-    bool useRenderPass2 = device->getInstance()->apiVersion >= VK_API_VERSION_1_2;
+    // vkCreateRenderPass2 is supported with the VK_KHR_create_renderpass2 device extension, or in Vulkan core 1.2 and later
     auto extensions = device->getExtensions();
-    if (useRenderPass2 && extensions->vkCreateRenderPass2)
+    if (extensions->vkCreateRenderPass2)
     {
-        // Vulkan 1.2 vkCreateRenderPass2 code path
+        // vkCreateRenderPass2 code path
         auto copyAttachmentDescriptions = [&scratchMemory](const Attachments& attachmentDescriptions) -> VkAttachmentDescription2* {
             if (attachmentDescriptions.empty()) return nullptr;
 
@@ -211,6 +210,8 @@ RenderPass::RenderPass(Device* in_device, const Attachments& in_attachments, con
             for (size_t i = 0; i < subpassDescriptions.size(); ++i)
             {
                 auto& src = subpassDescriptions[i];
+                if (!src.depthStencilResolveAttachments.empty())
+                    vsg::warn("vsg::RenderPass::create(...): Subpass includes depthStencilResolveAttachments but vkCreateRenderPass2 is not enabled. Set WindowTraits::vulkanVersion to at least VK_API_VERSION_1_2 or add VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME to WindowTraits::deviceExtensionNames.");
                 auto& dst = vk_subpassDescription[i];
                 dst.flags = src.flags;
                 dst.pipelineBindPoint = src.pipelineBindPoint;


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed vsg::RenderPass to support VK_KHR_create_renderpass2 for Vulkan versions less than 1.2. Fixed Vulkan 1.2 check to include the physicalDevice's apiVersion.

The Vulkan spec 3.7.2. states: "Device-level functionality added by a device extension that is dispatched from a VkDevice [...] must not be used unless that extension is supported by the device as determined by vkEnumerateDeviceExtensionProperties, and that extension is enabled in VkDeviceCreateInfo. [...] Device-level functionality or behavior added by a new core version of the API must not be used unless it is supported by the device as determined by VkPhysicalDeviceProperties::apiVersion and the specified version of VkApplicationInfo::apiVersion."

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested that depth resolve attachment is no longer blank when VkInstance is created with apiVersion 1.1

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
