### PR TITLE
Update Keyboard.cpp to handle repeat key presses in windows

### DIFF
--- a/src/vsg/ui/Keyboard.cpp
+++ b/src/vsg/ui/Keyboard.cpp
@@ -25,7 +25,7 @@ void Keyboard::apply(KeyPressEvent& keyPress)
     {
         auto& keyHistory = keyState_itr->second;
         keyHistory.handled = keyPress.handled;
-        if (keyHistory.timeOfKeyRelease == keyPress.time)
+        if (keyHistory.timeOfKeyRelease == keyPress.time || keyHistory.timeOfKeyRelease <= keyHistory.timeOfLastKeyPress)
         {
             keyHistory.timeOfKeyRelease = keyHistory.timeOfFirstKeyPress;
             keyHistory.timeOfLastKeyPress = keyPress.time;


### PR DESCRIPTION
Identify repeated key press events (when key held down) in windows by checking in the key history that a key release event time is not more recent than the last key press.

Fixes # (issue)
Previously windows repeat key press events were not handled. This change identifies them so they can be processed the same was as xcb key events

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in windows 10 & 11, using vsgviewer with vsgTrackBall and IMGUI example
