### PR TITLE
Descriptor set layouts based on shader set definitions

### DIFF
--- a/include/vsg/utils/GraphicsPipelineConfigurator.h
+++ b/include/vsg/utils/GraphicsPipelineConfigurator.h
@@ -73,6 +73,15 @@ namespace vsg
 
         void init();
 
+        std::set<std::string>& defines()
+        {
+            return shaderHints->defines;
+        }
+        const std::set<std::string>& defines() const
+        {
+            return shaderHints->defines;
+        }
+
         // setup by init()
         ref_ptr<DescriptorSetLayout> descriptorSetLayout;
         ref_ptr<PipelineLayout> layout;

--- a/include/vsg/utils/GraphicsPipelineConfigurator.h
+++ b/include/vsg/utils/GraphicsPipelineConfigurator.h
@@ -28,6 +28,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/state/ViewportState.h>
 #include <vsg/utils/ShaderSet.h>
 
+#include <optional>
+
 namespace vsg
 {
 
@@ -83,14 +85,22 @@ namespace vsg
     class VSG_DECLSPEC DescriptorConfigurator : public vsg::Inherit<Object, DescriptorConfigurator>
     {
     public:
-        DescriptorConfigurator(ref_ptr<ShaderSet> in_shaderSet = {});
-
+        DescriptorConfigurator(ref_ptr<ShaderSet> in_shaderSet = {})
+            : shaderSet(in_shaderSet)
+        {
+        }
+        DescriptorConfigurator(uint32_t in_setNumber, vsg::ref_ptr<vsg::ShaderSet> in_shaderSet = {})
+            : shaderSet(in_shaderSet), setNumber(in_setNumber)
+        {
+        }
         ref_ptr<ShaderSet> shaderSet;
         bool blending = false;
         bool two_sided = false;
 
         bool assignTexture(const std::string& name, ref_ptr<Data> textureData = {}, ref_ptr<Sampler> sampler = {});
+        bool assignTexture(const std::string& name, const vsg::ImageInfoList& imageInfoList, uint32_t arrayElement = 0);
         bool assignUniform(const std::string& name, ref_ptr<Data> data = {});
+        bool assignUniform(const std::string& name, const vsg::BufferInfoList& bufferInfoList, uint32_t arrayElement = 0);
 
         // assign Descriptors to a DescriptorSet
         void init();
@@ -102,6 +112,7 @@ namespace vsg
 
         // filled in by init()
         ref_ptr<DescriptorSet> descriptorSet;
+        std::optional<uint32_t> setNumber;
     };
     VSG_type_name(vsg::DescriptorConfigurator);
 

--- a/include/vsg/utils/ShaderSet.h
+++ b/include/vsg/utils/ShaderSet.h
@@ -135,6 +135,18 @@ namespace vsg
     };
     VSG_type_name(vsg::ShaderSet);
 
+    /**
+     * @brief Create a pipeline layout for some sets of a shader set.
+     *
+     * @param shaderSet the shader set
+     * @param defines Set of defines for assembling the bindings in the sets
+     * @param sets Number of sets to use, starting from 0. Defaults to all sets.
+     * @return the vsg::PipelineLayout object.
+     */
+    extern VSG_DECLSPEC ref_ptr<PipelineLayout> makePipelineLayout(ref_ptr<ShaderSet> shaderSet,
+                                                                   const std::set<std::string>& defines = {},
+                                                                   int sets = -1);
+
     /// create a ShaderSet for unlit, flat shaded rendering
     extern VSG_DECLSPEC ref_ptr<ShaderSet> createFlatShadedShaderSet(ref_ptr<const Options> options = {});
 


### PR DESCRIPTION
This moves GraphicsPipelineConfigurator away from managing a single descriptor set plus another for view dependent state. The layout is generated using the shader set and defines. These changes are ported from vsgCs, with an extra effort for compatibility with exisiting uses of GraphicsPipelineConfigurator.

There are two objectives here:
* support multiple, arbitrary descriptor sets i.e., don't assume model data on 0 and lighting on 1. I use this in vsgCs.
* Support additional descriptors in vsgXchange by defining them in a custom shader set.

I haven't changed the assimp loadger in vsgXchange yet, pending feedback on these changes.