### PR TITLE
[ADDED] Data::clone

### DIFF
--- a/include/vsg/core/Array.h
+++ b/include/vsg/core/Array.h
@@ -50,8 +50,7 @@ namespace vsg
             if (_size != 0)
             {
                 _data = _allocate(_size);
-                auto dest_v = _data;
-                for (auto& v : rhs) *(dest_v++) = v;
+                std::memcpy(_data, rhs.dataPointer(), dataSize());
             }
             dirty();
         }
@@ -121,6 +120,11 @@ namespace vsg
         static ref_ptr<Array> create(ref_ptr<Data> data, uint32_t offset, uint32_t stride, std::initializer_list<value_type> l)
         {
             return ref_ptr<Array>(new Array(data, offset, stride, l));
+        }
+
+        ref_ptr<Data> clone() const override
+        {
+            return ref_ptr<Array>(new Array(*this));
         }
 
         std::size_t sizeofObject() const noexcept override { return sizeof(Array); }
@@ -219,8 +223,7 @@ namespace vsg
             if (_size != 0)
             {
                 _data = _allocate(_size);
-                auto dest_v = _data;
-                for (auto& v : rhs) *(dest_v++) = v;
+                std::memcpy(_data, rhs.dataPointer(), dataSize());
             }
 
             dirty();

--- a/include/vsg/core/Array2D.h
+++ b/include/vsg/core/Array2D.h
@@ -52,8 +52,7 @@ namespace vsg
             if (_width != 0 && _height != 0)
             {
                 _data = _allocate(_width * _height);
-                auto dest_v = _data;
-                for (auto& v : rhs) *(dest_v++) = v;
+                std::memcpy(_data, rhs.dataPointer(), dataSize());
             }
             dirty();
         }
@@ -93,6 +92,11 @@ namespace vsg
         static ref_ptr<Array2D> create(Args&&... args)
         {
             return ref_ptr<Array2D>(new Array2D(args...));
+        }
+
+        ref_ptr<Data> clone() const override
+        {
+            return ref_ptr<Array2D>(new Array2D(*this));
         }
 
         std::size_t sizeofObject() const noexcept override { return sizeof(Array2D); }
@@ -196,8 +200,7 @@ namespace vsg
             if (_width != 0 && _height != 0)
             {
                 _data = _allocate(_width * _height);
-                auto dest_v = _data;
-                for (auto& v : rhs) *(dest_v++) = v;
+                std::memcpy(_data, rhs.dataPointer(), dataSize());
             }
 
             dirty();

--- a/include/vsg/core/Array3D.h
+++ b/include/vsg/core/Array3D.h
@@ -53,8 +53,7 @@ namespace vsg
             if (_width != 0 && _height != 0 && _depth != 0)
             {
                 _data = _allocate(_width * _height * _depth);
-                auto dest_v = _data;
-                for (auto& v : rhs) *(dest_v++) = v;
+                std::memcpy(_data, rhs.dataPointer(), dataSize());
             }
             dirty();
         }
@@ -101,6 +100,11 @@ namespace vsg
         static ref_ptr<Array3D> create(Args&&... args)
         {
             return ref_ptr<Array3D>(new Array3D(args...));
+        }
+
+        ref_ptr<Data> clone() const override
+        {
+            return ref_ptr<Array3D>(new Array3D(*this));
         }
 
         std::size_t sizeofObject() const noexcept override { return sizeof(Array3D); }
@@ -209,8 +213,7 @@ namespace vsg
             if (_width != 0 && _height != 0 && _depth != 0)
             {
                 _data = _allocate(_width * _height * _depth);
-                auto dest_v = _data;
-                for (auto& v : rhs) *(dest_v++) = v;
+                std::memcpy(_data, rhs.dataPointer(), dataSize());
             }
 
             dirty();

--- a/include/vsg/core/Data.h
+++ b/include/vsg/core/Data.h
@@ -156,6 +156,8 @@ namespace vsg
 
         bool dynamic() const { return properties.dataVariance >= DYNAMIC_DATA; }
 
+        virtual ref_ptr<Data> clone() const = 0;
+
         virtual std::size_t valueSize() const = 0;
         virtual std::size_t valueCount() const = 0;
 

--- a/include/vsg/core/Value.h
+++ b/include/vsg/core/Value.h
@@ -57,6 +57,11 @@ namespace vsg
             return ref_ptr<Value>(new Value(args...));
         }
 
+        ref_ptr<Data> clone() const override
+        {
+            return ref_ptr<Value>(new Value(*this));
+        }
+
         std::size_t sizeofObject() const noexcept override { return sizeof(Value); }
         const char* className() const noexcept override { return type_name<Value>(); }
         const std::type_info& type_info() const noexcept override { return typeid(*this); }


### PR DESCRIPTION
# Pull Request Template

## Description

Added vsg::Data::clone to help compensate the lack of vsg::Visitor support for user defined `vsg::Value<>` types. Fixed block array copy constructor compile errors caused by unassignable value_type `unsigned char[8]`.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Observed unique animation state on cloned `Value<>`, `floatArray` and `mat4Array` objects

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
