### PR TITLE
[FIXED] VK_LOD_CLAMP_NONE computed mipmap levels

### DIFF
--- a/src/vsg/state/ImageInfo.cpp
+++ b/src/vsg/state/ImageInfo.cpp
@@ -93,29 +93,25 @@ FormatTraits vsg::getFormatTraits(VkFormat format, bool default_one)
 
 uint32_t vsg::computeNumMipMapLevels(const Data* data, const Sampler* sampler)
 {
-    uint32_t mipLevels = sampler != nullptr ? static_cast<uint32_t>(ceil(sampler->maxLod)) : 1;
-
-    // clamp the mipLevels so that its no larger than what the data dimensions support
-    uint32_t maxDimension = std::max({data->width(), data->height(), data->depth()});
-    if (mipLevels == VK_LOD_CLAMP_NONE)
+    uint32_t mipLevels = 1;
+    if (sampler)
     {
-        mipLevels = 1;
-
-        while ((1u << (mipLevels - 1)) < maxDimension)
+        // clamp the mipLevels so that its no larger than what the data dimensions support
+        uint32_t maxDimension = std::max({data->width(), data->height(), data->depth()});
+        if (sampler->maxLod == VK_LOD_CLAMP_NONE)
         {
-            ++mipLevels;
+            while ((1u << (mipLevels - 1)) < maxDimension)
+            {
+                ++mipLevels;
+            }
         }
-    }
-    else
-    {
-        if (mipLevels == 0)
+        else if (static_cast<uint32_t>(sampler->maxLod) > 1)
         {
-            mipLevels = 1;
-        }
-
-        while ((1u << (mipLevels - 1)) > maxDimension)
-        {
-            --mipLevels;
+            mipLevels = static_cast<uint32_t>(sampler->maxLod);
+            while ((1u << (mipLevels - 1)) > maxDimension)
+            {
+                --mipLevels;
+            }
         }
     }
 

--- a/src/vsg/state/ImageInfo.cpp
+++ b/src/vsg/state/ImageInfo.cpp
@@ -94,16 +94,29 @@ FormatTraits vsg::getFormatTraits(VkFormat format, bool default_one)
 uint32_t vsg::computeNumMipMapLevels(const Data* data, const Sampler* sampler)
 {
     uint32_t mipLevels = sampler != nullptr ? static_cast<uint32_t>(ceil(sampler->maxLod)) : 1;
-    if (mipLevels == 0)
-    {
-        mipLevels = 1;
-    }
 
     // clamp the mipLevels so that its no larger than what the data dimensions support
     uint32_t maxDimension = std::max({data->width(), data->height(), data->depth()});
-    while ((1u << (mipLevels - 1)) > maxDimension)
+    if (mipLevels == VK_LOD_CLAMP_NONE)
     {
-        --mipLevels;
+        mipLevels = 1;
+
+        while ((1u << (mipLevels - 1)) < maxDimension)
+        {
+            ++mipLevels;
+        }
+    }
+    else
+    {
+        if (mipLevels == 0)
+        {
+            mipLevels = 1;
+        }
+
+        while ((1u << (mipLevels - 1)) > maxDimension)
+        {
+            --mipLevels;
+        }
     }
 
     //mipLevels = 1;  // disable mipmapping


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed incorrect value returned by vsg::computeNumMipMapLevels when maxLod is set to VK_LOD_CLAMP_NONE.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Before:
```
computeNumMipMapLevels(width=256, maxLod=10) = 9
computeNumMipMapLevels(width=256, maxLod=VK_LOD_CLAMP_NONE) = 1000
```

After:
```
computeNumMipMapLevels(width=256, maxLod=10)
 = 9
computeNumMipMapLevels(width=256, maxLod=VK_LOD_CLAMP_NONE) = 9
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
