### PR TITLE
Deal with "missing" descriptor sets in ShaderSet::assignDescriptor

### DIFF
--- a/include/vsg/utils/ShaderSet.h
+++ b/include/vsg/utils/ShaderSet.h
@@ -167,6 +167,10 @@ namespace vsg
         inline ref_ptr<PipelineLayout> createPipelineLayout(const std::set<std::string>& defines) { return createPipelineLayout(defines, descriptorSetRange()); }
 
         /// create pipeline layout for specified range {minimum_set, maxiumum_set+1> of descriptor sets that are enabled by specified defines or required by default.
+        ///
+        /// Note: the underlying Vulkan call vkCreatePipelineLayout assumes that the array of
+        /// descriptor sets starts with set 0. Therefore the minimum_set argument should be 0 unless
+        /// you really know what you're doing.
         virtual ref_ptr<PipelineLayout> createPipelineLayout(const std::set<std::string>& defines, std::pair<uint32_t, uint32_t> range) const;
 
         int compare(const Object& rhs) const override;

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -152,17 +152,21 @@ bool DescriptorConfigurator::assignUniform(const std::string& name, const Buffer
 
 bool DescriptorConfigurator::assignDescriptor(uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Descriptor> descriptor)
 {
-    if (set >= descriptorSets.size()) descriptorSets.resize(set + 1);
-
-    auto& ds = descriptorSets[set];
-    if (!ds)
+    if (auto currentSize = descriptorSets.size(); set >= currentSize)
     {
-        ds = vsg::DescriptorSet::create();
-        ds->setLayout = DescriptorSetLayout::create();
+        descriptorSets.resize(set + 1);
+        for (auto i = currentSize; i <= set; i++)
+        {
+            if (!descriptorSets[i])
+            {
+                descriptorSets[i] = vsg::DescriptorSet::create();
+                descriptorSets[i]->setLayout = DescriptorSetLayout::create();
+            }
+        }
     }
 
+    auto& ds = descriptorSets[set];
     ds->descriptors.push_back(descriptor);
-
     auto& descriptorBindings = ds->setLayout->bindings;
     descriptorBindings.push_back(VkDescriptorSetLayoutBinding{binding, descriptorType, descriptorCount, stageFlags, nullptr});
 


### PR DESCRIPTION
Also, add a comment to createPipelineLayout

I found some of the same problems as @robertosfield did last night. The fix to assignDescriptor is necessary for vsgCs' usage.