### PR TITLE
Write nullptr to end of argv array after shifting it

### DIFF
--- a/include/vsg/utils/CommandLine.h
+++ b/include/vsg/utils/CommandLine.h
@@ -102,16 +102,19 @@ namespace vsg
             {
                 // removed section is at end of argv so just reset argc to i
                 *_argc = i;
-                return;
             }
-
-            // shift all the remaining entries down to fill the removed space
-            for (; source < *_argc; ++i, ++source)
+            else
             {
-                _argv[i] = _argv[source];
-            }
+                // shift all the remaining entries down to fill the removed space
+                for (; source < *_argc; ++i, ++source)
+                {
+                    _argv[i] = _argv[source];
+                }
 
-            *_argc -= num;
+                *_argc -= num;
+            }
+            // Preserve C invariant that argv ends with a null pointer
+            _argv[*_argc] = nullptr;
         }
 
         template<typename... Args>


### PR DESCRIPTION
Argv is specified both by the length of argc and a trailing nullptr. The motivation for this fix is unpleasant behavior in Qt, which under Windows presents the user's main() function with an argv built up using new and delete. However, this is a useful invariant in general.
