### PR TITLE
[FIXED] removed externalNumDescriptorSets for ViewDependentState

### DIFF
--- a/src/vsg/vk/ResourceRequirements.cpp
+++ b/src/vsg/vk/ResourceRequirements.cpp
@@ -226,9 +226,6 @@ void CollectResourceRequirements::apply(const View& view)
 
     if (view.viewDependentState)
     {
-        uint32_t numBufferedDescriptorSets = 3;
-        requirements.externalNumDescriptorSets += numBufferedDescriptorSets;
-        requirements.descriptorTypeMap[VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER] += numBufferedDescriptorSets;
         if (requirements.maxSlot < 2) requirements.maxSlot = 2;
 
         view.viewDependentState->accept(*this);


### PR DESCRIPTION
# Pull Request Template

## Description

Removed no longer required externalNumDescriptorSets for vsg::ViewDependentState.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested several vsgExamples

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
