### PR TITLE
include type_traits for std::is_floating_point_v

### DIFF
--- a/include/vsg/maths/vec2.h
+++ b/include/vsg/maths/vec2.h
@@ -26,6 +26,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/type_name.h>
 
 #include <cmath>
+#include <type_traits>
 
 namespace vsg
 {


### PR DESCRIPTION
The template is officially defined in type_traits. I thought that this was causing a compilation problem with clang; it turns out it wasn't, but we can't depend on it being magically defined somewhere else.

