### PR TITLE
Prevent Scissor being rescaled multiple times if camera shared by multiple views.

### DIFF
--- a/src/vsg/app/WindowResizeHandler.cpp
+++ b/src/vsg/app/WindowResizeHandler.cpp
@@ -187,7 +187,7 @@ void WindowResizeHandler::apply(vsg::View& view)
         bool renderAreaMatches = (renderArea.offset.x == scissor.offset.x) && (renderArea.offset.y == scissor.offset.y) &&
                                  (renderArea.extent.width == scissor.extent.width) && (renderArea.extent.height == scissor.extent.height);
 
-        scale_rect(scissor);
+        if(new_extent != scissor.extent) scale_rect(scissor);
 
         viewport.x = static_cast<float>(scissor.offset.x);
         viewport.y = static_cast<float>(scissor.offset.y);


### PR DESCRIPTION
## Description

If a camera is shared by multiple views and the window is resized, then the WindowResizeHandler::apply(vsg::View& view) method will rescale the viewport for every view. This results in the first view having a correct viewport, but successive views being incorrect. 

Fixes # (issue)

This PR checks if the new_extent is different from the current scissor extent and only applies the scaling if they are different. For the second view, the extents are the same and no additional scaling is applied.

Note that I don't fully understand if there are other implications to this.

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Fixes the issue in my own application of Kubuntu 22.04

