### PR TITLE
[FIXED] threaded command graph submission order

### DIFF
--- a/src/vsg/app/Viewer.cpp
+++ b/src/vsg/app/Viewer.cpp
@@ -511,19 +511,14 @@ void Viewer::setupThreading()
             // we have multiple CommandGraphs in a single Task so set up a thread per CommandGraph
             struct SharedData : public Inherit<Object, SharedData>
             {
-                SharedData(ref_ptr<RecordAndSubmitTask> in_task, ref_ptr<FrameBlock> in_frameBlock, ref_ptr<Barrier> in_submissionCompleted, uint32_t numThreads) :
+                SharedData(ref_ptr<RecordAndSubmitTask> in_task, ref_ptr<FrameBlock> in_frameBlock, ref_ptr<Barrier> in_submissionCompleted, uint32_t numThreads, size_t numCommandGraphs) :
                     task(in_task),
                     frameBlock(in_frameBlock),
                     submissionCompletedBarrier(in_submissionCompleted)
                 {
                     recordStartBarrier = Barrier::create(numThreads);
                     recordCompletedBarrier = Barrier::create(numThreads);
-                }
-
-                void add(CommandBuffers& commandBuffers)
-                {
-                    std::scoped_lock lock(recordCommandBuffersMutex);
-                    recordedCommandBuffers.insert(recordedCommandBuffers.end(), commandBuffers.begin(), commandBuffers.end());
+                    orderedRecordedCommandBuffers.resize(numCommandGraphs);
                 }
 
                 // shared between all threads
@@ -532,8 +527,7 @@ void Viewer::setupThreading()
                 ref_ptr<Barrier> submissionCompletedBarrier;
 
                 // shared between threads associated with each task
-                std::mutex recordCommandBuffersMutex;
-                CommandBuffers recordedCommandBuffers;
+                std::vector<CommandBuffers> orderedRecordedCommandBuffers;
 
                 ref_ptr<Barrier> recordStartBarrier;
                 ref_ptr<Barrier> recordCompletedBarrier;
@@ -542,7 +536,7 @@ void Viewer::setupThreading()
             uint32_t numThreads = static_cast<uint32_t>(task->commandGraphs.size());
             if (task->earlyTransferTask) ++numThreads;
 
-            ref_ptr<SharedData> sharedData = SharedData::create(task, _frameBlock, _submissionCompleted, numThreads);
+            ref_ptr<SharedData> sharedData = SharedData::create(task, _frameBlock, _submissionCompleted, numThreads, task->commandGraphs.size());
 
             auto run_primary = [](ref_ptr<SharedData> data, ref_ptr<CommandGraph> commandGraph) {
                 auto frameStamp = data->frameBlock->initial_value;
@@ -557,22 +551,23 @@ void Viewer::setupThreading()
 
                     //vsg::info("run_primary");
 
-                    CommandBuffers localRecordedCommandBuffers;
-                    commandGraph->record(localRecordedCommandBuffers, frameStamp, data->task->databasePager);
-
-                    data->add(localRecordedCommandBuffers);
+                    commandGraph->record(data->orderedRecordedCommandBuffers.front(), frameStamp, data->task->databasePager);
 
                     data->recordCompletedBarrier->arrive_and_wait();
 
                     // primary thread finishes the task, submitting all the command buffers recorded by the primary and all secondary threads to it's queue
-                    data->task->finish(data->recordedCommandBuffers);
-                    data->recordedCommandBuffers.clear();
+                    CommandBuffers localRecordedCommandBuffers;
+                    for (const auto& commandBuffers : data->orderedRecordedCommandBuffers)
+                        localRecordedCommandBuffers.insert(localRecordedCommandBuffers.end(), commandBuffers.begin(), commandBuffers.end());
+                    data->task->finish(localRecordedCommandBuffers);
+                    for (auto& commandBuffers : data->orderedRecordedCommandBuffers)
+                        commandBuffers.clear();
 
                     data->submissionCompletedBarrier->arrive_and_wait();
                 }
             };
 
-            auto run_secondary = [](ref_ptr<SharedData> data, ref_ptr<CommandGraph> commandGraph) {
+            auto run_secondary = [](ref_ptr<SharedData> data, ref_ptr<CommandGraph> commandGraph, uint32_t commandGraphIndex) {
                 auto frameStamp = data->frameBlock->initial_value;
 
                 // wait for this frame to be signaled
@@ -580,10 +575,7 @@ void Viewer::setupThreading()
                 {
                     data->recordStartBarrier->arrive_and_wait();
 
-                    CommandBuffers localRecordedCommandBuffers;
-                    commandGraph->record(localRecordedCommandBuffers, frameStamp, data->task->databasePager);
-
-                    data->add(localRecordedCommandBuffers);
+                    commandGraph->record(data->orderedRecordedCommandBuffers[commandGraphIndex], frameStamp, data->task->databasePager);
 
                     data->recordCompletedBarrier->arrive_and_wait();
                 }
@@ -610,7 +602,7 @@ void Viewer::setupThreading()
                 if (i == 0)
                     threads.emplace_back(run_primary, sharedData, task->commandGraphs[i]);
                 else
-                    threads.emplace_back(run_secondary, sharedData, task->commandGraphs[i]);
+                    threads.emplace_back(run_secondary, sharedData, task->commandGraphs[i], i);
             }
 
             if (task->earlyTransferTask)


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed the submission order of command graphs contained in a threaded RecordAndSubmitTask to match the submission order in a single threaded task.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested that vsgrendertotexture --mt -s no longer displays black in the first frame due to the undefined submission order of the RTT and main command graphs

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
