### PR TITLE
Filter repeated keypress events when holding keys down on windows

### DIFF
--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -616,8 +616,8 @@ LRESULT Win32_Window::handleWin32Messages(UINT msg, WPARAM wParam, LPARAM lParam
         if (_keyboard->getKeySymbol(wParam, lParam, keySymbol, modifiedKeySymbol, keyModifier))
         {
             int32_t repeatCount = (lParam & 0xffff);
-            bool previousKeyDown = (lParam & 0x40000000);
-            if (!previousKeyDown)
+            bool previouslyKeyDown = (lParam & 0x40000000);
+            if (!previouslyKeyDown)
                 bufferedEvents.emplace_back(vsg::KeyPressEvent::create(this, event_time, keySymbol, modifiedKeySymbol, keyModifier, repeatCount));
         }
         break;

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -616,7 +616,9 @@ LRESULT Win32_Window::handleWin32Messages(UINT msg, WPARAM wParam, LPARAM lParam
         if (_keyboard->getKeySymbol(wParam, lParam, keySymbol, modifiedKeySymbol, keyModifier))
         {
             int32_t repeatCount = (lParam & 0xffff);
-            bufferedEvents.emplace_back(vsg::KeyPressEvent::create(this, event_time, keySymbol, modifiedKeySymbol, keyModifier, repeatCount));
+            bool previousKeyDown = (lParam & 0x40000000);
+            if (!previousKeyDown)
+                bufferedEvents.emplace_back(vsg::KeyPressEvent::create(this, event_time, keySymbol, modifiedKeySymbol, keyModifier, repeatCount));
         }
         break;
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Holding a key down on windows generates repeated keydown events after a second or so. This change filters out key press events by checking if their last state was also down (using the "previous key state", bit 30) 

[https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-keydown]

Note that the "repeat count" field isn't much help for this as is not cumulative when multiple messages are sent when a key is held down. 

Fixes # (issue)
Keyboard functionality in trackball manipulator on windows not working properly when holding down alpha numeric keys.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issues

## How Has This Been Tested?

- Tested trackball manipulator on vsgviewer example.

**Test Configuration**:

Windows 10
