### PR TITLE
[FIXED] typos found in code review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ vsg_add_target_docs(
         ${VSG_SOURCE_DIR}/include/vsg
 )
 
-# automatically buil_all_h build target to generate the include/vsg/all.h from the headers in the include/vsg/* directories
+# build_all_h build target to automatically generate the include/vsg/all.h from the headers in the include/vsg/* directories
 add_custom_target(build_all_h
     COMMAND ${CMAKE_COMMAND} -DVSG_SOURCE_DIR=${VSG_SOURCE_DIR} -P ${VSG_SOURCE_DIR}/cmake/build_all_h.cmake
 )

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@
 ## Prerequisites
 
 * C++17 compliant compiler i.e. g++ 7.3 or later, Clang 6.0 or later, Visual Studio S2017 or later.
-* [Vulkan](https://vulkan.lunarg.com/) 1.1 or later.  You can use Vulkan (libs and headers) installed from repositories or using VulkanSDK.
+* [Vulkan](https://vulkan.lunarg.com/) 1.1 or later.  You can use Vulkan (libs and headers) installed from repositories or VulkanSDK.
 * [CMake](https://www.cmake.org) 3.7 or later.
 
 ---
@@ -148,7 +148,7 @@ Most of these are standard options which you can look up in CMake and make docum
 
 ## Using the VSG within your own projects
 
-The project is currently a prototype that is undergoing continuous development so it isn't recommend to use as base for long term software development. At this point it's available for developers who want to test the bleeding edge and provide feedback on it's fitness for purpose. Following instructions assume your project uses CMake, which at this early stage in the project is the recommended route when using the VSG.
+The project is currently a prototype that is undergoing continuous development so it isn't recommended to use as a base for long term software development. At this point it's available for developers who want to test the bleeding edge and provide feedback on its fitness for purpose. The following instructions assume your project uses CMake, which at this early stage in the project is the recommended route when using the VSG.
 
 To assist with setting up software to work with the VSG when you install the library a CMake package configuration file will be installed in the lib/cmake/vsg directory. Within your CMake CMakeLists.txt script to find the VSG related dependencies you'll need to add:
 
@@ -174,9 +174,9 @@ For example, a bare minimum CMakeLists.txt file to compile a single file applica
 
 ### Using VSG provided cmake macros within your own projects
 
-The build system provides macros that create specific cmake targets to use in their project. Examples include: Setup of common cmake variables, Formatting source code, performing static code analysis, creating API documentation, cleaning up source directories, and removing installed files. Documentation of the available macros (the public ones starting with ```vsg_```) are at https://github.com/vsg-dev/VulkanSceneGraph/blob/master/cmake/vsgMacros.cmake.
+The build system provides macros that create specific cmake targets to use in your project. Examples include: Setup of common cmake variables, formatting source code, performing static code analysis, creating API documentation, cleaning up source directories, and removing installed files. Documentation of the available macros (the public ones starting with ```vsg_```) are at https://github.com/vsg-dev/VulkanSceneGraph/blob/master/cmake/vsgMacros.cmake.
 
-For example, a bare minimum CMakeLists.txt file adding the mentioned cmake target would be:
+For example, a bare minimum CMakeLists.txt file adding the mentioned cmake targets would be:
 
 	cmake_minimum_required(VERSION 3.7)
 	find_package(vsg REQUIRED)
@@ -227,7 +227,7 @@ Hints for the structure of the template file can be found at https://cmake.org/c
 
 ## Detailed instructions for setting up your environment and building for Microsoft Windows
 
-While not the only route to installing Vulkan libs an headers on Windows the most common approach is to use the Vulkan SDK. LunarG provides a convenient installer for the Vulkan SDK and runtime on Windows.
+While not the only route to installing Vulkan libs and headers on Windows the most common approach is to use the Vulkan SDK. LunarG provides a convenient installer for the Vulkan SDK and runtime on Windows.
 
 [Vulkan Downloads](https://vulkan.lunarg.com/sdk/home#windows)
 
@@ -247,7 +247,7 @@ So now we have the Vulkan SDK installed and findable by CMake so we can go ahead
 
 After running CMake open the generated VSG.sln file and build the All target. Once built you can run the install target. If you are using the default CMake install path (in Program Files folder), ensure you have started Visual Studio as administrator otherwise the install will fail.
 
-It's recommended at this point that you add the VSG install path to you CMAKE_PREFIX_PATH, this will allow other CMake projects, like the vsgExamples project to find your VSG installation. CMAKE_PREFIX_PATH can be set as an environment variable on you system.
+It's recommended at this point that you add the VSG install path to your CMAKE_PREFIX_PATH, this will allow other CMake projects, like the vsgExamples project to find your VSG installation. CMAKE_PREFIX_PATH can be set as an environment variable on your system.
 
     CMAKE_PREFIX_PATH = C:\Program Files\VSG
 
@@ -255,7 +255,7 @@ It's recommended at this point that you add the VSG install path to you CMAKE_PR
 
 ## Detailed instructions for setting up your environment and building for Android
 
-This guide is to build VSG for Android, these steps have been completed on macOS but should be almost identical on Linux and similar on Windows. Inorder to build VSG for Android you'll need the following installed on your machine.
+This guide describes building the VSG for Android. These steps have been completed on macOS but should be almost identical on Linux and similar on Windows. In order to build VSG for Android you'll need the following installed on your machine.
 
 	Android NDK 18
 	CMake 3.13
@@ -264,9 +264,9 @@ The easiest way to get the Android NDK installed is via Android Studio. Follow t
 
 [Android Studio](https://developer.android.com/studio/)
 
-If you got to the 'SDK Manager' ensure you have at least Android API level 24 installed, then go to the 'SDK Tools' tab and check the 'NDK' option. Once done click apply and Android Studio should download and install these components for you.
+Go to the 'SDK Manager' and ensure you have at least Android API level 24 installed, then go to the 'SDK Tools' tab and check the 'NDK' option. Once done click apply and Android Studio should download and install these components for you.
 
-If you already have Android Studio and or the NDK installed. Still go to the 'SDK Manager' and see if you need to update your NDK to version 18.
+If you already have Android Studio and or the NDK installed, still go to the 'SDK Manager' and see if you need to update your NDK to version 18.
 
 Take note of the 'Android SDK Location' as you'll need it when running CMake to generate our Android make files.
 
@@ -299,9 +299,9 @@ macOS does not natively support Vulkan. However the excellent MoltenVK library h
 
 [Vulkan Downloads](https://vulkan.lunarg.com/sdk/home#mac)
 
-Download the sdk and unpack it. There's no form of installer but you're able to place the root sdk folder anywhere on your machine. The sdk contains detailed instuctions on how to setup MoltenVK to work on your machine as well has how to redistribute your application contained in the /Documentation/getting_started_macos.md file.
+Download the sdk and unpack it. There's no form of installer but you're able to place the root sdk folder anywhere on your machine. The sdk contains detailed instuctions on how to setup MoltenVK to work on your machine as well as how to redistribute your application contained in the /Documentation/getting_started_macos.md file.
 
-As with other platforms we need the VULKAN_SDK variable which should point to your downloaded sdk folder. Specifically the macOS subfolder of the sdk. This is needed so CMake can find the sdk. Unique to macOS we also need to set environment variables pointing a few files within the sdk. Again the getting started document in the sdk has detailed information relating to these. A quick cheat sheet is provided here, if you use a .bash_profile file in your user folder you can add the following.
+As with other platforms we need the VULKAN_SDK variable which should point to your downloaded sdk folder. Specifically the macOS subfolder of the sdk. This is needed so CMake can find the sdk. Unique to macOS we also need to set environment variables pointing to a few files within the sdk. Again the getting started document in the sdk has detailed information relating to these. A quick cheat sheet is provided here, if you use a .bash_profile file in your user folder you can add the following.
 
 	export VULKAN_SDK="/path/to/your/vulkansdk/macOS"
 	export VK_LAYER_PATH="$VULKAN_SDK/etc/vulkan/explicit_layer.d"
@@ -309,9 +309,9 @@ As with other platforms we need the VULKAN_SDK variable which should point to yo
 	export PATH="$VULKAN_SDK:$VULKAN_SDK/bin:$PATH"
 	export DYLD_LIBRARY_PATH="$VULKAN_SDK/lib:$DYLD_LIBRARY_PATH"
 
-At this point MoltenVK application should be able to run on your machine, as a quick test it's worth running vulkaninfo executable contained within vulkansdk/macOS/bin. If this runs and doesn't produce any errors it's a good indication the sdk is setup correctly.
+At this point MoltenVK applications should be able to run on your machine, as a quick test it's worth running vulkaninfo executable contained within vulkansdk/macOS/bin. If this runs and doesn't produce any errors it's a good indication the sdk is setup correctly.
 
-So now we're ready to build VSG. With the SDK installed this is very similar to other platforms. You can simple run the following commands to clone the source and use CMake to generate and Xcode project.
+So now we're ready to build VSG. With the SDK installed this is very similar to other platforms. You can simply run the following commands to clone the source and use CMake to generate an Xcode project.
 
 	git clone https://github.com/vsg-dev/VulkanSceneGraph.git
 	cd VulkanSceneGraph
@@ -319,12 +319,12 @@ So now we're ready to build VSG. With the SDK installed this is very similar to 
 	
 Once CMake has finished you can open the generated Xcode project and build the 'install' target. This will build VSG and install the headers and generated library onto your machine.
 
-Again, as with other platforms it's useful to now set your CMAKE_PREFIX_PATH to point to the VSG library we have just installed. If you've installed to the default location you can add the following to you .bash_profile file.
+Again, as with other platforms it's useful to now set your CMAKE_PREFIX_PATH to point to the VSG library we have just installed. If you've installed to the default location you can add the following to your .bash_profile file.
 
 	export CMAKE_PREFIX_PATH="/usr/local/lib/cmake/vsg"
-	
-That's it, we've installed the MoltenVK sdk, built VSG and prepared are machine so other CMake projects can find and use the VSG library.
+
+That's it, we've installed the MoltenVK sdk, built VSG and prepared our machine so other CMake projects can find and use the VSG library.
 
 **Important Note!**
 
-Xcode typically ignores the system environment variables, so when running a VSG application from within Xcode you may run into issues. One solution is to add the environment variables to to the run scheme. This can be done by going to 'Product>Scheme>Edit Scheme>Arguments. Then added the above mentioned environment variables.
+Xcode typically ignores the system environment variables, so when running a VSG application from within Xcode you may run into issues. One solution is to add the environment variables to the run scheme. This can be done by going to 'Product>Scheme>Edit Scheme>Arguments. Then add the above mentioned environment variables.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 ![VulkanSceneGraph](https://raw.githubusercontent.com/vsg-dev/VulkanSceneGraph/master/docs/images/VSGlogo.png)
 
-VulkanSceneGraph (VSG), is a modern, cross platform, high performance scene graph library built upon [Vulkan](https://www.khronos.org/vulkan/) graphics/compute API. The software is written in [C++17](https://en.wikipedia.org/wiki/C%2B%2B17), and follows the [CppCoreGuidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) and [FOSS Best Practices](https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria.md).  The source code is published under the [MIT License](LICENSE.md), with the exception a [vulkan.h](include/vsg/vk/vulkan.h) file, used for Vulkan extensions, which is under [Apache License 2.0](LICENSE.Vulkan-Headers.md).
+VulkanSceneGraph (VSG), is a modern, cross platform, high performance scene graph library built upon [Vulkan](https://www.khronos.org/vulkan/) graphics/compute API. The software is written in [C++17](https://en.wikipedia.org/wiki/C%2B%2B17), and follows the [CppCoreGuidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) and [FOSS Best Practices](https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria.md).  The source code is published under the [MIT License](LICENSE.md), with the exception of [vulkan.h](include/vsg/vk/vulkan.h), used for Vulkan extensions, which is under [Apache License 2.0](LICENSE.Vulkan-Headers.md).
 
 This repository contains C++ headers and source and CMake build scripts to build the libvsg library.  Additional support libraries and examples are provided in separate repositories, links to these are provided below.  The software currently builds under Linux (desktops variants through to Jetson & Raspberry Pi), Windows (VisualStudio, MinGW & Cygwin), Android, and macOS & iOS (using [MoltenVk](https://github.com/KhronosGroup/MoltenVK)).
 
 ## Links to further information
 
-The [vulkanscenegraph.org website](https://www.vulkanscenegraph.org) provides a detailed list of features, tutorials and reference documentation, while this repository provides the source code and build support for creating the VulkanScenGraph library. Quick links to resources hosted on the website:
+The [vulkanscenegraph.org website](https://www.vulkanscenegraph.org) provides a detailed list of features, tutorials and reference documentation, while this repository provides the source code and build support for creating the VulkanSceneGraph library. Quick links to resources hosted on the website:
 * [Features](https://vsg-dev.github.io/vsg-dev.io/features) - tour of features you'll find in the VulkanSceneGraph and companion projects.
-* [Screenshots](https://vsg-dev.github.io/vsg-dev.io/screenshots) - screenshots from VulkanSceneGraph exmples and 3rd party library and applications
+* [Screenshots](https://vsg-dev.github.io/vsg-dev.io/screenshots) - screenshots from VulkanSceneGraph examples and 3rd party libraries and applications
 * [Tutorials](https://vsg-dev.github.io/vsg-dev.io/tutorials) - mulit-part tutorial that takes you from introduction to scene graphs to multi-threading and optimization.
 * [Documentation](https://vsg-dev.github.io/vsg-dev.io/documentation) - doxygen generated reference documentation and links to 3rd party learning materials
 * [Discussion](https://github.com/vsg-dev/VulkanSceneGraph/discussions) - Discussion forum hosted on github.
-* [Services](https://vsg-dev.github.io/vsg-dev.io/services) - List of companinies connected to the VulkanSceneGraph project that can provide professional services
+* [Services](https://vsg-dev.github.io/vsg-dev.io/services) - List of companies connected to the VulkanSceneGraph project that can provide professional services
 
 
 ## Links to companion projects that offer additional features
 
 Hosted as part of the [vsg-dev](https://github.com/vsg-dev):
-* [vsgXchange](https://github.com/vsg-dev/vsgXchange) reading and writing of 3rd party image and 3d models and HTTP support.
+* [vsgXchange](https://github.com/vsg-dev/vsgXchange) reading and writing of 3rd party images and 3d models and HTTP support.
 * [vsgExamples](https://github.com/vsg-dev/vsgExamples) tests & examples.
 * [osg2vsg](https://github.com/vsg-dev/osg2vsg) OpenSceneGraph integration library that enables converting of OSG to VSG scene graph and use of OpenSceneGraph loaders.
 * [vsgImGui](https://github.com/vsg-dev/vsgImGui) ImGui integration enabling UI in graphics window.
 * [vsgQt](https://github.com/vsg-dev/vsgQt) Qt integration with VulkanSceneGraph.
-* [vsgPoints](https://github.com/vsg-dev/vsgPoints) 3d point cloud loading and rendering for VulkanSceneGraph with database paging support and scalability up to billions of ponts.
+* [vsgPoints](https://github.com/vsg-dev/vsgPoints) 3d point cloud loading and rendering for VulkanSceneGraph with database paging support and scalability up to billions of points.
 * [vsgUnity](https://github.com/vsg-dev/vsgUnity) plugin for Unity that provides export to native VulkanSceneGraph binary/ascii format.
 * [MyFirstVsgApplication](https://github.com/vsg-dev/MyFirstVsgApplication) simple standalone VSG application that can be used as a template for your own applications.
 * [vsgFramework](https://github.com/vsg-dev/vsgFramework) template project that uses CMake FetchContent to pull in all the main libraries associated with VulkanSceneGraph and dependencies and builds them together.
@@ -37,13 +37,13 @@ Community projects:
 ## Quick Guide to building the VSG
 
 ### Prerequisites:
-* C++17 compliant compiler i.e.. g++ 7.3 or later, Clang 6.0 or later, Visual Studio S2017 or later.
+* C++17 compliant compiler i.e. g++ 7.3 or later, Clang 6.0 or later, Visual Studio S2017 or later.
 * [Vulkan](https://vulkan.lunarg.com/) 1.1 or later.
 * [CMake](https://www.cmake.org) 3.7 or later.
 
 The above dependency versions are known to work so they've been set as the current minimum, it may be possible to build against older versions.  If you find success with older versions let us know and we can update the version info.
 
-Download VulkanSDK from [LunarG](https://vulkan.lunarg.com/sdk/home), unpack into local directory and set VUKAN_SDK environment variable to the include/lib directory within it. For Linux it would typically be along the lines of:
+Download VulkanSDK from [LunarG](https://vulkan.lunarg.com/sdk/home), unpack into local directory and set VULKAN_SDK environment variable to the include/lib directory within it. For Linux it would typically be along the lines of:
 
     export VULKAN_SDK_VERSION=1.2.162.1
     export VULKAN_SDK=${PWD}/VulkanSDK/${VULKAN_SDK_VERSION}/x86_64
@@ -64,4 +64,4 @@ To build and install the static libvsg library (.a/.lib) in source:
     make -j 8
     sudo make install
 
-Full details on how to build of the VSG (Unix/Windows/Android/macOS) can be found in the [INSTALL.md](INSTALL.md) file.
+Full details on how to build the VSG (Unix/Windows/Android/macOS) can be found in the [INSTALL.md](INSTALL.md) file.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,9 @@
 ## Roadmap
 
-Follows are are initially plans for future releases and then going back into time to previously completed milestones.
+Follows are initial plans for future releases and then going back into time to previously completed milestones.
 
 ### Stable Release Support and Functionality build-out Phase, 2023 onwards (underway)
-**Goal: Maintain the VulkanSceneGraph-1.0.x release series and work towards the next stable release VulkanSceneGraph-1.2 - expanding the VulkanScenGraph and companion projects feature sets to address a wider range of uses**
+**Goal: Maintain the VulkanSceneGraph-1.0.x release series and work towards the next stable release VulkanSceneGraph-1.2 - expanding the VulkanSceneGraph and companion projects feature sets to address a wider range of uses**
 
 Discussion of new features:[New Feature Development RoadMap for future VulkanSceneGraph-1.2 release and beyond](https://github.com/vsg-dev/VulkanSceneGraph/discussions/600)
 
@@ -19,7 +19,7 @@ Discussion of new features:[New Feature Development RoadMap for future VulkanSce
 
 #### Future development tasks:
 
-* Support for shadows and environment maps in the Phong and PBR ShaderSets, and helpers functions/classes for creating scene graphs that render shadow maps.
+* Support for shadows and environment maps in the Phong and PBR ShaderSets, and helper functions/classes for creating scene graphs that render shadow maps.
 * Character animation/skinning in standard.vert shaders used by Phong and ShaderSets?
 * Rewrite RayTracing classes to modernize them and bring them more inline with other core VSG classes.
 * Acceleration structures for CPU based geometry operations i.e. KdTree or similar to speed up intersection testing etc.
@@ -50,7 +50,7 @@ Using the prototyping work as a guide implement the final scene graph library wi
 * Support for RTX Mesh shaders and ray tracing.
 * Scene graph level multi-bin support with bin sorting.
 * Support for Khronos ray tracing.
-* Memory allocator with support with grouping associated types
+* Memory allocator with support for grouping associated types
 * Positional state support to enable easier support of lighting, shadows, texture projection.
 * Matrix decomposition
 * Port to iOS

--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -426,7 +426,7 @@ macro(vsg_check_min_vulkan_header_version _min_version)
           file(STRINGS  ${VULKAN_CORE_H} VulkanHeaderVersionLine2 REGEX "^#define VK_HEADER_VERSION_COMPLETE ")
           string(REGEX MATCHALL "[0-9]+" VulkanHeaderVersion2 "${VulkanHeaderVersionLine2}")
           list(LENGTH VulkanHeaderVersion2 _len)
-          #  versions >= 1.2.175 adds an additional numbers in front of e.g. '0, 1, 2' instead of '1, 2'
+          #  versions >= 1.2.175 add an additional number in front e.g. '0, 1, 2' instead of '1, 2'
           if(_len EQUAL 3)
               list(REMOVE_AT VulkanHeaderVersion2 0)
           endif()

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute
 Developers can help contribute to the VSG through testing, reporting issues, bug fixing, feature development and creation of tutorials and documentation.
 
-## Report an bug
+## Report a bug
 
 Please use the Issue tracker on github. We provide two templates, a bug report template and a feature request template to help guide what type of information is useful to us.
 
@@ -15,7 +15,7 @@ If you wish to make a feature request, this can be done via our github Issue tra
 
 ## Feature development
 
-If you have refinement of existing features or added new feature please a make pull requests.
+If you have refined existing features or added new features please a make pull request.
 
 ## In source documentation
 
@@ -23,4 +23,4 @@ In source documentation can be provided in the form of markdown (.MD) files to b
 
 ## 3rd Party tutorials, documentation, libraries and program
 
-If you have written documentation, tutorials, libraries or programs and wish to inform developers about then please considering adding details about them to the docs/3rdParty files and generate a pull request.
+If you have written documentation, tutorials, libraries or programs and wish to inform developers then please consider adding details about them to the docs/3rdParty files and generating a pull request.

--- a/include/vsg/app/Camera.h
+++ b/include/vsg/app/Camera.h
@@ -20,8 +20,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Camera class provides the and projection and view matrices, and viewport settings that control the what a View looks at in a scene.
-    /// Typically assign to a vsg::View, but can also be placed in the scene graph for cases where applications want to track an in scene camera.
+    /// Camera class provides the projection and view matrices, and viewport settings that control what a View looks at in a scene.
+    /// Typically assigned to a vsg::View, but can also be placed in the scene graph for cases where applications want to track an in scene camera
     /// or to specify defined views within the scene, such as places of interest.
     class VSG_DECLSPEC Camera : public Inherit<Node, Camera>
     {
@@ -43,7 +43,7 @@ namespace vsg
     };
     VSG_type_name(vsg::Camera);
 
-    /// FindCameras is visitor that traversals a scene graph to collect the Cameras found within it.
+    /// FindCameras is a visitor that traverses a scene graph to collect the Cameras found within it.
     class VSG_DECLSPEC FindCameras : public Inherit<Visitor, FindCameras>
     {
     public:

--- a/include/vsg/app/CommandGraph.h
+++ b/include/vsg/app/CommandGraph.h
@@ -22,7 +22,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// CommandGraph is a group node that sits at the top of the scene graph and manages the recording of it's subgraph to Vulkan command buffers.
+    /// CommandGraph is a group node that sits at the top of the scene graph and manages the recording of its subgraph to Vulkan command buffers.
     class VSG_DECLSPEC CommandGraph : public Inherit<Group, CommandGraph>
     {
     public:

--- a/include/vsg/app/CompileManager.h
+++ b/include/vsg/app/CompileManager.h
@@ -37,7 +37,7 @@ namespace vsg
         bool requiresViewerUpdate() const;
     };
 
-    /// ComppileManager is a helper class that compiles subgraphs for the window/framebuffer associated with the CompileManager.
+    /// CompileManager is a helper class that compiles subgraphs for the windows/framebuffers associated with the CompileManager.
     class VSG_DECLSPEC CompileManager : public Inherit<Object, CompileManager>
     {
     public:

--- a/include/vsg/app/CompileTraversal.h
+++ b/include/vsg/app/CompileTraversal.h
@@ -28,7 +28,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// CompileTraversal traverses a scene graph invoke all the StateCommand/Command::compile(..) methods to create all Vulkan objects, allocated GPU memory and transfer data to GPU.
+    /// CompileTraversal traverses a scene graph and invokes all the StateCommand/Command::compile(..) methods to create all Vulkan objects, allocate GPU memory and transfer data to GPU.
     class VSG_DECLSPEC CompileTraversal : public Inherit<Visitor, CompileTraversal>
     {
     public:
@@ -38,7 +38,7 @@ namespace vsg
         explicit CompileTraversal(Window& window, ref_ptr<ViewportState> viewport = {}, const ResourceRequirements& resourceRequirements = {});
         explicit CompileTraversal(const Viewer& viewer, const ResourceRequirements& resourceRequirements = {});
 
-        /// specification of the queue to uses
+        /// specification of the queue to use
         VkQueueFlags queueFlags = VK_QUEUE_GRAPHICS_BIT;
         uint32_t queueFamilyIndex = 1;
 
@@ -63,7 +63,7 @@ namespace vsg
         virtual bool record();
         virtual void waitForCompletion();
 
-        /// convenience method that compiles a object/subgraph
+        /// convenience method that compiles an object/subgraph
         template<typename T>
         void compile(T object, bool wait = true)
         {

--- a/include/vsg/app/EllipsoidModel.h
+++ b/include/vsg/app/EllipsoidModel.h
@@ -22,7 +22,7 @@ namespace vsg
     const double WGS_84_RADIUS_EQUATOR = 6378137.0;
     const double WGS_84_RADIUS_POLAR = 6356752.3142;
 
-    /// EllipsoidModel provides a ellipsoid definition of celastral body and helper methods for computing positions/transforms on that ellipsoid.
+    /// EllipsoidModel provides an ellipsoid definition of a celestrial body and helper methods for computing positions/transforms on that ellipsoid.
     /// Defaults to WGS_84 ellipsoid model of Earth.
     class VSG_DECLSPEC EllipsoidModel : public Inherit<Object, EllipsoidModel>
     {

--- a/include/vsg/app/ProjectionMatrix.h
+++ b/include/vsg/app/ProjectionMatrix.h
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// ProjectionMatrix is a base class for specifying the Camera projection matrix and it's inverse.
+    /// ProjectionMatrix is a base class for specifying the Camera projection matrix and its inverse.
     class VSG_DECLSPEC ProjectionMatrix : public Inherit<Object, ProjectionMatrix>
     {
     public:
@@ -36,7 +36,7 @@ namespace vsg
     };
     VSG_type_name(vsg::ProjectionMatrix);
 
-    /// Perspective is a ProjectionMatrix that implements gluPerspective model for setting projection matrix.
+    /// Perspective is a ProjectionMatrix that implements the gluPerspective model for setting the projection matrix.
     class VSG_DECLSPEC Perspective : public Inherit<ProjectionMatrix, Perspective>
     {
     public:
@@ -73,7 +73,7 @@ namespace vsg
     };
     VSG_type_name(vsg::Perspective);
 
-    /// Orthographic is a ProjectionMatrix that implements glOtho model for setting projection matrix.
+    /// Orthographic is a ProjectionMatrix that implements the glOrtho model for setting the projection matrix.
     class Orthographic : public Inherit<ProjectionMatrix, Orthographic>
     {
     public:
@@ -116,7 +116,7 @@ namespace vsg
     };
     VSG_type_name(vsg::Orthographic);
 
-    /// RelativeViewMatrix is a ProjectionMatrix that decorates another ProjectionMatrix and pre-multiplies it's transform matrix to give a relative projection matrix.
+    /// RelativeProjection is a ProjectionMatrix that decorates another ProjectionMatrix and pre-multiplies its transform matrix to give a relative projection matrix.
     class RelativeProjection : public Inherit<ProjectionMatrix, RelativeProjection>
     {
     public:
@@ -143,8 +143,8 @@ namespace vsg
     };
     VSG_type_name(vsg::RelativeProjection);
 
-    /// EllipsoidPerspective is a ProjectionMatrix that implements gluPerspective model for setting projection matrix,
-    /// with automatic clamping of the near/far to an ellispoidModel, typically used for rendering whole earth models.
+    /// EllipsoidPerspective is a ProjectionMatrix that implements the gluPerspective model for setting the projection matrix,
+    /// with automatic clamping of the near/far values to an ellipsoidModel, typically used for rendering whole earth models.
     class EllipsoidPerspective : public Inherit<ProjectionMatrix, EllipsoidPerspective>
     {
     public:

--- a/include/vsg/app/RecordAndSubmitTask.h
+++ b/include/vsg/app/RecordAndSubmitTask.h
@@ -22,7 +22,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// RecordAndSubmitTask manages the recording of it's list of CommanGraph to CommandBuffer which are then submitted to associated vulkan Queue.
+    /// RecordAndSubmitTask manages the recording of its list of CommandGraph to CommandBuffer which are then submitted to the associated vulkan Queue.
     class VSG_DECLSPEC RecordAndSubmitTask : public Inherit<Object, RecordAndSubmitTask>
     {
     public:
@@ -48,7 +48,7 @@ namespace vsg
         /// return the fence index value for relativeFrameIndex where 0 is current frame, 1 is previous frame etc.
         size_t index(size_t relativeFrameIndex = 0) const;
 
-        /// fence() and fence(0) return the Fence for the frame currently being rendered, fence(1) return the previous frame's Fence etc.
+        /// fence() and fence(0) return the Fence for the frame currently being rendered, fence(1) returns the previous frame's Fence etc.
         Fence* fence(size_t relativeFrameIndex = 0);
 
         ref_ptr<Queue> queue;
@@ -64,7 +64,7 @@ namespace vsg
 
     using RecordAndSubmitTasks = std::vector<ref_ptr<RecordAndSubmitTask>>;
 
-    /// update RecordAndSubmitTask data structures to match the needs of newly compile subgraph
+    /// update RecordAndSubmitTask data structures to match the needs of newly compiled subgraphs
     extern VSG_DECLSPEC void updateTasks(RecordAndSubmitTasks& tasks, ref_ptr<CompileManager> compileManager, const CompileResult& compileResult);
 
 } // namespace vsg

--- a/include/vsg/app/RecordTraversal.h
+++ b/include/vsg/app/RecordTraversal.h
@@ -54,7 +54,7 @@ namespace vsg
 
     VSG_type_name(vsg::RecordTraversal);
 
-    /// RecordTraversal traverses a scene graph doing view frustum culling and invoking state/commands to record them to Vulkan command buffer
+    /// RecordTraversal traverses a scene graph doing view frustum culling and invoking state/commands to record them to a Vulkan command buffer
     class VSG_DECLSPEC RecordTraversal : public Object
     {
     public:
@@ -75,13 +75,13 @@ namespace vsg
         Mask traversalMask = MASK_ALL;
         Mask overrideMask = MASK_OFF;
 
-        /// get the current State object used to track state and projection/modelview matrices for current subgraph being traversed
+        /// get the current State object used to track state and projection/modelview matrices for the current subgraph being traversed
         State* getState() { return _state; }
 
-        /// get the current CommandBuffer for current subgraph being traversed
+        /// get the current CommandBuffer for the current subgraph being traversed
         CommandBuffer* getCommandBuffer();
 
-        /// get the current DeviceID for current subgraph being traversed
+        /// get the current DeviceID for the current subgraph being traversed
         uint32_t deviceID() const;
 
         void setFrameStamp(FrameStamp* fs);

--- a/include/vsg/app/RenderGraph.h
+++ b/include/vsg/app/RenderGraph.h
@@ -21,9 +21,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// RenderGraph encapsulates the vkCmdRenderPass/vkCmdEndRenderPass functionality.
-    /// Members variables of the RenderGraph map to the settings of the VkRenderPassBeginInfo.
-    /// During the RecordTraversal children of RenderGraph are visited within vkCmdRenderPass/vkCmdEndRenderPass pair.
+    /// RenderGraph encapsulates the vkCmdBeginRenderPass/vkCmdEndRenderPass functionality.
+    /// Member variables of the RenderGraph map to the settings of the VkRenderPassBeginInfo.
+    /// During the RecordTraversal children of RenderGraph are visited within the vkCmdBeginRenderPass/vkCmdEndRenderPass pair.
     class VSG_DECLSPEC RenderGraph : public Inherit<Group, RenderGraph>
     {
     public:
@@ -44,31 +44,31 @@ namespace vsg
         /// RenderPass to use passed to the vkCmdBeginRenderPass, if renderPass is set it takes precedence, if not then either obtained from which of the framebuffer or window are active
         RenderPass* getRenderPass();
 
-        /// Get the Exten2D of the attached Framebuffer or Window.
+        /// Get the Extent2D of the attached Framebuffer or Window.
         VkExtent2D getExtent() const;
 
-        /// ReandingArea settings for VkRenderPassBeginInfo.renderArea passed to the vkCmdBeginRenderPass, usually maps the ViewportState's scissor
+        /// RenderArea settings for VkRenderPassBeginInfo.renderArea passed to the vkCmdBeginRenderPass, usually matches the ViewportState's scissor
         VkRect2D renderArea;
 
         /// RenderPass to use passed to the vkCmdBeginRenderPass in place of the framebuffer's or window's renderPass. renderPass must be compatible with the render pass used to create the window or framebuffer.
         ref_ptr<RenderPass> renderPass;
 
-        /// Buffer clearing settings for vkRrenderPassInfo.clearValueCount & vkRenderPassInfo.pClearValues passed to the vkCmdBeginRenderPass
+        /// Buffer clearing settings for VkRenderPassBeginInfo.clearValueCount & VkRenderPassBeginInfo.pClearValues passed to the vkCmdBeginRenderPass
         using ClearValues = std::vector<VkClearValue>;
         ClearValues clearValues; // initialize window colour and depth/stencil
 
-        /// initialize cleaValues with the cleaColor or cleaDpethStencil based on the attachments set up in the associated RenderPass.
+        /// initialize clearValues with the clearColor and/or clearDepthStencil based on the attachments set up in the associated RenderPass.
         /// call after a framebuffer or window has been assigned to the RenderGraph.
         void setClearValues(VkClearColorValue clearColor = {{0.2f, 0.2f, 0.4f, 1.0f}}, VkClearDepthStencilValue clearDepthStencil = {0.0f, 0});
 
-        /// Subpass contents stetting passed to vkCmdBeginRenderPass
+        /// Subpass contents setting passed to vkCmdBeginRenderPass
         VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE;
 
         /// Callback used to automatically update viewports, scissors, renderArea and clears when the window is resized.
-        /// By default is null so no resize handling is done.
+        /// By default resize handling is done.
         ref_ptr<WindowResizeHandler> windowResizeHandler;
 
-        /// invoke the WindowResizeHandler, called automatically when window dimension change is detected.
+        /// invoke the WindowResizeHandler, called automatically when a window dimension change is detected.
         void resized();
 
         /// window extent at previous frame, used to track window resizes

--- a/include/vsg/app/SecondaryCommandGraph.h
+++ b/include/vsg/app/SecondaryCommandGraph.h
@@ -50,7 +50,7 @@ namespace vsg
 
     using SecondaryCommandGraphs = std::vector<ref_ptr<SecondaryCommandGraph>>;
 
-    /// convenience function that sets up secondaryCommandGraph to render the specified scene graph from the specified Camera view
+    /// convenience function that sets up SecondaryCommandGraph to render the specified scene graph from the specified Camera view
     extern VSG_DECLSPEC ref_ptr<SecondaryCommandGraph> createSecondaryCommandGraphForView(ref_ptr<Window> window, ref_ptr<Camera> camera, ref_ptr<Node> scenegraph, uint32_t subpass, bool assignHeadlight = true);
 
 } // namespace vsg

--- a/include/vsg/app/Trackball.h
+++ b/include/vsg/app/Trackball.h
@@ -116,7 +116,7 @@ namespace vsg
         /// Key that moves the view upward
         KeySymbol moveUpKey = KEY_Up;
 
-        /// Key that moves the view downard
+        /// Key that moves the view downward
         KeySymbol moveDownKey = KEY_Down;
 
         /// Button mask value used to enable panning of the view, defaults to left mouse button
@@ -131,7 +131,7 @@ namespace vsg
         /// Button mask value used used for touch events
         ButtonMask touchMappedToButtonMask = BUTTON_MASK_1;
 
-        /// Scale for control how rapidly the view zooms in/out. Positive value zooms in when mouse moved downwards
+        /// Scale for controlling how rapidly the view zooms in/out. Positive value zooms in when mouse moves downwards
         double zoomScale = 1.0;
 
         /// Toggle on/off whether the view should continue moving when the mouse buttons are released while the mouse is in motion.

--- a/include/vsg/app/TransferTask.h
+++ b/include/vsg/app/TransferTask.h
@@ -21,7 +21,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// TransferTask manages a collection of dynamically updated vsg::Data associated with GPU memory associated vsg::BufferInfo and vsg::ImageInfo.
+    /// TransferTask manages a collection of dynamically updated vsg::Data associated with GPU memory of vsg::BufferInfo and vsg::ImageInfo.
     /// During the viewer.compile(..) traversal the collection of dynamic data that has dataVariance of DYNAMIC_DATA* is assigned to the appropriate TransferTask
     /// and then each new frame that collection of data is checked to see if the modification count has changed, if it has that data is copied to the associated BufferInfo/ImageInfo.
     /// vsg::Data that are orphaned so the TransferTask has the only remaining reference to them are automatically removed.
@@ -30,7 +30,7 @@ namespace vsg
     public:
         explicit TransferTask(Device* in_device, uint32_t numBuffers = 3);
 
-        /// transfer any vsg::Data entries, that have been updated, to have the associated GPU memory.
+        /// transfer any vsg::Data entries that have been updated to the associated GPU memory.
         virtual VkResult transferDynamicData();
 
         virtual bool containsDataToTransfer() const;
@@ -45,7 +45,7 @@ namespace vsg
         /// return the fence index value for relativeFrameIndex where 0 is current frame, 1 is previous frame etc.
         size_t index(size_t relativeFrameIndex = 0) const;
 
-        /// fence() and fence(0) return the Fence for the frame currently being rendered, fence(1) return the previous frame's Fence etc.
+        /// fence() and fence(0) return the Fence for the frame currently being rendered, fence(1) returns the previous frame's Fence etc.
         Fence* fence(size_t relativeFrameIndex = 0);
 
         void assign(const ResourceRequirements::DynamicData& dynamicData);

--- a/include/vsg/app/View.h
+++ b/include/vsg/app/View.h
@@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// View class is Group class that pairs a Camera that defines the view with a subgraph that defines the scene that is being viewed/rendered
+    /// View is a Group class that pairs a Camera that defines the view with a subgraph that defines the scene that is being viewed/rendered
     class VSG_DECLSPEC View : public Inherit<Group, View>
     {
     public:

--- a/include/vsg/app/ViewMatrix.h
+++ b/include/vsg/app/ViewMatrix.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// ViewMatrix is a base class for specifying the Camera view matrix and it's inverse.
+    /// ViewMatrix is a base class for specifying the Camera view matrix and its inverse.
     class VSG_DECLSPEC ViewMatrix : public Inherit<Object, ViewMatrix>
     {
     public:
@@ -31,7 +31,7 @@ namespace vsg
     };
     VSG_type_name(vsg::ViewMatrix);
 
-    /// LookAt is a ViewMatrix that implements gluLookAt model for specify the view matrix.
+    /// LookAt is a ViewMatrix that implements the gluLookAt model for specifying the view matrix.
     class VSG_DECLSPEC LookAt : public Inherit<ViewMatrix, LookAt>
     {
     public:
@@ -93,7 +93,7 @@ namespace vsg
     };
     VSG_type_name(vsg::LookAt);
 
-    /// RelativeViewMatrix is a ViewMatrix that decorates another ViewMatrix and pre-multiplies it's transform matrix to give a relative view matrix.
+    /// RelativeViewMatrix is a ViewMatrix that decorates another ViewMatrix and pre-multiplies its transform matrix to give a relative view matrix.
     class RelativeViewMatrix : public Inherit<ViewMatrix, RelativeViewMatrix>
     {
     public:
@@ -116,7 +116,7 @@ namespace vsg
 
     /// TrackingViewMatrix is a ViewMatrix that tracks an object in the scene graph.
     /// The view matrix is computed by accumulating the transform matrix encountered
-    /// along a objectPath and then pre-multiplying this by specified matrix.
+    /// along an objectPath and then pre-multiplying this by the specified matrix.
     class VSG_DECLSPEC TrackingViewMatrix : public Inherit<ViewMatrix, TrackingViewMatrix>
     {
     public:

--- a/include/vsg/app/Viewer.h
+++ b/include/vsg/app/Viewer.h
@@ -70,7 +70,7 @@ namespace vsg
 
         void addEventHandlers(EventHandlers&& eventHandlers) { _eventHandlers.splice(_eventHandlers.end(), eventHandlers); }
 
-        /// get the const list of EventHandlers
+        /// get the list of EventHandlers
         EventHandlers& getEventHandlers() { return _eventHandlers; }
 
         /// get the const list of EventHandlers
@@ -85,15 +85,15 @@ namespace vsg
             updateOperations->add(op, runBehavior);
         }
 
-        /// compile manager provides thread safe support for compiling subgraph
+        /// compile manager provides thread safe support for compiling subgraphs
         ref_ptr<CompileManager> compileManager;
 
         /// convenience method for advancing to the next frame.
         /// Check active status, return false if viewer no longer active.
-        /// lf still active poll for pending events and place them in the Events list and advance to the next frame, update generate FrameStamp to signify the advancement to a new frame and return true.
+        /// lf still active, poll for pending events and place them in the Events list and advance to the next frame, generate updated FrameStamp to signify the advancement to a new frame and return true.
         virtual bool advanceToNextFrame();
 
-        /// pass the Events into the any register EventHandlers
+        /// pass the Events into any registered EventHandlers
         virtual void handleEvents();
 
         virtual void compile(ref_ptr<ResourceHints> hints = {});
@@ -104,14 +104,14 @@ namespace vsg
         /// timeout is in nanoseconds.
         virtual VkResult waitForFences(size_t relativeFrameIndex, uint64_t timeout);
 
-        // Manage the work to do each frame using RecordAndSubmitTasks. those that need to present results to be wired up to respective Presentation object
+        // Manage the work to do each frame using RecordAndSubmitTasks. Those that need to present results need to be wired up to respective Presentation objects.
         RecordAndSubmitTasks recordAndSubmitTasks;
 
         // Manage the presentation of rendering using Presentation objects
         using Presentations = std::vector<ref_ptr<Presentation>>;
         Presentations presentations;
 
-        /// Create a RecordAndSubmitTasks and Presentation objects configured to manage specified commandGraphs and assign it to the viewer.
+        /// Create RecordAndSubmitTask and Presentation objects configured to manage specified commandGraphs and assign them to the viewer.
         /// Replace any prexisting setup.
         virtual void assignRecordAndSubmitTaskAndPresentation(CommandGraphs commandGraphs);
 
@@ -152,7 +152,7 @@ namespace vsg
     };
     VSG_type_name(vsg::Viewer);
 
-    /// update Viewer data structures to match the needs of newly compiled subgraph
+    /// update Viewer data structures to match the needs of newly compiled subgraphs
     extern VSG_DECLSPEC void updateViewer(Viewer& viewer, const CompileResult& compileResult);
 
 } // namespace vsg

--- a/include/vsg/app/Window.h
+++ b/include/vsg/app/Window.h
@@ -25,8 +25,8 @@ namespace vsg
 {
 
     /// Window base class provides a cross platform window
-    /// The Android_Window, iOS_Window, MacOS_Window, Xcb_Window and Win32_Window classes from Window provide
-    /// the platform specific implementations of Window that are create by Window::create(traits).
+    /// The Android_Window, iOS_Window, MacOS_Window, Xcb_Window and Win32_Window classes derived from Window provide
+    /// the platform specific implementations of Window that are created by Window::create(traits).
     class VSG_DECLSPEC Window : public Inherit<Object, Window>
     {
     public:
@@ -43,7 +43,7 @@ namespace vsg
         virtual bool visible() const { return valid(); }
 
         /// Release the window as it's owned by a 3rd party windowing object.
-        /// Resets the window handle and invalidating the window, preventing Window deletion or closing from deleting the window resource.
+        /// Resets the window handle and invalidates the window, preventing Window deletion or closing from deleting the window resource.
         virtual void releaseWindow() {}
 
         /// Release the connection as it's owned by a 3rd party windowing object.
@@ -53,7 +53,7 @@ namespace vsg
         /// events buffered since the last pollEvents.
         UIEvents bufferedEvents;
 
-        /// get the list of events since the last poolEvents() call by splicing bufferEvents with polled windowing events.
+        /// get the list of events since the last pollEvents() call by splicing bufferEvents with polled windowing events.
         virtual bool pollEvents(UIEvents& events);
 
         virtual void resize() {}
@@ -112,7 +112,7 @@ namespace vsg
         /// call vkAquireNextImageKHR to find the next imageIndex of the swapchain images/framebuffers
         VkResult acquireNextImage(uint64_t timeout = std::numeric_limits<uint64_t>::max());
 
-        /// get the image index for specified relative frame index, a 0 value is the current frame being rendered, 1 is the previous frame, 2 is the previous frame that.
+        /// get the image index for specified relative frame index, a 0 value is the current frame being rendered, 1 is the previous frame, 2 is the frame before that.
         size_t imageIndex(size_t relativeFrameIndex = 0) const { return relativeFrameIndex < _indices.size() ? _indices[relativeFrameIndex] : _indices.size(); }
 
         bool debugLayersEnabled() const { return _traits->debugLayer; }

--- a/include/vsg/app/WindowAdapter.h
+++ b/include/vsg/app/WindowAdapter.h
@@ -16,10 +16,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    /// Class from adapting 3rd party Windowing implementations to a form usable as a vsg::Window
-    /// Note, the VulkanSceneGraph provides it's own cross platform Windowing support, WindowAdapter
+    /// Class for adapting 3rd party Windowing implementations to a form usable as a vsg::Window
+    /// Note, the VulkanSceneGraph provides its own cross platform Windowing support, WindowAdapter
     /// is only required when 3rd party windowing is used.
-    /// The vsgQt project provides an example of WindowAdapter used to adapt Qt window with Vulkan
+    /// The vsgQt project provides an example of a WindowAdapter used to adapt Qt windows with Vulkan
     /// support for use with VSG applications.
     class VSG_DECLSPEC WindowAdapter : public Inherit<Window, WindowAdapter>
     {

--- a/include/vsg/app/WindowResizeHandler.h
+++ b/include/vsg/app/WindowResizeHandler.h
@@ -40,7 +40,7 @@ namespace vsg
     };
     VSG_type_name(vsg::UpdateGraphicsPipelines);
 
-    /// WindowResizeHandler resize calls for updating viewport/scissor and attachments to fit with new window dimensions.
+    /// WindowResizeHandler class for updating viewport/scissor and attachments to fit with new window dimensions.
     class VSG_DECLSPEC WindowResizeHandler : public Inherit<Visitor, WindowResizeHandler>
     {
     public:
@@ -61,7 +61,7 @@ namespace vsg
 
         void scale_rect(VkRect2D& rect);
 
-        /// return true if the object visited
+        /// return true if the object was visited
         bool visit(const Object* object, uint32_t index = 0);
 
         void apply(BindGraphicsPipeline& bindPipeline) override;

--- a/include/vsg/commands/BindIndexBuffer.h
+++ b/include/vsg/commands/BindIndexBuffer.h
@@ -23,7 +23,7 @@ namespace vsg
     /** Compute the VkIndexType from Data source's value size.*/
     extern VSG_DECLSPEC VkIndexType computeIndexType(const Data* indices);
 
-    /// BindIndexBuffer command encapsulates vkBindIndexBuffer call and associated settings.
+    /// BindIndexBuffer command encapsulates vkCmdBindIndexBuffer call and associated settings.
     class VSG_DECLSPEC BindIndexBuffer : public Inherit<Command, BindIndexBuffer>
     {
     public:

--- a/include/vsg/commands/BindVertexBuffers.h
+++ b/include/vsg/commands/BindVertexBuffers.h
@@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// BindVertexBuffers command encapsulates vkBindVertexBuffers call and associated settings.
+    /// BindVertexBuffers command encapsulates vkCmdBindVertexBuffers call and associated settings.
     class VSG_DECLSPEC BindVertexBuffers : public Inherit<Command, BindVertexBuffers>
     {
     public:

--- a/include/vsg/commands/ClearAttachments.h
+++ b/include/vsg/commands/ClearAttachments.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// ClearAttachments command encapsulates vkCmdCopyAttachments functionality and associated settings.
+    /// ClearAttachments command encapsulates vkCmdClearAttachments functionality and associated settings.
     class VSG_DECLSPEC ClearAttachments : public Inherit<Command, ClearAttachments>
     {
     public:

--- a/include/vsg/commands/Command.h
+++ b/include/vsg/commands/Command.h
@@ -18,7 +18,7 @@ namespace vsg
 {
     class CommandBuffer;
 
-    /// Command base class from encapsualting vkCmd* calls and associated settings.
+    /// Command base class for encapsulating vkCmd* calls and associated settings.
     class VSG_DECLSPEC Command : public Inherit<Compilable, Command>
     {
     public:

--- a/include/vsg/commands/Commands.h
+++ b/include/vsg/commands/Commands.h
@@ -23,8 +23,8 @@ namespace vsg
 {
 
     /// Commands is a command that acts as a container for other commands.
-    /// vsg::Commands is a functionally equivalent to use vsg::Group but is faster thanks to lowering CPU overhead in applying
-    /// the state stack prior to vsg::Command call.
+    /// vsg::Commands is functionally equivalent to vsg::Group but is faster thanks to lower CPU overhead in applying
+    /// the state stack prior to vsg::Command calls.
     class VSG_DECLSPEC Commands : public Inherit<Command, Commands>
     {
     public:

--- a/include/vsg/commands/CopyAndReleaseBuffer.h
+++ b/include/vsg/commands/CopyAndReleaseBuffer.h
@@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Deprecated - use vsg::Data dataVariance and Data.dirty() to signal vsg::TransferData to transfer data.
+    /// Deprecated - use vsg::Data dataVariance and Data::dirty() to signal vsg::TransferTask to transfer data.
     class VSG_DECLSPEC CopyAndReleaseBuffer : public Inherit<Command, CopyAndReleaseBuffer>
     {
     public:
@@ -28,7 +28,7 @@ namespace vsg
 
         void add(ref_ptr<BufferInfo> src, ref_ptr<BufferInfo> dest);
 
-        /// MemoryBufferPools used for allocation staging buffer used by the copy(ref_ptr<Data>, BufferInfo) method.  Users should assign a MemoryBufferPools with appropriate settings.
+        /// MemoryBufferPools used for allocation of staging buffer used by the copy(ref_ptr<Data>, BufferInfo) method.  Users should assign MemoryBufferPools with appropriate settings.
         ref_ptr<MemoryBufferPools> stagingMemoryBufferPools;
 
         void copy(ref_ptr<Data> data, ref_ptr<BufferInfo> dest);

--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Deprecated - use vsg::Data dataVariance and Data.dirty() to signal vsg::TransferData to transfer data.
+    /// Deprecated - use vsg::Data dataVariance and Data::dirty() to signal vsg::TransferTask to transfer data.
     class VSG_DECLSPEC CopyAndReleaseImage : public Inherit<Command, CopyAndReleaseImage>
     {
     public:
@@ -49,7 +49,7 @@ namespace vsg
         void add(ref_ptr<BufferInfo> src, ref_ptr<ImageInfo> dest);
         void add(ref_ptr<BufferInfo> src, ref_ptr<ImageInfo> dest, uint32_t numMipMapLevels);
 
-        /// MemoryBufferPools used for allocation staging buffer used by the copy(ref_ptr<Data>, ImageInfo) method.  Users should assign a MemoryBufferPools with appropriate settings.
+        /// MemoryBufferPools used for allocation of staging buffer used by the copy(ref_ptr<Data>, ImageInfo) method.  Users should assign MemoryBufferPools with appropriate settings.
         ref_ptr<MemoryBufferPools> stagingMemoryBufferPools;
 
         /// copy data into a staging buffer and then use copy command to transfer this to the GPU image specified by ImageInfo

--- a/include/vsg/commands/Dispatch.h
+++ b/include/vsg/commands/Dispatch.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /** Dispatch command encapsulates vkCmdDispatch, used for dispatching a Compute command.*/
+    /** Dispatch command encapsulates vkCmdDispatch, used for dispatching a Compute pipeline.*/
     class VSG_DECLSPEC Dispatch : public Inherit<Command, Dispatch>
     {
     public:

--- a/include/vsg/commands/Event.h
+++ b/include/vsg/commands/Event.h
@@ -61,7 +61,7 @@ namespace vsg
     };
     VSG_type_name(vsg::SetEvent);
 
-    /// Command class encapsulating vkCmdReetEvent
+    /// Command class encapsulating vkCmdResetEvent
     class VSG_DECLSPEC ResetEvent : public Inherit<Command, ResetEvent>
     {
     public:

--- a/include/vsg/commands/ExecuteCommands.h
+++ b/include/vsg/commands/ExecuteCommands.h
@@ -18,19 +18,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Encapsulation of vkCmdExecuteCommands with thread safe integration with secondary CommandGraph that provide the secondary CommandBuffer
+    /// Encapsulation of vkCmdExecuteCommands with thread safe integration with SecondaryCommandGraph that provides the secondary CommandBuffer
     class VSG_DECLSPEC ExecuteCommands : public Inherit<Command, ExecuteCommands>
     {
     public:
         ExecuteCommands();
 
-        /// connect a SecodaryCommmandGraph that will provide the CommandBuffer each frame
+        /// connect a SecondaryCommmandGraph that will provide the CommandBuffer each frame
         void connect(ref_ptr<SecondaryCommandGraph> commandGraph);
 
         /// clean the internal cache of CommandBuffer and reset the Latch used to signal when all the connected CommandGraph have completed the recording of their CommandBuffer
         void reset();
 
-        /// called by secondary CommandGraph to pass on the completed CommandBuffer that the CommandGraph recorded.
+        /// called by SecondaryCommandGraph to pass on the completed CommandBuffer that was recorded.
         void completed(const SecondaryCommandGraph& commandGraph, ref_ptr<CommandBuffer> commandBuffer);
 
         /// call vkCmdExecuteCommands with all the CommandBuffer that have been recorded with this ExecuteCommands

--- a/include/vsg/commands/SetDepthBias.h
+++ b/include/vsg/commands/SetDepthBias.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// SetDepthBias command encapsulates vkCmdDepthBias functionality, associated with dynamic updating a GraphicsPipeline's RasterizationState.depthBias* values.
+    /// SetDepthBias command encapsulates vkCmdSetDepthBias functionality, associated with dynamic updating of a GraphicsPipeline's RasterizationState::depthBias* values.
     class VSG_DECLSPEC SetDepthBias : public Inherit<Command, SetDepthBias>
     {
     public:

--- a/include/vsg/commands/SetLineWidth.h
+++ b/include/vsg/commands/SetLineWidth.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// SetLineWidth command encapsulates vkCmdLineWidth functionality, associated with dynamic updating a GraphicsPipeline's RasterizationState.lineWidth
+    /// SetLineWidth command encapsulates vkCmdSetLineWidth functionality, associated with dynamic updating of a GraphicsPipeline's RasterizationState::lineWidth
     class VSG_DECLSPEC SetLineWidth : public Inherit<Command, SetLineWidth>
     {
     public:

--- a/include/vsg/commands/SetScissor.h
+++ b/include/vsg/commands/SetScissor.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// SetScissor command encapsulates of vkCmdSetScissor functionality, associated with dynamic updating a GraphicsPipeline's ViewportState
+    /// SetScissor command encapsulates vkCmdSetScissor functionality, associated with dynamic updating of a GraphicsPipeline's ViewportState
     class VSG_DECLSPEC SetScissor : public Inherit<Command, SetScissor>
     {
     public:

--- a/include/vsg/commands/SetViewport.h
+++ b/include/vsg/commands/SetViewport.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// SetViewport command encapsulates vkCmdSetViewport call, associated with dynamic updating a GraphicsPipeline's ViewportState
+    /// SetViewport command encapsulates vkCmdSetViewport call, associated with dynamic updating of a GraphicsPipeline's ViewportState
     class VSG_DECLSPEC SetViewport : public Inherit<Command, SetViewport>
     {
     public:

--- a/include/vsg/core/Allocator.h
+++ b/include/vsg/core/Allocator.h
@@ -47,16 +47,16 @@ namespace vsg
         /// Allocator singleton
         static std::unique_ptr<Allocator>& instance();
 
-        /// allocate from the pool of memory blocks, or allocate from a new memory bock
+        /// allocate from the pool of memory blocks, or allocate from a new memory block
         virtual void* allocate(std::size_t size, AllocatorAffinity allocatorAffinity = ALLOCATOR_AFFINITY_OBJECTS);
 
-        /// deallocate returning data to pool.
+        /// deallocate, returning data to pool.
         virtual bool deallocate(void* ptr, std::size_t size);
 
         /// delete any MemoryBlock that are empty
         virtual size_t deleteEmptyMemoryBlocks();
 
-        /// return the total available size amount allocated MemoryBlocks
+        /// return the total available size of allocated MemoryBlocks
         virtual size_t totalAvailableSize() const;
 
         /// return the total reserved size of allocated MemoryBlocks
@@ -65,7 +65,7 @@ namespace vsg
         /// return the total memory size of allocated MemoryBlocks
         virtual size_t totalMemorySize() const;
 
-        /// report stats about block of memory allocated.
+        /// report stats about blocks of memory allocated.
         virtual void report(std::ostream& out) const;
 
         AllocatorType allocatorType = ALLOCATOR_TYPE_VSG_ALLOCATOR;          // use MemoryBlocks by default

--- a/include/vsg/core/Array.h
+++ b/include/vsg/core/Array.h
@@ -156,7 +156,7 @@ namespace vsg
             {
                 size_t new_total_size = computeValueCountIncludingMipmaps(width_size, 1, 1, properties.maxNumMipmaps);
 
-                if (_data) // if data already may be able to reuse it
+                if (_data) // if data exists already may be able to reuse it
                 {
                     if (original_total_size != new_total_size) // if existing data is a different size delete old, and create new
                     {
@@ -267,7 +267,7 @@ namespace vsg
             dirty();
         }
 
-        // release the data so that ownership can be passed on, the local data pointer and size is set to 0 and destruction of Array will no result in the data being deleted.
+        // release the data so that ownership can be passed on, the local data pointer and size is set to 0 and destruction of Array will not result in the data being deleted.
         // when the data is stored in a separate vsg::Data object then return nullptr and do not attempt to release data.
         void* dataRelease() override
         {

--- a/include/vsg/core/Array2D.h
+++ b/include/vsg/core/Array2D.h
@@ -129,7 +129,7 @@ namespace vsg
             {
                 size_t new_size = computeValueCountIncludingMipmaps(w, h, 1, properties.maxNumMipmaps);
 
-                if (_data) // if data already may be able to reuse it
+                if (_data) // if data exists already may be able to reuse it
                 {
                     if (original_size != new_size) // if existing data is a different size delete old, and create new
                     {
@@ -247,7 +247,7 @@ namespace vsg
             dirty();
         }
 
-        // release the data so that ownership can be passed on, the local data pointer and size is set to 0 and destruction of Array will no result in the data being deleted.
+        // release the data so that ownership can be passed on, the local data pointer and size is set to 0 and destruction of Array will not result in the data being deleted.
         // when the data is stored in a separate vsg::Data object then return nullptr and do not attempt to release data.
         void* dataRelease() override
         {

--- a/include/vsg/core/Array3D.h
+++ b/include/vsg/core/Array3D.h
@@ -138,7 +138,7 @@ namespace vsg
             {
                 size_t new_size = computeValueCountIncludingMipmaps(w, h, d, properties.maxNumMipmaps);
 
-                if (_data) // if data already may be able to reuse it
+                if (_data) // if data exists already may be able to reuse it
                 {
                     if (original_size != new_size) // if existing data is a different size delete old, and create new
                     {
@@ -263,7 +263,7 @@ namespace vsg
             dirty();
         }
 
-        // release the data so that ownership can be passed on, the local data pointer and size is set to 0 and destruction of Array will no result in the data being deleted.
+        // release the data so that ownership can be passed on, the local data pointer and size is set to 0 and destruction of Array will not result in the data being deleted.
         // when the data is stored in a separate vsg::Data object then return nullptr and do not attempt to release data.
         void* dataRelease() override
         {

--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -24,7 +24,7 @@ namespace vsg
     class Objects;
     class External;
 
-    // forward declare nodes classes
+    // forward declare node classes
     class Node;
     class Commands;
     class Group;
@@ -48,7 +48,7 @@ namespace vsg
     class PointLight;
     class SpotLight;
 
-    // forward declare vulkan classes
+    // forward declare text classes
     class Text;
     class TextGroup;
     class TextTechnique;

--- a/include/vsg/core/Data.h
+++ b/include/vsg/core/Data.h
@@ -55,7 +55,7 @@ namespace vsg
 
     enum DataVariance : uint8_t
     {
-        STATIC_DATA = 0,                       /** treat data as if doesn't not change .*/
+        STATIC_DATA = 0,                       /** treat data as if it doesn't change .*/
         STATIC_DATA_UNREF_AFTER_TRANSFER = 1,  /** unref this vsg::Data after the data has been transferred to the GPU memory .*/
         DYNAMIC_DATA = 2,                      /** data is updated prior to the record traversal and will need transferring to GPU memory.*/
         DYNAMIC_DATA_TRANSFER_AFTER_RECORD = 3 /** data is updated during the record traversal and will need transferring to GPU memory.*/
@@ -104,7 +104,7 @@ namespace vsg
         value_type* operator->() { return reinterpret_cast<value_type*>(ptr); }
     };
 
-    /// Data base class for abstracting data such a values, vertices, images etc.
+    /// Data base class for abstracting data such as values, vertices, images etc.
     /// Main subclasses are vsg::Value, vsg::Array, vsg::Array2D and vsg::Array3D.
     class VSG_DECLSPEC Data : public Object
     {
@@ -127,7 +127,7 @@ namespace vsg
             uint8_t blockDepth = 1;
             uint8_t origin = TOP_LEFT;               /// Hint for setting up texture coordinates, bit 0 x/width axis, bit 1 y/height axis, bit 2 z/depth axis. Vulkan origin for images is top left, which is denoted as 0 here.
             int8_t imageViewType = -1;               /// -1 signifies undefined VkImageViewType, if value >=0 then value should be treated as valid VkImageViewType.
-            DataVariance dataVariance = STATIC_DATA; /// hint as how the data values may change during the lifetime of the vsg::Data.
+            DataVariance dataVariance = STATIC_DATA; /// hint as to how the data values may change during the lifetime of the vsg::Data.
             AllocatorType allocatorType = ALLOCATOR_TYPE_VSG_ALLOCATOR;
 
             int compare(const Properties& rhs) const;
@@ -207,7 +207,7 @@ namespace vsg
                 return false;
         }
 
-        /// return true if Data's ModifiedCount is different than the specified ModifiedCount
+        /// return true if Data's ModifiedCount is different from the specified ModifiedCount
         bool differentModifiedCount(const ModifiedCount& mc) const { return _modifiedCount != mc; }
 
     protected:
@@ -223,11 +223,11 @@ namespace vsg
         /// deprecated: use data->properties = properties instead.
         void setLayout(Layout layout)
         {
-            VkFormat previous_format = properties.format; // temporary hack to keep applications that call setFormat(..) before setProperties(..) working
+            VkFormat previous_format = properties.format; // temporary hack to keep applications that call setFormat(..) before setLayout(..) working
             uint32_t previous_stride = properties.stride;
             properties = layout;
             if (properties.format == 0 && previous_format != 0) properties.format = previous_format; // temporary hack to keep existing applications working
-            if (properties.stride == 0 && previous_stride != 0) properties.stride = previous_stride; // make sure the layout as a valid stride.
+            if (properties.stride == 0 && previous_stride != 0) properties.stride = previous_stride; // make sure the layout has a valid stride.
         }
         /// deprecated: use data->properties
         Layout& getLayout() { return properties; }

--- a/include/vsg/core/Exception.h
+++ b/include/vsg/core/Exception.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Exception object that can be thrown from VSG code, such as failed Vulkan calls where the result value will the VkResult value
+    /// Exception object that can be thrown from VSG code, such as failed Vulkan calls where the result value will be the VkResult value
     /// returned from failed Vulkan call.
     struct Exception
     {

--- a/include/vsg/core/External.h
+++ b/include/vsg/core/External.h
@@ -21,9 +21,9 @@ namespace vsg
 {
 
     /// External provides a means to loading objects from external files, such as shaders, textures or models
-    /// To use set up the External object with all the pairs of [filename, object] that should be managed externally
-    /// then assign the External object, as use value, to root node of the scene graph that you wish to use external objects with
-    /// so that when serializing the External object is initialized and external objects are loaded before they are
+    /// To use, set up the External object with all the pairs of [filename, object] that should be managed externally,
+    /// then assign the External object, as a value, to the root node of the scene graph that you wish to use external objects with
+    /// so that when serializing, the External object is initialized and external objects are loaded before they are
     /// needed by the rest of the subgraph i.e.
     ///     auto external = vsg::External::create("mytexture.png", texture);
     ///     scene->setObject("external", external); // scene uses the texture object somewhere within it.
@@ -50,7 +50,7 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        /// custom readwriter/writer options
+        /// custom reader/writer options
         ref_ptr<Options> options;
 
         /// list of path/object pairs

--- a/include/vsg/core/MemorySlots.h
+++ b/include/vsg/core/MemorySlots.h
@@ -22,7 +22,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Mask for hint what checks/reporting to do when using MemorySlots within Allocator/Buffer/DeviceMemory.
+    /// Hint for what checks/reporting to do when using MemorySlots within Allocator/Buffer/DeviceMemory.
     enum MemoryTracking
     {
         MEMORY_TRACKING_NO_CHECKS = 0,
@@ -31,7 +31,7 @@ namespace vsg
         MEMORY_TRACKING_DEFAULT = MEMORY_TRACKING_NO_CHECKS
     };
 
-    /** class used internally by vsg::Allocator, vsg::DeviceMemory and vsg::Buffer to manage allocation of within a block of CPU or GPU memory.*/
+    /** class used internally by vsg::Allocator, vsg::DeviceMemory and vsg::Buffer to manage suballocation within a block of CPU or GPU memory.*/
     class VSG_DECLSPEC MemorySlots
     {
     public:

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -24,7 +24,7 @@ namespace vsg
     class Objects;
     class External;
 
-    // forward declare nodes classes
+    // forward declare node classes
     class Node;
     class Commands;
     class Group;
@@ -48,7 +48,7 @@ namespace vsg
     class PointLight;
     class SpotLight;
 
-    // forward declare vulkan classes
+    // forward declare text classes
     class Text;
     class TextGroup;
     class TextTechnique;

--- a/include/vsg/core/observer_ptr.h
+++ b/include/vsg/core/observer_ptr.h
@@ -118,10 +118,10 @@ namespace vsg
 
         explicit operator bool() const noexcept { return valid(); }
 
-        /// convert observer_ptr into a ref_ptr so that Object that pointed to can be safely accessed.
+        /// convert observer_ptr into a ref_ptr so that Object pointed to can be safely accessed.
         vsg::ref_ptr<T> ref_ptr() const { return vsg::ref_ptr<T>(*this); }
 
-        /// convert observer_ptr into a ref_ptr so that Object that pointed to can be safely accessed.
+        /// convert observer_ptr into a ref_ptr so that Object pointed to can be safely accessed.
         template<class R>
         operator vsg::ref_ptr<R>() const
         {

--- a/include/vsg/core/ref_ptr.h
+++ b/include/vsg/core/ref_ptr.h
@@ -81,7 +81,7 @@ namespace vsg
 
             if (_ptr) _ptr->ref();
 
-            // unref the original pointer after ref in case the old pointer object a parent of the new pointers object
+            // unref the original pointer after ref in case the old pointer object is a parent of the new pointer's object
             if (temp_ptr) temp_ptr->unref();
 
             return *this;
@@ -97,7 +97,7 @@ namespace vsg
 
             if (_ptr) _ptr->ref();
 
-            // unref the original pointer after ref in case the old pointer object a parent of the new pointers object
+            // unref the original pointer after ref in case the old pointer object is a parent of the new pointer's object
             if (temp_ptr) temp_ptr->unref();
 
             return *this;
@@ -114,7 +114,7 @@ namespace vsg
 
             if (_ptr) _ptr->ref();
 
-            // unref the original pointer after ref in case the old pointer object a parent of the new pointers object
+            // unref the original pointer after ref in case the old pointer object is a parent of the new pointer's object
             if (temp_ptr) temp_ptr->unref();
 
             return *this;
@@ -157,7 +157,7 @@ namespace vsg
 
         explicit operator bool() const noexcept { return valid(); }
 
-        // potentially dangerous automatic type conversion, could cause dangling pointer if ref_ptr<> assigned to C pointer, if ref_ptr<> destruction cause an object delete.
+        // potentially dangerous automatic type conversion, could cause dangling pointer if ref_ptr<> assigned to C pointer and ref_ptr<> destruction causes an object delete.
         operator T*() const noexcept { return _ptr; }
 
         void operator[](int) const = delete;

--- a/include/vsg/io/AsciiInput.h
+++ b/include/vsg/io/AsciiInput.h
@@ -98,7 +98,7 @@ namespace vsg
         /// read one or more strings
         void read(size_t num, std::wstring* value) override;
 
-        /// read one or more strings
+        /// read one or more paths
         void read(size_t num, Path* value) override;
 
         /// read object

--- a/include/vsg/io/BinaryOutput.h
+++ b/include/vsg/io/BinaryOutput.h
@@ -27,10 +27,10 @@ namespace vsg
     public:
         explicit BinaryOutput(std::ostream& output, ref_ptr<const Options> in_options = {});
 
-        /// write property name an non op for binary
+        /// write property name is a non op for binary
         void writePropertyName(const char*) override {}
 
-        /// write end of line a non op for binary
+        /// write end of line is a non op for binary
         void writeEndOfLine() override {}
 
         template<typename T>

--- a/include/vsg/io/DatabasePager.h
+++ b/include/vsg/io/DatabasePager.h
@@ -105,7 +105,7 @@ namespace vsg
 
         ref_ptr<CulledPagedLODs> culledPagedLODs;
 
-        /// for systems for smaller GPU memory limits you may need to reduce the targetMaxNumPagedLODWithHighResSubgraphs to keep memory usage within available limits.
+        /// for systems with smaller GPU memory limits you may need to reduce the targetMaxNumPagedLODWithHighResSubgraphs to keep memory usage within available limits.
         uint32_t targetMaxNumPagedLODWithHighResSubgraphs = 1500;
 
         std::mutex pendingPagedLODMutex;

--- a/include/vsg/io/FileSystem.h
+++ b/include/vsg/io/FileSystem.h
@@ -27,11 +27,11 @@ namespace vsg
     /// get the specified environmental variable.
     extern VSG_DECLSPEC std::string getEnv(const char* env_var);
 
-    /// parse the specified environmental variable using platorm specific delimiter, returning list of Paths
+    /// parse the specified environmental variable using platform specific delimiter, returning list of Paths
     /// delimiter used is ; under Windows, and : on all other platforms.
     extern VSG_DECLSPEC Paths getEnvPaths(const char* env_var);
 
-    /// parsing multiple environmental variables, parsing them to return a list of Paths.
+    /// parse multiple environmental variables, merging them and return a list of Paths.
     template<typename... Args>
     Paths getEnvPaths(const char* env_var, Args... args)
     {
@@ -44,14 +44,14 @@ namespace vsg
     /// return file type, see include/vsg/io/Path.h for FileType enum,
     extern VSG_DECLSPEC FileType fileType(const Path& path);
 
-    /// return true if a specified file/path exist on system.
+    /// return true if a specified file/path exists on system.
     extern VSG_DECLSPEC bool fileExists(const Path& path);
 
     /// return the full filename path if specified filename can be found in the list of paths.
     extern VSG_DECLSPEC Path findFile(const Path& filename, const Paths& paths);
 
     /// return the full filename path if specified filename can be found in the options->paths list.
-    /// If options is null and the filename can be found using it's existing path that filename is return, otherwise empty Path{} is returned.
+    /// If options is null and the filename can be found using its existing path that filename is returned, otherwise empty Path{} is returned.
     extern VSG_DECLSPEC Path findFile(const Path& filename, const Options* options);
 
     /// make a directory, return true if path already exists or full path has been created successfully, return false on failure.
@@ -63,7 +63,7 @@ namespace vsg
     /// returns the path/filename of the currently executed program.
     extern VSG_DECLSPEC Path executableFilePath();
 
-    /// Open a file using a the C style fopen() adapted with work with the vsg::Path.
+    /// Open a file using the C style fopen() adapted to work with the vsg::Path.
     extern VSG_DECLSPEC FILE* fopen(const Path& path, const char* mode);
 
 } // namespace vsg

--- a/include/vsg/io/Input.h
+++ b/include/vsg/io/Input.h
@@ -38,7 +38,7 @@ namespace vsg
     // forward declare
     class Options;
 
-    /// Base class that provides a means of read a range of data types to an input stream.
+    /// Base class that provides a means of reading a range of data types from an input stream.
     /// Used by vsg::Object::read(Input&) implementations across the VSG to provide native serialization from binary/ascii files
     class VSG_DECLSPEC Input
     {
@@ -226,7 +226,7 @@ namespace vsg
             return v;
         }
 
-        /// read a value as a type, then cast it another type
+        /// read a value as a type, then cast it to another type
         template<typename W, typename T>
         void readValue(const char* propertyName, T& value)
         {

--- a/include/vsg/io/Logger.h
+++ b/include/vsg/io/Logger.h
@@ -283,27 +283,27 @@ namespace vsg
         Logger::instance()->warn_stream(print);
     }
 
-    /// write warn message to the current vsg::Logger::instance().
+    /// write error message to the current vsg::Logger::instance().
     template<typename... Args>
     void error(Args&&... args)
     {
         Logger::instance()->error(args...);
     }
 
-    /// thread safe access to stream for writing warn output.
+    /// thread safe access to stream for writing error output.
     inline void error_stream(Logger::PrintToStreamFunction print)
     {
         Logger::instance()->error_stream(print);
     }
 
-    /// write warn message to the current vsg::Logger::instance().
+    /// write fatal message to the current vsg::Logger::instance().
     template<typename... Args>
     void fatal(Args&&... args)
     {
         Logger::instance()->fatal(args...);
     }
 
-    /// thread safe access to stream for writing warn output.
+    /// thread safe access to stream for writing fatal output.
     inline void fatal_stream(Logger::PrintToStreamFunction print)
     {
         Logger::instance()->fatal_stream(print);
@@ -316,13 +316,13 @@ namespace vsg
         Logger::instance()->log(msg_level, args...);
     }
 
-    /// thread safe access to stream for writing warn output for specified Logger level.
+    /// thread safe access to stream for writing output for specified Logger level.
     inline void log_stream(Logger::Level msg_level, Logger::PrintToStreamFunction print)
     {
         Logger::instance()->log_stream(msg_level, print);
     }
 
-    /// default Logger that sends debug and info messages to std:cout, and warn and error messages to std::cert
+    /// default Logger that sends debug and info messages to std:cout, and warn and error messages to std::cerr
     class VSG_DECLSPEC StdLogger : public Inherit<Logger, StdLogger>
     {
     public:

--- a/include/vsg/io/ObjectFactory.h
+++ b/include/vsg/io/ObjectFactory.h
@@ -21,7 +21,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Singleton factory class to provides means for creating instances of VSG objects given the namespace::class name
+    /// Singleton factory class to provide means for creating instances of VSG objects given the namespace::class name
     /// Used by the VSG ReaderWriter to create objects serialized from files/streams/memory.
     class VSG_DECLSPEC ObjectFactory : public vsg::Object
     {
@@ -51,7 +51,7 @@ namespace vsg
         CreateMap _createMap;
     };
 
-    // Helper template class for registering the ability to create a Object of specified T on demand.
+    // Helper template class for registering the ability to create an Object of specified T on demand.
     template<class T>
     struct RegisterWithObjectFactoryProxy
     {

--- a/include/vsg/io/Options.h
+++ b/include/vsg/io/Options.h
@@ -61,8 +61,8 @@ namespace vsg
         /// Hint to use when searching for Paths with vsg::findFile(filename, options);
         enum FindFileHint
         {
-            CHECK_ORIGINAL_FILENAME_EXISTS_FIRST, /// check the filename exists with it's original path before trying to find it in Options::paths.
-            CHECK_ORIGINAL_FILENAME_EXISTS_LAST,  /// check the filename exists with it's original path after failing to find it in Options::paths.
+            CHECK_ORIGINAL_FILENAME_EXISTS_FIRST, /// check the filename exists with its original path before trying to find it in Options::paths.
+            CHECK_ORIGINAL_FILENAME_EXISTS_LAST,  /// check the filename exists with its original path after failing to find it in Options::paths.
             ONLY_CHECK_PATHS                      /// only check the filename exists in the Options::paths
         };
         FindFileHint checkFilenameHint = CHECK_ORIGINAL_FILENAME_EXISTS_FIRST;
@@ -83,7 +83,7 @@ namespace vsg
         /// Coordinate convention to assume for specified lower case file formats extensions
         std::map<Path, CoordinateConvention> formatCoordinateConventions;
 
-        /// User defined ShaderSet map, loaders should check the available ShaderSet used the name of the type ShaderSet.
+        /// User defined ShaderSet map, loaders should check the available ShaderSet using the name of the type of ShaderSet.
         /// Standard names are :
         ///     "pbr" will substitute for vsg::createPhysicsBasedRenderingShaderSet()
         ///     "phong" will substitute for vsg::createPhongShaderSet()

--- a/include/vsg/io/Output.h
+++ b/include/vsg/io/Output.h
@@ -187,7 +187,7 @@ namespace vsg
             write(object);
         }
 
-        /// write a value casting it specified type i.e. output.write<uint32_t>("Value", value);
+        /// write a value casting it to specified type i.e. output.write<uint32_t>("Value", value);
         template<typename W, typename T>
         void writeValue(const char* propertyName, T value)
         {

--- a/include/vsg/io/Path.h
+++ b/include/vsg/io/Path.h
@@ -26,7 +26,7 @@ namespace vsg
         DIRECTORY
     };
 
-    /// Class for managing paths/filename with full support for wide and single wide path strings.
+    /// Class for managing paths/filenames with full support for wide and single width path strings.
     /// Similar in role and features to std::filesystem::path, but is able to work on older compilers.
     class VSG_DECLSPEC Path
     {
@@ -202,7 +202,7 @@ namespace vsg
         return path.concat(rhs);
     }
 
-    /// join two paths with a path separator between
+    /// join two paths with a path separator in between
     inline Path operator/(const Path& lhs, const Path& rhs)
     {
         Path path(lhs);
@@ -215,20 +215,20 @@ namespace vsg
     /// return path stripped of the filename or final path component.
     extern VSG_DECLSPEC Path filePath(const Path& path);
 
-    /// return file extension include the . prefix, i.e. vsg::fileExtension("file.vsgt") returns .vsgt
+    /// return file extension including the . prefix, i.e. vsg::fileExtension("file.vsgt") returns .vsgt
     extern VSG_DECLSPEC Path fileExtension(const Path& path);
 
-    /// return lower case file extension include the . prefix, i.e. vsg::fileExtension("file.VSGT") returns .vsgt
+    /// return lower case file extension including the . prefix, i.e. vsg::fileExtension("file.VSGT") returns .vsgt
     /// By default prunes extras such as REST strings at the end of the extensions, uses ? as the deliminator for REST additions i.e. ".jpeg?g=42" becomes ".jpeg"
     extern VSG_DECLSPEC Path lowerCaseFileExtension(const Path& path, bool pruneExtras = true);
 
-    /// return the filename stripped of any paths and extensions, i.e vsg::simpleFilname("path/file.vsgb") returns file
+    /// return the filename stripped of any paths and extensions, i.e vsg::simpleFilename("path/file.vsgb") returns file
     extern VSG_DECLSPEC Path simpleFilename(const Path& path);
 
     /// return true if the path equals ., .. or has a trailing \.. \.., /.. or /....
     extern VSG_DECLSPEC bool trailingRelativePath(const Path& path);
 
-    /// return the path minus the extension, i.e. vsg::removeExtension("path/file.png") return path/file
+    /// return the path minus the extension, i.e. vsg::removeExtension("path/file.png") returns path/file
     extern VSG_DECLSPEC Path removeExtension(const Path& path);
 
 } // namespace vsg

--- a/include/vsg/io/ReaderWriter.h
+++ b/include/vsg/io/ReaderWriter.h
@@ -30,7 +30,7 @@ namespace vsg
     };
     VSG_type_name(vsg::ReadError);
 
-    /// Base class from providing support for reading and/or writing various file formats and IO protocols
+    /// Base class for providing support for reading and/or writing various file formats and IO protocols
     class VSG_DECLSPEC ReaderWriter : public Inherit<Object, ReaderWriter>
     {
     public:
@@ -100,7 +100,7 @@ namespace vsg
     };
     VSG_type_name(vsg::ReaderWriter);
 
-    /// Class for managing a list of ReaderWriter, providing a single read/write call to invoke each RaderWriter in turn until success
+    /// Class for managing a list of ReaderWriter, providing a single read/write call to invoke each ReaderWriter in turn until success
     class VSG_DECLSPEC CompositeReaderWriter : public Inherit<ReaderWriter, CompositeReaderWriter>
     {
     public:

--- a/include/vsg/io/mem_stream.h
+++ b/include/vsg/io/mem_stream.h
@@ -21,7 +21,7 @@ namespace vsg
 {
 
     /// Input stream that enables reading from a read only block of memory
-    /// Like std::string_view the memory referenced by the mem_stream has been kept in memory for the duration of the mem_stream existence.
+    /// Like std::string_view the memory referenced by the mem_stream has to be kept in memory for the duration of the mem_stream existence.
     class VSG_DECLSPEC mem_stream : public std::istream
     {
     public:

--- a/include/vsg/io/stream.h
+++ b/include/vsg/io/stream.h
@@ -165,7 +165,7 @@ namespace vsg
         return input;
     }
 
-    /// output stream support for vsg::t_box
+    /// output stream support for vsg::t_sphere
     template<typename T>
     std::ostream& operator<<(std::ostream& output, const vsg::t_sphere<T>& sp)
     {
@@ -173,7 +173,7 @@ namespace vsg
         return output;
     }
 
-    /// input stream support for vsg::t_box
+    /// input stream support for vsg::t_sphere
     template<typename T>
     std::istream& operator>>(std::istream& input, vsg::t_sphere<T>& sp)
     {

--- a/include/vsg/io/tile.h
+++ b/include/vsg/io/tile.h
@@ -21,7 +21,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// tile reader that is used by th vsg::TileDatabase node to implement the reading of external tiles
+    /// tile reader that is used by the vsg::TileDatabase node to implement the reading of external tiles
     class VSG_DECLSPEC tile : public Inherit<ReaderWriter, tile>
     {
     public:

--- a/include/vsg/maths/box.h
+++ b/include/vsg/maths/box.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    /// t_box template class that represent a axis aligned bounding box
+    /// t_box template class that represents an axis aligned bounding box
     template<typename T>
     struct t_box
     {

--- a/include/vsg/maths/plane.h
+++ b/include/vsg/maths/plane.h
@@ -12,7 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-// we can't implement the anonymous union/structs combination without causing warnings, so disabled them for just this header
+// we can't implement the anonymous union/structs combination without causing warnings, so disable them for just this header
 #if defined(__GNUC__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wpedantic"
@@ -151,7 +151,7 @@ namespace vsg
         return dot(pl.n, normal_type(v)) + pl.p;
     }
 
-    /** return true if bounding sphere is wholly or partially intersects with convex polytope defined by a list of planes with normals pointing inwards towards center of the polytope. */
+    /** return true if bounding sphere wholly or partially intersects with convex polytope defined by a list of planes with normals pointing inwards towards center of the polytope. */
     template<class PlaneItr, typename T>
     constexpr bool intersect(PlaneItr first, PlaneItr last, const t_sphere<T>& s)
     {

--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -12,7 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-// we can't implement the anonymous union/structs combination without causing warnings, so disabled them for just this header
+// we can't implement the anonymous union/structs combination without causing warnings, so disable them for just this header
 
 #include <vsg/maths/mat4.h>
 
@@ -29,7 +29,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// t_quat template class that a represents quaternion
+    /// t_quat template class that represents a quaternion
     template<typename T>
     struct t_quat
     {
@@ -292,7 +292,7 @@ namespace vsg
         }
         else
         {
-            // quaternion's are very close so just linearly interpolate
+            // quaternions are very close so just linearly interpolate
             return (from * (one - r)) + (to * r);
         }
     }

--- a/include/vsg/maths/sphere.h
+++ b/include/vsg/maths/sphere.h
@@ -12,7 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-// we can't implement the anonymous union/structs combination without causing warnings, so disabled them for just this header
+// we can't implement the anonymous union/structs combination without causing warnings, so disable them for just this header
 #if defined(__GNUC__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wpedantic"

--- a/include/vsg/maths/transform.h
+++ b/include/vsg/maths/transform.h
@@ -53,7 +53,7 @@ namespace vsg
                          0, 0, 0, 1);
     }
 
-    /// create a 4x4 matrix that represents the rotation by a radian angle around an vec3 axis
+    /// create a 4x4 matrix that represents the rotation by a radian angle around a vec3 axis
     template<typename T>
     t_mat4<T> rotate(T angle_radians, const t_vec3<T>& v)
     {
@@ -123,9 +123,9 @@ namespace vsg
                          m[0][3], m[1][3], m[2][3], m[3][3]);
     }
 
-    /// create a 4x4 matrix for an Reverse depth perspective matrix,
+    /// create a 4x4 matrix for a Reverse depth perspective matrix,
     /// Reverse depth convention: 1 to 0 depth range. Y NDC coordinates are inverted in Vulkan.
-    /// For best precision we record setting up Windows with windowTraits->depthFormat = VK_FORMAT_D32_SFLOAT;
+    /// For best precision we recommend setting up windows with windowTraits->depthFormat = VK_FORMAT_D32_SFLOAT;
     /// Background reading : https://developer.nvidia.com/content/depth-precision-visualized
     //.                      https://vincent-p.github.io/posts/vulkan_perspective_matrix/
     template<typename T>
@@ -139,7 +139,7 @@ namespace vsg
                          0, 0, (zFar * zNear) * r, 0);
     }
 
-    /// create a 4x4 matrix for an Reverse depth perspective matrix, convention: 1 to 0 depth range. Y NDC coordinates are inverted in Vulkan.
+    /// create a 4x4 matrix for a Reverse depth perspective matrix, convention: 1 to 0 depth range. Y NDC coordinates are inverted in Vulkan.
     template<typename T>
     constexpr t_mat4<T> perspective(T left, T right, T bottom, T top, T zNear, T zFar)
     {
@@ -195,10 +195,10 @@ namespace vsg
     /// invert the top left 3x3 portion of a double 4x4 matrix.
     extern VSG_DECLSPEC dmat3 inverse_3x3(const dmat4& m);
 
-    /// fast float matrix inversion that use assumes the matrix is composed of only scales, rotations and translations forming a 4x3 matrix.
+    /// fast float matrix inversion that assumes the matrix is composed of only scales, rotations and translations forming a 4x3 matrix.
     extern VSG_DECLSPEC mat4 inverse_4x3(const mat4& m);
 
-    /// fast double matrix inversion that use assumes the matrix is composed of only scales, rotations and translations forming a 4x3 matrix.
+    /// fast double matrix inversion that assumes the matrix is composed of only scales, rotations and translations forming a 4x3 matrix.
     extern VSG_DECLSPEC dmat4 inverse_4x3(const dmat4& m);
 
     /// general purpose 4x4 float matrix inversion.

--- a/include/vsg/maths/vec2.h
+++ b/include/vsg/maths/vec2.h
@@ -12,7 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-// we can't implement the anonymous union/structs combination without causing warnings, so disabled them for just this header
+// we can't implement the anonymous union/structs combination without causing warnings, so disable them for just this header
 #if defined(__GNUC__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wpedantic"
@@ -31,7 +31,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// t_vec2 template class that a represents a 2D vector
+    /// t_vec2 template class that represents a 2D vector
     template<typename T>
     struct t_vec2
     {
@@ -241,7 +241,7 @@ namespace vsg
         return lhs[0] * rhs[0] + lhs[1] * rhs[1];
     }
 
-    /// cross product of a vec2 can be thought of cross product of vec3's with the z value of 0.0/vec3's in the xy plane.
+    /// cross product of a vec2 can be thought of as cross product of vec3's with the z value of 0.0/vec3's in the xy plane.
     /// The returned value is the length of the resulting vec3 cross product, and can be treated as the signed area of the parallelogram, negative if rhs is clockwise from lhs when looking down on xy plane.
     template<typename T>
     constexpr T cross(const t_vec2<T>& lhs, const t_vec2<T>& rhs)

--- a/include/vsg/maths/vec3.h
+++ b/include/vsg/maths/vec3.h
@@ -12,7 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-// we can't implement the anonymous union/structs combination without causing warnings, so disabled them for just this header
+// we can't implement the anonymous union/structs combination without causing warnings, so disable them for just this header
 #if defined(__GNUC__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wpedantic"
@@ -28,7 +28,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// t_vec3 template class that a represents a 3D vector
+    /// t_vec3 template class that represents a 3D vector
     template<typename T>
     struct t_vec3
     {

--- a/include/vsg/maths/vec4.h
+++ b/include/vsg/maths/vec4.h
@@ -12,7 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
-// we can't implement the anonymous union/structs combination without causing warnings, so disabled them for just this header
+// we can't implement the anonymous union/structs combination without causing warnings, so disable them for just this header
 #if defined(__GNUC__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wpedantic"
@@ -28,7 +28,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// t_vec4 template class that a represents a 4D vector
+    /// t_vec4 template class that represents a 4D vector
     template<typename T>
     struct t_vec4
     {

--- a/include/vsg/nodes/AbsoluteTransform.h
+++ b/include/vsg/nodes/AbsoluteTransform.h
@@ -17,9 +17,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// MatrixTransform is a transform node that provides a 4x4 matrix that is used to position subgraphs in absolute coordinate frame.
+    /// AbsoluteTransform is a transform node that provides a 4x4 matrix that is used to position subgraphs in absolute coordinate frame.
     /// During the RecordTraversal the matrix is directly pushed to the State::modelviewMatrixStack stack without the normal multiplication.
-    /// After the subgraphs is traversed the matrix is popped from the State::modelviewMatrixStack.
+    /// After the subgraph is traversed the matrix is popped from the State::modelviewMatrixStack.
     class VSG_DECLSPEC AbsoluteTransform : public Inherit<Transform, AbsoluteTransform>
     {
     public:

--- a/include/vsg/nodes/Bin.h
+++ b/include/vsg/nodes/Bin.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Bin node is used internally by RecoredTraversal/View to collect and then sort command nodes assigned the bin,
+    /// Bin node is used internally by RecordTraversal/View to collect and then sort command nodes assigned to the bin,
     /// then recorded to the command buffer in the sorted order.
     class VSG_DECLSPEC Bin : public Inherit<Node, Bin>
     {

--- a/include/vsg/nodes/Compilable.h
+++ b/include/vsg/nodes/Compilable.h
@@ -18,7 +18,7 @@ namespace vsg
 {
     class Context;
 
-    /// Base class from encapsualting nodes that have Vulkan objects associated with them that will need compiled during the compile traversal
+    /// Base class for encapsulating nodes that have Vulkan objects associated with them that will need compiling during the compile traversal
     class VSG_DECLSPEC Compilable : public Inherit<Node, Compilable>
     {
     public:

--- a/include/vsg/nodes/CullNode.h
+++ b/include/vsg/nodes/CullNode.h
@@ -20,7 +20,7 @@ namespace vsg
 
     /// CullNode that enables view frustum culling on a single child node.
     /// A valid node must always be assigned to a CullNode before it's used,
-    /// for performance reasons there are no internal checks made when accessing the child.*/
+    /// for performance reasons there are no internal checks made when accessing the child.
     class VSG_DECLSPEC CullNode : public Inherit<Node, CullNode>
     {
     public:

--- a/include/vsg/nodes/DepthSorted.h
+++ b/include/vsg/nodes/DepthSorted.h
@@ -18,9 +18,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// DepthSorted node is used to control which bin to place the subgraph in placed in.
-    /// During the RecordTraversak the nodes bound sphere is tested against the view frustum
-    /// and if within the subgraph is traversed, with the children being in specified bin.
+    /// DepthSorted node is used to control which bin to place the subgraph in.
+    /// During the RecordTraversal the node's bound sphere is tested against the view frustum
+    /// and if within, the subgraph is traversed, with the children being in specified bin.
     /// Typically used for decorating translucent objects that should be sorted back to front to
     /// ensure correct blending.
     class VSG_DECLSPEC DepthSorted : public Inherit<Node, DepthSorted>

--- a/include/vsg/nodes/Geometry.h
+++ b/include/vsg/nodes/Geometry.h
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Geometry node is class that provides vertex arrays, optional index array and a list of draw commands
+    /// Geometry node is a class that provides vertex arrays, optional index array and a list of draw commands
     /// that are recorded to command buffer during RecordTraversal. Provides a lower CPU overhead
     /// compared to the equivalent functionality of adding individual commands:
     ///     auto group = vsg::Commands::create();

--- a/include/vsg/nodes/LOD.h
+++ b/include/vsg/nodes/LOD.h
@@ -23,11 +23,11 @@ namespace vsg
 {
 
     /** Level of Detail Node,
-     *  Children should be ordered with the highest resolution Child first, thought to lowest resolution LOD child last.
+     *  Children should be ordered with the highest resolution child first, through to lowest resolution LOD child last.
      *  The Child struct stores the visibleHeightRatio and child that it's associated with.
-     *  During culling tHe visibleHeightRatio is used as a ratio of screen height that Bound sphere occupies on screen needs to be at least in order for the associated child to be traversed.
-     *  Once on child passes this test no more children are checked, so that no more than on child will ever being traversed in a record traversal.
-     *  If no Child pass the visible height test then none of the LOD's children will be visible.
+     *  During culling the visibleHeightRatio is used as a minimum ratio of screen height that a bounding sphere needs to occupy in order for the associated child to be traversed.
+     *  Once one child passes this test no more children are checked, so that no more than one child will ever be traversed in a record traversal.
+     *  If no child passes the visible height test then none of the LOD's children will be visible.
      *  During the record traversals the Bound sphere is also checked against the view frustum so that LOD's also enable view frustum culling for subgraphs so there is no need for a separate CullNode/CullGroup to decorate it. */
     class VSG_DECLSPEC LOD : public Inherit<Node, LOD>
     {

--- a/include/vsg/nodes/Light.h
+++ b/include/vsg/nodes/Light.h
@@ -18,8 +18,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Light node a base class for different light types - AmbientLight, DirectionalLight, PointLight and SpotLight.
-    /// Used to by the RecordTraversal to represent a light source that is placed in the LightData uniform used by the shaders when implementing lighting.
+    /// Light is a base node class for different light types - AmbientLight, DirectionalLight, PointLight and SpotLight.
+    /// Used by the RecordTraversal to represent a light source that is placed in the LightData uniform used by the shaders when implementing lighting.
     /// Provides name, color and intensity settings common to all Light types.
     class VSG_DECLSPEC Light : public Inherit<Node, Light>
     {
@@ -48,7 +48,7 @@ namespace vsg
     };
     VSG_type_name(vsg::AmbientLight);
 
-    /// DirectionalLight represents a directional light source - used for light sources that are treated as if at infinity, like sun/moon.
+    /// DirectionalLight represents a directional light source - used for light sources that are treated as if at infinite distance, like sun/moon.
     class VSG_DECLSPEC DirectionalLight : public Inherit<Light, DirectionalLight>
     {
     public:
@@ -93,7 +93,7 @@ namespace vsg
     };
     VSG_type_name(vsg::SpotLight);
 
-    /// convenience method for creating a subgraph that creates a headlight illumination using a white AmibientLight and DirectionalLight with intensity of 0.1 and 0.9 respectively.
+    /// convenience method for creating a subgraph with a headlight illumination using a white AmbientLight and DirectionalLight with intensity of 0.1 and 0.9 respectively.
     extern VSG_DECLSPEC ref_ptr<vsg::Node> createHeadlight();
 
 } // namespace vsg

--- a/include/vsg/nodes/MatrixTransform.h
+++ b/include/vsg/nodes/MatrixTransform.h
@@ -19,7 +19,7 @@ namespace vsg
 
     /// MatrixTransform is a transform node that provides a 4x4 matrix that is used to position subgraphs.
     /// During the RecordTraversal the matrix is multiplied by the modelview matrix and pushed to the State::modelviewMatrixStack stack.
-    /// the subgraphs is traversed the multiplied matrix is popped from the State::modelviewMatrixStack.
+    /// When the subgraph has been traversed the multiplied matrix is popped from the State::modelviewMatrixStack.
     class VSG_DECLSPEC MatrixTransform : public Inherit<Transform, MatrixTransform>
     {
     public:

--- a/include/vsg/nodes/PagedLOD.h
+++ b/include/vsg/nodes/PagedLOD.h
@@ -26,11 +26,11 @@ namespace vsg
     class PagedLODList;
 
     /** Level of Detail Node,
-     *  Children should be ordered with the highest resolution PagedLODChild first, thought to lowest resolution PagedLOD child last.
+     *  Children should be ordered with the highest resolution PagedLODChild first, through to lowest resolution PagedLODChild last.
      *  The PagedLODChild struct stores the visibleHeightRatio and child that it's associated with.
-     *  During culling tHe visibleHeightRatio is used as a ratio of screen height that Bound sphere occupies on screen needs to be at least in order for the associated child to be traversed.
-     *  Once on child passes this test no more children are checked, so that no more than on child will ever being traversed in a record traversal.
-     *  If no PagedLODChild pass the visible height test then none of the PagedLOD's children will be visible.
+     *  During culling the visibleHeightRatio is used as a minimum ratio of screen height that a bounding sphere needs to occupy in order for the associated child to be traversed.
+     *  Once one child passes this test no more children are checked, so that no more than one child will ever be traversed in a record traversal.
+     *  If no PagedLODChild passes the visible height test then none of the PagedLOD's children will be visible.
      *  During the record traversals the Bound sphere is also checked against the view frustum so that PagedLOD's also enable view frustum culling for subgraphs so there is no need for a separate CullNode/CullGroup to decorate it. */
     class VSG_DECLSPEC PagedLOD : public Inherit<Node, PagedLOD>
     {

--- a/include/vsg/nodes/QuadGroup.h
+++ b/include/vsg/nodes/QuadGroup.h
@@ -22,9 +22,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// QuadGroup is a specialist group node that manages a 4 children, designed to keep minimize the CPU overhead of traversing quad trees.
-    /// The number of children is fixed and all children are assumed to set before traversal of the scene graph, failure to set up correctly
-    /// will lead to memory faults, this is deliberate choice as any checks for pointer validity will incur CPU overhead.
+    /// QuadGroup is a specialized group node that manages 4 children, designed to minimize the CPU overhead of traversing quad trees.
+    /// The number of children is fixed and all children are assumed to be set before traversal of the scene graph, failure to set up correctly
+    /// will lead to memory faults, this is a deliberate choice as any checks for pointer validity will incur CPU overhead.
     class VSG_DECLSPEC QuadGroup : public Inherit<Node, QuadGroup>
     {
     public:

--- a/include/vsg/nodes/StateGroup.h
+++ b/include/vsg/nodes/StateGroup.h
@@ -24,8 +24,8 @@ namespace vsg
     // forward declare
     class CommandBuffer;
 
-    /// StateGroup is a Group node that manages a list of StateCommands that are use during the RecordTraversal for applying state to subgraph
-    /// When the RecordTraversal encounters a The StateGroup the StateGroup::stateCommands are pushed to the appropriate vsg::State stacks
+    /// StateGroup is a Group node that manages a list of StateCommands that are used during the RecordTraversal for applying state to subgraphs
+    /// When the RecordTraversal encounters the StateGroup its StateGroup::stateCommands are pushed to the appropriate vsg::State stacks
     /// and when a Command is encountered during the RecordTraversal the current head of these State stacks are applied.  After traversing
     /// the StateGroup's subgraph the StateGroup::stateCommands are popped from the vsg::State stacks.
     class VSG_DECLSPEC StateGroup : public Inherit<Group, StateGroup>

--- a/include/vsg/nodes/TileDatabase.h
+++ b/include/vsg/nodes/TileDatabase.h
@@ -80,7 +80,7 @@ namespace vsg
     };
     VSG_type_name(vsg::TileDatabase);
 
-    /// convenience function for getting the part of string that enclosed between a start_match and end_match string
+    /// convenience function for getting the part of a string enclosed between a start_match and end_match string
     extern VSG_DECLSPEC std::string_view find_field(const std::string& source, const std::string_view& start_match, const std::string_view& end_match);
 
     /// convenience function for replacing all instances of a match string with the replacement string.

--- a/include/vsg/nodes/Transform.h
+++ b/include/vsg/nodes/Transform.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Transform node is a pure virtual base class for positioning/scaling/rotation subgraphs.
+    /// Transform node is a pure virtual base class for positioning/scaling/rotating subgraphs.
     class VSG_DECLSPEC Transform : public Inherit<Group, Transform>
     {
     public:
@@ -33,7 +33,7 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        /// Return the transform matrix, multiplying local transform matrix against the matrix passed into the transform(,,) method.
+        /// Return the transform matrix, multiplying local transform matrix against the matrix passed into the transform(..) method.
         /// Typically one pre multiplies local transform against the matrix passed in, which during a RecordTraversal will be the previous modelview matrix inherited from above.
         virtual dmat4 transform(const dmat4& mv) const = 0;
 

--- a/include/vsg/nodes/VertexDraw.h
+++ b/include/vsg/nodes/VertexDraw.h
@@ -20,7 +20,7 @@ namespace vsg
 {
 
     /** VertexDraw provides a lightweight way of binding vertex arrays and then issuing a vkCmdDrawIndexed command.
-      * Higher performance equivalent to use of individual vsg::BindVertexBuffers and vsg::DrawIndex commands.*/
+      * Higher performance equivalent to use of individual vsg::BindVertexBuffers and vsg::Draw commands.*/
     class VSG_DECLSPEC VertexDraw : public Inherit<Command, VertexDraw>
     {
     public:

--- a/include/vsg/nodes/VertexIndexDraw.h
+++ b/include/vsg/nodes/VertexIndexDraw.h
@@ -20,7 +20,7 @@ namespace vsg
 {
 
     /** VertexIndexDraw provides a lightweight way of binding vertex arrays, indices and then issuing a vkCmdDrawIndexed command.
-      * Higher performance equivalent to use of individual vsg::BindVertexBuffers, vsg::BVindIndexBuffer and vsg::DrawIndex commands.*/
+      * Higher performance equivalent to use of individual vsg::BindVertexBuffers, vsg::BindIndexBuffer and vsg::DrawIndexed commands.*/
     class VSG_DECLSPEC VertexIndexDraw : public Inherit<Command, VertexIndexDraw>
     {
     public:

--- a/include/vsg/platform/android/Android_Window.h
+++ b/include/vsg/platform/android/Android_Window.h
@@ -23,7 +23,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsgAndroid
 {
 
-    /// KeyboardMap maps Andriod keyboard events to vsg::KeySymbol
+    /// KeyboardMap maps Android keyboard events to vsg::KeySymbol
     class KeyboardMap : public vsg::Object
     {
     public:

--- a/include/vsg/raytracing/BuildAccelerationStructureTraversal.h
+++ b/include/vsg/raytracing/BuildAccelerationStructureTraversal.h
@@ -28,7 +28,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// BuildAccelerationStructureTraversal is helper class for traversal of a scene graph to required acceleration structures.
+    /// BuildAccelerationStructureTraversal is a helper class for traversal of a scene graph to build required acceleration structures.
     class VSG_DECLSPEC BuildAccelerationStructureTraversal : public Visitor
     {
     public:

--- a/include/vsg/raytracing/DescriptorAccelerationStructure.h
+++ b/include/vsg/raytracing/DescriptorAccelerationStructure.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// DescriptorAccelerationStructure descriptor encapsulates of VkAccelerationStructure.
+    /// DescriptorAccelerationStructure encapsulates descriptors of type VkAccelerationStructure.
     class VSG_DECLSPEC DescriptorAccelerationStructure : public Inherit<Descriptor, DescriptorAccelerationStructure>
     {
     public:

--- a/include/vsg/state/ArrayState.h
+++ b/include/vsg/state/ArrayState.h
@@ -22,8 +22,8 @@ namespace vsg
 {
 
     /// ArrayState base class provides a mechanism for CPU mapping of array data that is processed in novel ways on the GPU.
-    /// Assigned to StategGroup that are associated GraphicsPipline that use vertex shaders with novel vertex processing,
-    /// and used during traversal such as ComputeTraversal and IntersectionTraversal.
+    /// Assigned to StateGroup with an associated GraphicsPipeline that uses vertex shaders with novel vertex processing,
+    /// and used during traversals such as ComputeBounds and Intersector.
     class VSG_DECLSPEC ArrayState : public Inherit<ConstVisitor, ArrayState>
     {
     public:
@@ -89,9 +89,9 @@ namespace vsg
     };
     VSG_type_name(vsg::ArrayState);
 
-    /// NullArrayState provides a mechanism for geometry in a subgraph to be ignored by traversals that use ArrayState such as ComputeBounds/Intersection/LineSegmentIntersector
+    /// NullArrayState provides a mechanism for geometry in a subgraph to be ignored by traversals that use ArrayState such as ComputeBounds/Intersector/LineSegmentIntersector
     /// this is useful for subgraphs that have custom shaders that move the final rendered geometry to a different place that would be naively interpreted by a straight forward vec3Array vertex array in local coordinates.
-    /// To disable the handling of geometry in a subgraph simple assign a NullArrayState to the StateGroup::prototypeArrayState, i.e.
+    /// To disable the handling of geometry in a subgraph simply assign a NullArrayState to the StateGroup::prototypeArrayState, i.e.
     ///     stateGroup->prototypeArrayState = vsg::NullArrayState::create();
     class VSG_DECLSPEC NullArrayState : public Inherit<ArrayState, NullArrayState>
     {
@@ -109,7 +109,7 @@ namespace vsg
     };
     VSG_type_name(vsg::NullArrayState);
 
-    /// PositionArrayState is ArrayState subclass for mapping vertex array data for instanced geometries.
+    /// PositionArrayState is an ArrayState subclass for mapping vertex array data for instanced geometries.
     class VSG_DECLSPEC PositionArrayState : public Inherit<ArrayState, PositionArrayState>
     {
     public:
@@ -130,7 +130,7 @@ namespace vsg
     };
     VSG_type_name(vsg::PositionArrayState);
 
-    /// DisplacementMapArrayState is ArrayState subclass for mapping vertex array data for displacement mapped geometries.
+    /// DisplacementMapArrayState is an ArrayState subclass for mapping vertex array data for displacement mapped geometries.
     class VSG_DECLSPEC DisplacementMapArrayState : public Inherit<ArrayState, DisplacementMapArrayState>
     {
     public:
@@ -164,7 +164,7 @@ namespace vsg
     };
     VSG_type_name(vsg::DisplacementMapArrayState);
 
-    /// PositionAndDisplacementMapArrayState is ArrayState subclass for mapping vertex array data for instanced, displacement mapped geometries.
+    /// PositionAndDisplacementMapArrayState is an ArrayState subclass for mapping vertex array data for instanced, displacement mapped geometries.
     class VSG_DECLSPEC PositionAndDisplacementMapArrayState : public Inherit<DisplacementMapArrayState, PositionAndDisplacementMapArrayState>
     {
     public:
@@ -183,7 +183,7 @@ namespace vsg
     };
     VSG_type_name(vsg::PositionAndDisplacementMapArrayState);
 
-    /// BillboardArrayState is ArrayState subclass for mapping vertex array data for billboard instanced geometries.
+    /// BillboardArrayState is an ArrayState subclass for mapping vertex array data for billboard instanced geometries.
     class VSG_DECLSPEC BillboardArrayState : public Inherit<ArrayState, BillboardArrayState>
     {
     public:

--- a/include/vsg/state/BindDescriptorSet.h
+++ b/include/vsg/state/BindDescriptorSet.h
@@ -85,7 +85,7 @@ namespace vsg
     VSG_type_name(vsg::BindDescriptorSets);
 
     /// BindDescriptorSet state command encapsulates vkCmdBindDescriptorSets call and associated settings for a single DescriptorSet.
-    /// Functionality the same as assigning a single DescriptorSet to a BindDescriptorSets but has slightly lower memory footprint and CPU overhead.
+    /// Functionally the same as assigning a single DescriptorSet to a BindDescriptorSets but has slightly lower memory footprint and CPU overhead.
     class VSG_DECLSPEC BindDescriptorSet : public Inherit<StateCommand, BindDescriptorSet>
     {
     public:

--- a/include/vsg/state/Buffer.h
+++ b/include/vsg/state/Buffer.h
@@ -21,7 +21,7 @@ namespace vsg
     class Context;
 
     /// Buffer encapsulates VkBuffer and VkBufferCreateInfo settings used to set it up.
-    /// Buffer is used map blocks of DeviceMemory for use with BufferInfo associated DescriptorBuffer/BufferView/Vertex/Index arrays.
+    /// Buffer maps blocks of DeviceMemory for use with BufferInfo typically associated with DescriptorBuffer/BufferView/Vertex/Index arrays.
     class VSG_DECLSPEC Buffer : public Inherit<Object, Buffer>
     {
     public:

--- a/include/vsg/state/BufferInfo.h
+++ b/include/vsg/state/BufferInfo.h
@@ -41,7 +41,7 @@ namespace vsg
         /// Requires associated buffer memory to be host visible, for non host visible buffers you must use a staging buffer
         void copyDataToBuffer();
 
-        /// Copy data to the VkBuffer associated with the a specified Device
+        /// Copy data to the VkBuffer associated with the specified Device
         /// Requires associated buffer memory to be host visible, for non host visible buffers you must use a staging buffer
         void copyDataToBuffer(uint32_t deviceID);
 
@@ -59,7 +59,7 @@ namespace vsg
             return data && data->differentModifiedCount(copiedModifiedCounts[deviceID]);
         }
 
-        /// return true if the BufferInfo's data has been modified and should be copied to the buffer, and sync the moificationCounts
+        /// return true if the BufferInfo's data has been modified and should be copied to the buffer, and sync the modification counts
         bool syncModifiedCounts(uint32_t deviceID)
         {
             return data && data->getModifiedCount(copiedModifiedCounts[deviceID]);

--- a/include/vsg/state/ColorBlendState.h
+++ b/include/vsg/state/ColorBlendState.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// ColorBlendState encapsulates to VkPipelineColorBlendStateCreateInfo settings passed when setting up GraphicsPipeline
+    /// ColorBlendState encapsulates VkPipelineColorBlendStateCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC ColorBlendState : public Inherit<GraphicsPipelineState, ColorBlendState>
     {
     public:

--- a/include/vsg/state/DepthStencilState.h
+++ b/include/vsg/state/DepthStencilState.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// DepthStencilState encapsulates to VkPipelineDepthStencilStateCreateInfo settings passed when setting up GraphicsPipeline
+    /// DepthStencilState encapsulates VkPipelineDepthStencilStateCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC DepthStencilState : public Inherit<GraphicsPipelineState, DepthStencilState>
     {
     public:

--- a/include/vsg/state/Descriptor.h
+++ b/include/vsg/state/Descriptor.h
@@ -20,7 +20,7 @@ namespace vsg
     class Context;
 
     /// Descriptor base class for descriptor DescriptorBuffer/DescriptorImage/DescriptorTexelBufferView classes.
-    /// Descriptors are assigned BindDescriptorState state commands.
+    /// Descriptors are assigned to BindDescriptorSet state commands.
     /// Provides VkWriteDescriptorSet settings that are required for all types of descriptors.
     class VSG_DECLSPEC Descriptor : public Inherit<Object, Descriptor>
     {

--- a/include/vsg/state/DescriptorBuffer.h
+++ b/include/vsg/state/DescriptorBuffer.h
@@ -18,8 +18,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// DescriptorBuffer is Descriptor class that encapsulates bufferInfoList used to set VkWriteDescriptorSet.pBufferInfo settings
-    /// DescriptorBuffer is means for passing uniforms to shaders.
+    /// DescriptorBuffer is a Descriptor class that encapsulates the bufferInfoList used to set VkWriteDescriptorSet::pBufferInfo settings
+    /// DescriptorBuffer is a means for passing uniforms to shaders.
     class VSG_DECLSPEC DescriptorBuffer : public Inherit<Descriptor, DescriptorBuffer>
     {
     public:

--- a/include/vsg/state/DescriptorImage.h
+++ b/include/vsg/state/DescriptorImage.h
@@ -18,8 +18,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// DescriptorImage is Descriptor class that encapsulates imageInfoList used to set VkWriteDescriptorSet.pImageInfo settings
-    /// DescriptorImage is means for passing textures to shaders.
+    /// DescriptorImage is a Descriptor class that encapsulates the imageInfoList used to set VkWriteDescriptorSet::pImageInfo settings
+    /// DescriptorImage is a means for passing textures to shaders.
     class VSG_DECLSPEC DescriptorImage : public Inherit<Descriptor, DescriptorImage>
     {
     public:

--- a/include/vsg/state/DescriptorTexelBufferView.h
+++ b/include/vsg/state/DescriptorTexelBufferView.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// DescriptorTexelBufferView is Descriptor class that encapsulates texelBufferViews used to set VkWriteDescriptorSet.pTexelBufferViews
+    /// DescriptorTexelBufferView is a Descriptor class that encapsulates texelBufferViews used to set VkWriteDescriptorSet::pTexelBufferViews
     class VSG_DECLSPEC DescriptorTexelBufferView : public Inherit<Descriptor, DescriptorTexelBufferView>
     {
     public:

--- a/include/vsg/state/DynamicState.h
+++ b/include/vsg/state/DynamicState.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// DynamicState encapsulates to VkPipelineDynamicStateCreateInfo settings passed when setting up GraphicsPipeline
+    /// DynamicState encapsulates VkPipelineDynamicStateCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC DynamicState : public Inherit<GraphicsPipelineState, DynamicState>
     {
     public:

--- a/include/vsg/state/Image.h
+++ b/include/vsg/state/Image.h
@@ -20,11 +20,11 @@ namespace vsg
     // forward declare
     class Context;
 
-    /// Image class encapsulates VkImage and VkImageCreateInfo settings used to it up.
+    /// Image class encapsulates VkImage and VkImageCreateInfo settings used to set it up.
     class VSG_DECLSPEC Image : public Inherit<Object, Image>
     {
     public:
-        /// create a vsg::Image with optional CreateInfo, delay VkUmage creation to compile
+        /// create a vsg::Image, optional Data is used to initialize createInfo, delay VkImage creation to compile
         Image(ref_ptr<Data> in_data = {});
 
         /// create a vsg::Image wrapper for specified VkImage

--- a/include/vsg/state/ImageInfo.h
+++ b/include/vsg/state/ImageInfo.h
@@ -68,7 +68,7 @@ namespace vsg
             return data && data->differentModifiedCount(copiedModifiedCounts[deviceID]);
         }
 
-        /// return true if the ImageInfo's data has been modified and should be copied to the buffer, and sync the moificationCounts
+        /// return true if the ImageInfo's data has been modified and should be copied to the buffer, and sync the modification counts
         bool syncModifiedCounts(uint32_t deviceID)
         {
             if (!imageView || !imageView->image) return false;
@@ -85,7 +85,7 @@ namespace vsg
 
     using ImageInfoList = std::vector<ref_ptr<ImageInfo>>;
 
-    /// format traits hints that can be used when initialize image data
+    /// format traits hints that can be used when initializing image data
     struct FormatTraits
     {
         int size = 0;
@@ -108,7 +108,7 @@ namespace vsg
         }
     };
 
-    /// return the traits suitable for specified VkFDormat.
+    /// return the traits suitable for specified VkFormat.
     extern VSG_DECLSPEC FormatTraits getFormatTraits(VkFormat format, bool default_one = true);
 
     /// return the number of mip map levels specified by Data/Sampler.

--- a/include/vsg/state/ImageView.h
+++ b/include/vsg/state/ImageView.h
@@ -61,10 +61,10 @@ namespace vsg
 
     using ImageViews = std::vector<ref_ptr<ImageView>>;
 
-    /// convenience function that create an ImageView and allocates device memory and an Image for it. For device memory allocation the Context's DeviceMemoryPools are utilized.
+    /// convenience function that creates an ImageView and allocates device memory and an Image for it. For device memory allocation the Context's deviceMemoryBufferPools are utilized.
     extern VSG_DECLSPEC ref_ptr<ImageView> createImageView(Context& context, ref_ptr<Image> image, VkImageAspectFlags aspectFlags);
 
-    /// convenience function that create an ImageView and allocates device memory and an Image for it.
+    /// convenience function that creates an ImageView and allocates device memory and an Image for it.
     extern VSG_DECLSPEC ref_ptr<ImageView> createImageView(Device* device, ref_ptr<Image> image, VkImageAspectFlags aspectFlags);
 
     /// convenience function that uploads staging buffer data to device including mipmaps.

--- a/include/vsg/state/InputAssemblyState.h
+++ b/include/vsg/state/InputAssemblyState.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// InputAssemblyState encapsulates to VkPipelineInputAssemblyStateCreateInfo settings passed when setting up GraphicsPipeline
+    /// InputAssemblyState encapsulates VkPipelineInputAssemblyStateCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC InputAssemblyState : public Inherit<GraphicsPipelineState, InputAssemblyState>
     {
     public:

--- a/include/vsg/state/MultisampleState.h
+++ b/include/vsg/state/MultisampleState.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// MultisampleState encapsulates to VkPipelineMultisampleStateCreateInfo settings passed when setting up GraphicsPipeline
+    /// MultisampleState encapsulates VkPipelineMultisampleStateCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC MultisampleState : public Inherit<GraphicsPipelineState, MultisampleState>
     {
     public:

--- a/include/vsg/state/RasterizationState.h
+++ b/include/vsg/state/RasterizationState.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// RasterizationState encapsulates to VkPipelineRasterizationStateCreateInfo settings passed when setting up GraphicsPipeline
+    /// RasterizationState encapsulates VkPipelineRasterizationStateCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC RasterizationState : public Inherit<GraphicsPipelineState, RasterizationState>
     {
     public:

--- a/include/vsg/state/ShaderStage.h
+++ b/include/vsg/state/ShaderStage.h
@@ -19,7 +19,7 @@ namespace vsg
     // forward declare
     class Context;
 
-    /// ShaderStage encapsulates to VkPipelineShaderStageCreateInfo settings passed when setting up GraphicsPipeline
+    /// ShaderStage encapsulates VkPipelineShaderStageCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC ShaderStage : public Inherit<Object, ShaderStage>
     {
     public:

--- a/include/vsg/state/StateCommand.h
+++ b/include/vsg/state/StateCommand.h
@@ -18,7 +18,7 @@ namespace vsg
 {
 
     /// Base class for Vulkan commands associated with state, such as binding graphics pipelines and descriptors sets (textures and uniforms).
-    /// StateCommands can be attached directly as nodes in the scene graph, or more typically assigned to StateGroup node to enable push/popping of state.
+    /// StateCommands can be attached directly as nodes in the scene graph, or more typically assigned to StateGroup nodes to enable push/popping of state.
     class VSG_DECLSPEC StateCommand : public Inherit<Command, StateCommand>
     {
     public:

--- a/include/vsg/state/StateSwitch.h
+++ b/include/vsg/state/StateSwitch.h
@@ -16,8 +16,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    /// StateSwitch is a StateCommand that provides support, during the RecordTraveral, for applying StateCommand children based on pass a mask.
-    /// Can be used for enable state for specific View's were the StateSwitch child masks are matched the View mask.
+    /// StateSwitch is a StateCommand that provides support, during the RecordTraveral, for applying StateCommand children based on passing a mask.
+    /// Can be used to enable state for specific Views where the StateSwitch child masks are matched with the View mask.
     class VSG_DECLSPEC StateSwitch : public Inherit<StateCommand, StateSwitch>
     {
     public:

--- a/include/vsg/state/TessellationState.h
+++ b/include/vsg/state/TessellationState.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// TessellationState encapsulates to VkPipelineTessellationStateCreateInfo settings passed when setting up GraphicsPipeline
+    /// TessellationState encapsulates VkPipelineTessellationStateCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC TessellationState : public Inherit<GraphicsPipelineState, TessellationState>
     {
     public:

--- a/include/vsg/state/VertexInputState.h
+++ b/include/vsg/state/VertexInputState.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// VertexInputState encapsulates to VkPipelineVertexInputStateCreateInfo settings passed when setting up GraphicsPipeline
+    /// VertexInputState encapsulates VkPipelineVertexInputStateCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC VertexInputState : public Inherit<GraphicsPipelineState, VertexInputState>
     {
     public:

--- a/include/vsg/state/ViewDependentState.h
+++ b/include/vsg/state/ViewDependentState.h
@@ -20,7 +20,7 @@ namespace vsg
 {
 
     /// ViewDescriptorSetLayout is a proxy class that uses the ViewDependentState's descriptorSetLayout as the DescriptorSetLayout to use.
-    /// Used in pipelines that wish to utilize in the light and other view dependent data provided by the View::ViewDependentState.
+    /// Used in pipelines that wish to utilize lights and other view dependent data provided by the View::viewDependentState.
     /// Use in combination with the BindViewDescriptorSet.
     class VSG_DECLSPEC ViewDescriptorSetLayout : public Inherit<DescriptorSetLayout, ViewDescriptorSetLayout>
     {
@@ -41,8 +41,8 @@ namespace vsg
     };
     VSG_type_name(vsg::ViewDescriptorSetLayout);
 
-    /// BindViewDescriptorSets is proxy class that binds the View::ViewDependentState's descriptorSet
-    /// Used for pass light and other view dependent state to the GPU.
+    /// BindViewDescriptorSets is a proxy class that binds the View::viewDependentState's descriptorSet
+    /// Used for passing lights and other view dependent state to the GPU.
     /// Use in conjunction with a pipeline configured with vsg::ViewDescriptorSetLayout.
     class VSG_DECLSPEC BindViewDescriptorSets : public Inherit<StateCommand, BindViewDescriptorSets>
     {
@@ -87,12 +87,12 @@ namespace vsg
     VSG_type_name(vsg::BindViewDescriptorSets);
 
     /// ViewDependentState to manage lighting, clip planes and texture projection
-    /// By default assigned to the vsg::View, for standard usage you can don't need to create or modify the ViewDependentState
-    /// If you wish to override the standard lighting support provided by ViewDependentState you and subclass
+    /// By default assigned to the vsg::View, for standard usage you don't need to create or modify the ViewDependentState
+    /// If you wish to override the standard lighting support provided by ViewDependentState you can subclass it.
     ///
     /// To leverage the state that the ViewDependentState provides you need to set up the graphics pipelines with the vsg::ViewDescriptorSetLayout,
     /// and add a vsg::BindViewDescriptorSet to a StateGroup.  You don't need to explicitly add these if you have created your scene graph using
-    /// vsg::Builder created or used loaders like vsgXchange::Assimp.
+    /// vsg::Builder or used loaders like vsgXchange::Assimp.
     class VSG_DECLSPEC ViewDependentState : public Inherit<Object, ViewDependentState>
     {
     public:

--- a/include/vsg/state/ViewportState.h
+++ b/include/vsg/state/ViewportState.h
@@ -19,7 +19,7 @@ namespace vsg
     using Viewports = std::vector<VkViewport>;
     using Scissors = std::vector<VkRect2D>;
 
-    /// ViewportState encapsulates to VkPipelineViewportStateCreateInfo settings passed when setting up GraphicsPipeline
+    /// ViewportState encapsulates VkPipelineViewportStateCreateInfo settings passed when setting up GraphicsPipeline
     class VSG_DECLSPEC ViewportState : public Inherit<GraphicsPipelineState, ViewportState>
     {
     public:

--- a/include/vsg/state/material.h
+++ b/include/vsg/state/material.h
@@ -90,7 +90,7 @@ namespace vsg
     VSG_value(PhongMaterialValue, PhongMaterial);
     VSG_array(PhongMaterialArray, PhongMaterial);
 
-    /// PbrMaterial struct for passing material settings, suitable for phong lighting model, as uniform value to fragment shader
+    /// PbrMaterial struct for passing material settings, suitable for PBR lighting model, as uniform value to fragment shader
     /// Used in conjunction with vsg::createPhysicsBasedRenderingShaderSet().
     struct PbrMaterial
     {

--- a/include/vsg/text/Text.h
+++ b/include/vsg/text/Text.h
@@ -21,10 +21,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /** Text node provides high quality text rendering using signed distance field glyph texture atlas.
-      * Text does not provide view frustum culling or level of detail, but you can add this if require
-      * it by decorating the Text with a CullNode/LOD and after TextGroup::setup() is called to initialize
-      * the rendering component you can use the TextGroup->technique->extents() value to help set the
+    /** Text node provides high quality text rendering using a signed distance field glyph texture atlas.
+      * Text does not provide view frustum culling or level of detail, but you can add this if required
+      * by decorating the Text with a CullNode/LOD and after TextGroup::setup() is called to initialize
+      * the rendering component, you can use the TextGroup->technique->extents() value to help set the
       * CullNode/LOD.bounds value.*/
     class VSG_DECLSPEC Text : public Inherit<Node, Text>
     {
@@ -57,7 +57,7 @@ namespace vsg
     };
     VSG_type_name(vsg::Text);
 
-    /// create a ShaderSet used for both CpuALayutTechnique and GpuALayutTechnique or return the Options::shaderSet["text"] entry if available.
+    /// create a ShaderSet used for both CpuLayoutTechnique and GpuLayoutTechnique or return the Options::shaderSet["text"] entry if available.
     extern VSG_DECLSPEC ref_ptr<ShaderSet> createTextShaderSet(ref_ptr<const Options> options = {});
 
     /// convenience class for counting the number of text glyphs

--- a/include/vsg/text/TextGroup.h
+++ b/include/vsg/text/TextGroup.h
@@ -16,12 +16,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    /** TextGroup node provides high performance rendering of large numbers of text labels batched rendering of Text.
-      * In order to achieve batching all Text children of TextGroup node use the same Font, ShaderSet and TextTechnique
-      * provided by the TextGroup node, any local Text entries for these are discarded. The individual Text's are
-      * positioned by their local TextLayout.TextGroup does not provide view frustum culling or level of detail, but you
-      * can add this if require it by decorating the TextGroup with a CullNode/LOD and after TextGroup::setup() is called
-      * to initialize the rendering component you can use the TextGroup->technique->extents() value to help set the
+    /** TextGroup node provides high performance rendering of large numbers of text labels, i.e. batched rendering of Text.
+      * In order to achieve batching all Text children of a TextGroup node use the same Font, ShaderSet and TextTechnique
+      * provided by the TextGroup node, any local Text entries for these are discarded. The individual Texts are
+      * positioned by their local TextLayout. TextGroup does not provide view frustum culling or level of detail, but you
+      * can add this if required by decorating the TextGroup with a CullNode/LOD and after TextGroup::setup() is called
+      * to initialize the rendering component, you can use the TextGroup->technique->extents() value to help set the
       * CullNode/LOD.bounds value.*/
     class VSG_DECLSPEC TextGroup : public vsg::Inherit<vsg::Node, TextGroup>
     {

--- a/include/vsg/text/TextLayout.h
+++ b/include/vsg/text/TextLayout.h
@@ -26,7 +26,7 @@ namespace vsg
         vec4 outlineColors[4];
         float outlineWidths[4];
         vec3 normal;
-        vec4 centerAndAutoScaleDistance; // only used by when billboarding
+        vec4 centerAndAutoScaleDistance; // only used when billboarding
     };
 
     using TextQuads = std::vector<TextQuad>;

--- a/include/vsg/threading/Barrier.h
+++ b/include/vsg/threading/Barrier.h
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Barrier provides a means for synchronization multiple threads that all release together once specified number of threads joined the Barrier.
+    /// Barrier provides a means for synchronizing multiple threads that all release together once specified number of threads joined the Barrier.
     class Barrier : public Inherit<Object, Barrier>
     {
     public:
@@ -31,7 +31,7 @@ namespace vsg
         Barrier(const Barrier&) = delete;
         Barrier& operator=(const Barrier&) = delete;
 
-        /// increment the arrived count and release the barrier if count matches number of threads to arrive otherwise waiting for the arrived count to match the number if threads to arrive
+        /// increment the arrived count and release the barrier if count matches number of threads to arrive otherwise wait for the arrived count to match the number of threads to arrive
         void arrive_and_wait()
         {
             std::unique_lock lock(_mutex);

--- a/include/vsg/threading/FrameBlock.h
+++ b/include/vsg/threading/FrameBlock.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// FrameBlock provides mechanism for synchronization threads that are waiting on the start of new frame,
+    /// FrameBlock provides a mechanism for synchronizing threads that are waiting on the start of a new frame.
     class FrameBlock : public Inherit<Object, FrameBlock>
     {
     public:

--- a/include/vsg/threading/Latch.h
+++ b/include/vsg/threading/Latch.h
@@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Latch provides a means for synchronization multiple threads that waits for the latch count to be decremented to zero.
+    /// Latch provides a means for synchronizing multiple threads that waits for the latch count to be decremented to zero.
     class Latch : public Inherit<Object, Latch>
     {
     public:

--- a/include/vsg/threading/OperationQueue.h
+++ b/include/vsg/threading/OperationQueue.h
@@ -102,14 +102,14 @@ namespace vsg
 
             std::unique_lock lock(_mutex);
 
-            // wait to the conditional variable signals that an operation has been added
+            // wait until the conditional variable signals that an operation has been added
             while (_queue.empty() && _status->active())
             {
                 // debug("Waiting on condition variable");
                 _cv.wait_for(lock, waitDuration);
             }
 
-            // if the threads we are associated with should no longer running go for a quick exit and return nothing.
+            // if the threads we are associated with should no longer be running go for a quick exit and return nothing.
             if (_status->cancel())
             {
                 return {};

--- a/include/vsg/threading/OperationThreads.h
+++ b/include/vsg/threading/OperationThreads.h
@@ -21,7 +21,7 @@ namespace vsg
 
     /// OperationThreads provides a collection of std::threads that share a single OperationQueue.
     /// Each thread polls the queue for vsg::Operation to process, when one is available it's removed
-    /// from the queue and it's Operation::run() method.
+    /// from the queue and its Operation::run() method is called.
     class VSG_DECLSPEC OperationThreads : public Inherit<Object, OperationThreads>
     {
     public:

--- a/include/vsg/threading/atomics.h
+++ b/include/vsg/threading/atomics.h
@@ -41,7 +41,7 @@ namespace vsg
         while (!reference.compare_exchange_weak(original_value, original_value * t)) {}
     };
 
-    /// Convenience template function that modifies an atomic if it's value matches the from value, and sets it to, otherwise trues fales without modifying the atomic.
+    /// Convenience template function that modifies an atomic if its value matches the from value, setting it to the to value, otherwise returns false without modifying the atomic.
     template<typename T>
     bool compare_exchange(std::atomic<T>& reference, T from, T to)
     {

--- a/include/vsg/ui/ApplicationEvent.h
+++ b/include/vsg/ui/ApplicationEvent.h
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// TerminateEvent represents a application terminate event.
+    /// TerminateEvent represents an application termination event.
     class TerminateEvent : public Inherit<UIEvent, TerminateEvent>
     {
     public:

--- a/include/vsg/ui/Keyboard.h
+++ b/include/vsg/ui/Keyboard.h
@@ -40,8 +40,8 @@ namespace vsg
         /// return true if key is currently pressed
         bool pressed(KeySymbol key, bool ignore_handled_keys = true) const;
 
-        /// return a pair of times, the first is the time, in seconds, since the key was first pressed and the second is the time, in secnds, since it was released.
-        /// if the key hasn't been pressed then then first value will be < 0.0, if the key is still pressed then the second value will be 0.0.
+        /// return a pair of times, the first is the time, in seconds, since the key was first pressed and the second is the time, in seconds, since it was released.
+        /// if the key hasn't been pressed then then the first value will be < 0.0, if the key is still pressed then the second value will be 0.0.
         std::pair<double, double> times(KeySymbol key, bool ignore_handled_keys = true) const;
     };
     VSG_type_name(vsg::Keyboard);

--- a/include/vsg/ui/PointerEvent.h
+++ b/include/vsg/ui/PointerEvent.h
@@ -50,7 +50,7 @@ namespace vsg
     };
     VSG_type_name(vsg::PointerEvent);
 
-    /// ButtonPressEvent represent a button press event.
+    /// ButtonPressEvent represents a button press event.
     class VSG_DECLSPEC ButtonPressEvent : public Inherit<PointerEvent, ButtonPressEvent>
     {
     public:
@@ -67,7 +67,7 @@ namespace vsg
     };
     VSG_type_name(vsg::ButtonPressEvent);
 
-    /// ButtonReleaseEvent represent a button release event.
+    /// ButtonReleaseEvent represents a button release event.
     class VSG_DECLSPEC ButtonReleaseEvent : public Inherit<PointerEvent, ButtonReleaseEvent>
     {
     public:
@@ -84,7 +84,7 @@ namespace vsg
     };
     VSG_type_name(vsg::ButtonReleaseEvent);
 
-    /// MoveEvent represent a button move event.
+    /// MoveEvent represents a pointer move event.
     class MoveEvent : public Inherit<PointerEvent, MoveEvent>
     {
     public:

--- a/include/vsg/ui/PrintEvents.h
+++ b/include/vsg/ui/PrintEvents.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// PrintEvents prints ui event settings to stream, using for tracking/debugging event handling in applications.
+    /// PrintEvents prints ui event settings to stream, used for tracking/debugging event handling in applications.
     class VSG_DECLSPEC PrintEvents : public Inherit<Visitor, PrintEvents>
     {
     public:

--- a/include/vsg/ui/RecordEvents.h
+++ b/include/vsg/ui/RecordEvents.h
@@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// RecordEvents is a event recording class that can be assigned to a viewer as an event handler.
+    /// RecordEvents is an event recording class that can be assigned to a viewer as an event handler.
     /// Can be used in conjunction with vsg::PlayEvents to replay recorded events.
     /// See vsginput example to see how it's used.
     class VSG_DECLSPEC RecordEvents : public vsg::Inherit<vsg::Visitor, RecordEvents>

--- a/include/vsg/ui/ShiftEventTime.h
+++ b/include/vsg/ui/ShiftEventTime.h
@@ -20,7 +20,7 @@ namespace vsg
 {
 
     /// ShiftEventTime is a visitor for modifying the UIEvent::time values by a specified delta.
-    /// Use by PlayEvents to replace recorded events with a different time point.
+    /// Used by PlayEvents to replace recorded events with a different time point.
     class VSG_DECLSPEC ShiftEventTime : public vsg::Inherit<vsg::Visitor, ShiftEventTime>
     {
     public:

--- a/include/vsg/ui/TouchEvent.h
+++ b/include/vsg/ui/TouchEvent.h
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// TouchEvent is a base class touch events.
+    /// TouchEvent is a base class for touch events.
     class VSG_DECLSPEC TouchEvent : public Inherit<WindowEvent, TouchEvent>
     {
     public:

--- a/include/vsg/ui/WindowEvent.h
+++ b/include/vsg/ui/WindowEvent.h
@@ -59,7 +59,7 @@ namespace vsg
     };
     VSG_type_name(vsg::ExposeWindowEvent);
 
-    /// ExposeWindowEvent represents a window configure event - such as changes to the size of the window.
+    /// ConfigureWindowEvent represents a window configure event - such as changes to the size of the window.
     class VSG_DECLSPEC ConfigureWindowEvent : public Inherit<WindowEvent, ConfigureWindowEvent>
     {
     public:

--- a/include/vsg/utils/AnimationPath.h
+++ b/include/vsg/utils/AnimationPath.h
@@ -59,7 +59,7 @@ namespace vsg
     VSG_type_name(vsg::AnimationPath);
 
     /// AnimationPathHandler event handler animates Camera or MatrixTransform along an AnimationPath.
-    /// To automatically update attach the AnimationPathHandler to the viewer using Viewer::addEventHandler().
+    /// To automatically update, attach the AnimationPathHandler to the viewer using Viewer::addEventHandler().
     class VSG_DECLSPEC AnimationPathHandler : public Inherit<Visitor, AnimationPathHandler>
     {
     public:

--- a/include/vsg/utils/Builder.h
+++ b/include/vsg/utils/Builder.h
@@ -30,8 +30,8 @@ namespace vsg
         bool greyscale = false; /// greyscale image
         bool wireframe = false;
         bool instance_colors_vec4 = true;
-        bool instance_positions_vec3 = false; // user must assign GeometyInfo.position with vec3Array containing positions
-        bool billboard = false;               // user must assign GeometyInfo.position with vec4Array containing position_scaleDistance, overrides instance_positions_vec3 setting
+        bool instance_positions_vec3 = false; // user must assign GeometryInfo::positions with vec3Array containing positions
+        bool billboard = false;               // user must assign GeometryInfo::positions with vec4Array containing position_scaleDistance, overrides instance_positions_vec3 setting
 
         ref_ptr<Data> image;
         ref_ptr<Data> displacementMap;
@@ -75,7 +75,7 @@ namespace vsg
             dz.set(0.0f, 0.0f, sp.radius * 2.0f);
         }
 
-        /// when using geometry instancing use vec3Array with vec3{x,y,z} and for billboard use vec4Array with vec4{x,y,z,scaleDistance}
+        /// when using geometry instancing use vec3Array with vec3{x,y,z} and for billboards use vec4Array with vec4{x,y,z,scaleDistance}
         ref_ptr<Data> positions;
         ref_ptr<Data> colors;
 
@@ -92,7 +92,7 @@ namespace vsg
 
     /// Builder class that creates subgraphs that can render primitive geometries.
     /// Supported shapes are Box, Capsule, Cone, Cylinder, Disk, Quad, Sphere and HeightField.
-    /// Uses GeometryInfo and StateInfo to guide the geometry position/size and rendering state.
+    /// Uses GeometryInfo and StateInfo to guide the geometry's position/size and rendering state.
     class VSG_DECLSPEC Builder : public Inherit<Object, Builder>
     {
     public:

--- a/include/vsg/utils/CommandLine.h
+++ b/include/vsg/utils/CommandLine.h
@@ -38,7 +38,7 @@ namespace vsg
     // forward declare
     class Options;
 
-    /// CommandLine provides a convenient way parse command line arguments.
+    /// CommandLine provides a convenient way to parse command line arguments.
     /// Almost all examples in vsgExamples use vsg::CommandLine so look to them for a usage guide.
     class VSG_DECLSPEC CommandLine
     {

--- a/include/vsg/utils/GraphicsPipelineConfigurator.h
+++ b/include/vsg/utils/GraphicsPipelineConfigurator.h
@@ -96,11 +96,11 @@ namespace vsg
         ref_ptr<DepthStencilState> depthStencilState;
         ref_ptr<DynamicState> dynamicState;
         ref_ptr<InputAssemblyState> inputAssemblyState;
-        ref_ptr<MultisampleState> multisampleState; // typically leave unset as compile traversal with provide MultisampleState
+        ref_ptr<MultisampleState> multisampleState; // typically leave unset as compile traversal will provide MultisampleState
         ref_ptr<RasterizationState> rasterizationState;
         ref_ptr<TessellationState> tessellationState;
         ref_ptr<VertexInputState> vertexInputState; // set by assignArray(..) methods.
-        ref_ptr<ViewportState> viewportState;       // typically leave unset as compile traversal with provide ViewportState
+        ref_ptr<ViewportState> viewportState;       // typically leave unset as compile traversal will provide ViewportState
 
         uint32_t subpass = 0;
         uint32_t baseAttributeBinding = 0;
@@ -135,7 +135,7 @@ namespace vsg
     };
     VSG_type_name(vsg::GraphicsPipelineConfigurator);
 
-    /// provide for backwards compatibility
+    /// provided for backwards compatibility
     using GraphicsPipelineConfig = GraphicsPipelineConfigurator;
     using DescriptorConfig = DescriptorConfigurator;
 

--- a/include/vsg/utils/Intersector.h
+++ b/include/vsg/utils/Intersector.h
@@ -62,7 +62,7 @@ namespace vsg
 
         virtual void popTransform() = 0;
 
-        /// check for intersection intersects with sphere
+        /// check for intersection with sphere
         virtual bool intersects(const dsphere& sphere) = 0;
 
         /// intersect with a vkCmdDraw primitive

--- a/include/vsg/utils/LineSegmentIntersector.h
+++ b/include/vsg/utils/LineSegmentIntersector.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// IndexRatio is a pair of index and ratio used specify the baricentric coords of primitives that have been intersected.
+    /// IndexRatio is a pair of index and ratio used to specify the baricentric coords of primitives that have been intersected.
     struct IndexRatio
     {
         uint32_t index;
@@ -27,7 +27,7 @@ namespace vsg
 
     using IndexRatios = std::vector<IndexRatio>;
 
-    /// LineSegmentIntersector is a Intersector subclass that provides support for computing intersections between a line segment and geometry in the scene graph.
+    /// LineSegmentIntersector is an Intersector subclass that provides support for computing intersections between a line segment and geometry in the scene graph.
     class VSG_DECLSPEC LineSegmentIntersector : public Inherit<Intersector, LineSegmentIntersector>
     {
     public:
@@ -62,7 +62,7 @@ namespace vsg
         void pushTransform(const Transform& transform) override;
         void popTransform() override;
 
-        /// check for intersection intersects with sphere
+        /// check for intersection with sphere
         bool intersects(const dsphere& bs) override;
 
         bool intersectDraw(uint32_t firstVertex, uint32_t vertexCount, uint32_t firstInstance, uint32_t instanceCount) override;

--- a/include/vsg/utils/LoadPagedLOD.h
+++ b/include/vsg/utils/LoadPagedLOD.h
@@ -20,7 +20,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    //** Traverse the scene graph loading any PLOD that are required for a camera view.*/
+    // Traverse the scene graph loading any PLOD that are required for a camera view.
     class VSG_DECLSPEC LoadPagedLOD : public vsg::Visitor
     {
     public:

--- a/include/vsg/utils/ShaderCompiler.h
+++ b/include/vsg/utils/ShaderCompiler.h
@@ -9,8 +9,8 @@ namespace vsg
 
     /// ShaderCompiler integrates with GLSLang to provide shader compilation from GLSL shaders to SPIRV shaders usable by Vulkan.
     /// To be able to compile GLSL the VulkanSceneGraph has to be compiled against GLSLang, you can check whether shader compilation
-    /// is supported via the VSG_SUPPORTS_ShaderCompiler #define provided in include/core/Version.h, if the value 1 then shader compilation
-    /// is support. You can also check the ShaderCompile::supported() method.
+    /// is supported via the VSG_SUPPORTS_ShaderCompiler #define provided in include/core/Version.h, if the value is 1 then shader compilation
+    /// is supported. You can also check the ShaderCompiler::supported() method.
     class VSG_DECLSPEC ShaderCompiler : public Inherit<Visitor, ShaderCompiler>
     {
     public:

--- a/include/vsg/utils/ShaderSet.h
+++ b/include/vsg/utils/ShaderSet.h
@@ -88,7 +88,7 @@ namespace vsg
     };
     VSG_type_name(vsg::CustomDescriptorSetBinding);
 
-    /// Custom state binding class for providing the DescriptorSetLayout and StateCommaand required to pass view depedent data, lights/shaders etc., to shaders
+    /// Custom state binding class for providing the DescriptorSetLayout and StateCommand required to pass view dependent data, lights/shadows etc., to shaders
     struct VSG_DECLSPEC ViewDependentStateBinding : public Inherit<CustomDescriptorSetBinding, ViewDependentStateBinding>
     {
         ViewDependentStateBinding(uint32_t in_set = 0);
@@ -105,14 +105,14 @@ namespace vsg
     };
     VSG_type_name(vsg::ViewDependentStateBinding);
 
-    /// ShaderSet provides collection of shader related settings to provide a form of shader introspection.
+    /// ShaderSet provides a collection of shader related settings to provide a form of shader introspection.
     class VSG_DECLSPEC ShaderSet : public Inherit<Object, ShaderSet>
     {
     public:
         ShaderSet();
         explicit ShaderSet(const ShaderStages& in_stages, ref_ptr<ShaderCompileSettings> in_hints = {});
 
-        /// base ShaderStages that other variants as based on.
+        /// base ShaderStages that other variants are based on.
         ShaderStages stages;
 
         std::vector<AttributeBinding> attributeBindings;
@@ -127,7 +127,7 @@ namespace vsg
         /// variants of the rootShaderModule compiled for different combinations of ShaderCompileSettings
         std::map<ref_ptr<ShaderCompileSettings>, ShaderStages, DereferenceLess> variants;
 
-        /// mutex used be getShaderStages(..) so ensure the variants map can be used from multiple threads.
+        /// mutex used by getShaderStages(..) to ensure the variants map can be used from multiple threads.
         std::mutex mutex;
 
         /// add an attribute binding, Not thread safe, should only be called when initially setting up the ShaderSet
@@ -136,7 +136,7 @@ namespace vsg
         /// add an uniform binding. Not thread safe, should only be called when initially setting up the ShaderSet
         void addUniformBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data);
 
-        /// add an uniform binding. Not thread safe, should only be called when initially setting up the ShaderSet
+        /// add a push constant range. Not thread safe, should only be called when initially setting up the ShaderSet
         void addPushConstantRange(std::string name, std::string define, VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size);
 
         /// get the AttributeBinding associated with name
@@ -157,16 +157,16 @@ namespace vsg
         /// get the ShaderStages variant that uses specified ShaderCompileSettings.
         ShaderStages getShaderStages(ref_ptr<ShaderCompileSettings> scs = {});
 
-        /// return the <mininum_set, maxiumum_set+1> range of set numbers encompassed UniformBindings
+        /// return the <minimum_set, maximum_set+1> range of set numbers encompassing UniformBindings
         std::pair<uint32_t, uint32_t> descriptorSetRange() const;
 
-        /// create the descritor set layout.
+        /// create the descriptor set layout.
         virtual ref_ptr<DescriptorSetLayout> createDescriptorSetLayout(const std::set<std::string>& defines, uint32_t set) const;
 
         /// create the pipeline layout for all descriptor sets enabled by specified defines or required by default.
         inline ref_ptr<PipelineLayout> createPipelineLayout(const std::set<std::string>& defines) { return createPipelineLayout(defines, descriptorSetRange()); }
 
-        /// create pipeline layout for specified range {minimum_set, maxiumum_set+1> of descriptor sets that are enabled by specified defines or required by default.
+        /// create pipeline layout for specified range <minimum_set, maximum_set+1> of descriptor sets that are enabled by specified defines or required by default.
         ///
         /// Note: the underlying Vulkan call vkCreatePipelineLayout assumes that the array of
         /// descriptor sets starts with set 0. Therefore the minimum_set argument should be 0 unless

--- a/include/vsg/utils/SharedObjects.h
+++ b/include/vsg/utils/SharedObjects.h
@@ -27,7 +27,7 @@ namespace vsg
     // forward declare
     class SuitableForSharing;
 
-    /// class for facilitating the share of instances of objects that have the same properties.
+    /// class for facilitating the sharing of instances of objects that have the same properties.
     class VSG_DECLSPEC SharedObjects : public Inherit<Object, SharedObjects>
     {
     public:
@@ -45,19 +45,19 @@ namespace vsg
         template<class C>
         void share(C& container);
 
-        /// visitor that checks a loaded object, and it's children whether it is suitable for sharing in SharedObjects
+        /// visitor that checks a loaded object and its children for suitability for sharing in SharedObjects
         ref_ptr<SuitableForSharing> suitableForSharing;
 
         /// set of lower case file extensions for file types that should not be included in this SharedObjects
         std::set<Path> excludedExtensions;
 
-        /// return true if the filename is of a type suitable for inclusion this SharedObjects
+        /// return true if the filename is of a type suitable for inclusion in this SharedObjects
         virtual bool suitable(const Path& filename) const;
 
         /// check for an entry associated with filename.
         virtual bool contains(const Path& filename, ref_ptr<const Options> options = {}) const;
 
-        /// add entry that matches filename and option.
+        /// add entry that matches filename and options.
         virtual void add(ref_ptr<Object> object, const Path& filename, ref_ptr<const Options> options = {});
 
         /// remove entry associated with filename.
@@ -66,7 +66,7 @@ namespace vsg
         /// clear all the internal structures leaving no Objects cached.
         void clear();
 
-        // clear all the singly referenced objects
+        // clear all the singularly referenced objects
         void prune();
 
         /// write out stats of objects held, types of objects and their reference counts
@@ -81,7 +81,7 @@ namespace vsg
     };
     VSG_type_name(vsg::SharedObjects);
 
-    /// Helper class for support sharing of objects loaded from files.
+    /// Helper class for sharing of objects loaded from files.
     class VSG_DECLSPEC LoadedObject : public Inherit<Object, LoadedObject>
     {
     public:
@@ -99,11 +99,11 @@ namespace vsg
     VSG_type_name(vsg::LoadedObject);
 
     /// Helper class for deciding whether sharing is permitted for this type - required to avoid circular references
-    /// If an object that is put forward to be shared via the SharedObjects container then it can't contain any references to vsg::Options & associated SharedOjbjects
+    /// If an object is put forward to be shared via the SharedObjects container then it can't contain any references to vsg::Options & associated SharedObjects
     /// otherwise a circular reference can be created that prevents all the objects in the circular reference chain from being deleted. Such objects must
-    /// be prevent from inclusion in the SharedObejcts. An example of class not suitable is vsg::PagedLOD as it has an options member. If your subclasses are
-    /// like PagedLOD and might create a circular reference when using with SharedOjbects then you should subclass from SuitableForSharing and add support
-    /// for your class and when instances are found set the suitableForSharing flag to false, and then assign this to the SharedOjbects container so that
+    /// be prevented from inclusion in the SharedObejcts. An example of a class not suitable is vsg::PagedLOD as it has an options member. If your subclasses are
+    /// like PagedLOD and might create a circular reference when using with SharedObjects then you should subclass from SuitableForSharing and add support
+    /// for your class and when instances are found set the suitableForSharing flag to false, and then assign this to the SharedObjects container so that
     /// it can make sure it's not treated as suitable for inclusions.
     class VSG_DECLSPEC SuitableForSharing : public Inherit<ConstVisitor, SuitableForSharing>
     {

--- a/include/vsg/vk/Context.h
+++ b/include/vsg/vk/Context.h
@@ -37,7 +37,7 @@ namespace vsg
     class View;
     class ViewDependentState;
 
-    /// Helper command for settings up RayTracing structures.
+    /// Helper command for setting up RayTracing structures.
     class VSG_DECLSPEC BuildAccelerationStructureCommand : public Inherit<Command, BuildAccelerationStructureCommand>
     {
     public:
@@ -79,7 +79,7 @@ namespace vsg
         uint32_t viewID = 0;
         ViewDependentState* viewDependentState = nullptr;
 
-        /// get existing ShaderCompile or create a new one when GLSLang is supported
+        /// get existing ShaderCompiler or create a new one when GLSLang is supported
         ShaderCompiler* getOrCreateShaderCompiler();
 
         ref_ptr<CommandBuffer> getOrCreateCommandBuffer();

--- a/include/vsg/vk/DescriptorPool.h
+++ b/include/vsg/vk/DescriptorPool.h
@@ -17,7 +17,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// DesctiporPool encapsulates management of VkDescriptorPool
+    /// DescriptorPool encapsulates management of VkDescriptorPool
     class VSG_DECLSPEC DescriptorPool : public Inherit<Object, DescriptorPool>
     {
     public:
@@ -32,15 +32,15 @@ namespace vsg
         /// allocate or reuse available DescriptorSet::Implementation - called automatically when compiling DescriptorSet
         ref_ptr<DescriptorSet::Implementation> allocateDescriptorSet(DescriptorSetLayout* descriptorSetLayout);
 
-        /// free DescriptorSet::Implementation for reuse - called automatically be destruction of DescriptorSet or release of it's Vulkan resources.
+        /// free DescriptorSet::Implementation for reuse - called automatically by destruction of DescriptorSet or release of its Vulkan resources.
         void freeDescriptorSet(ref_ptr<DescriptorSet::Implementation> dsi);
 
         /// get the stats of the available DescriptorSets/Descriptors
         bool getAvailability(uint32_t& maxSets, DescriptorPoolSizes& descriptorPoolSizes) const;
 
-        /// mutex used to ensure thead safe access of DesciptorPool resources.
-        /// Locked automatically by allocatoeDecstiproSet(..), freeDescriptorSet(), getAvailability() and DescriptorSet:::Implementation
-        /// to ensure thread safe operation. Normal VulkanSceneGraph usage will not require users to lock this mutex so threat as an internal implementation detail.
+        /// mutex used to ensure thread safe access of DescriptorPool resources.
+        /// Locked automatically by allocateDescriptorSet(..), freeDescriptorSet(), getAvailability() and DescriptorSet:::Implementation
+        /// to ensure thread safe operation. Normal VulkanSceneGraph usage will not require users to lock this mutex so treat as an internal implementation detail.
         mutable std::mutex mutex;
 
     protected:

--- a/include/vsg/vk/Device.h
+++ b/include/vsg/vk/Device.h
@@ -32,7 +32,7 @@ namespace vsg
 
     using QueueSettings = std::vector<QueueSetting>;
 
-    /// Device encapsulate vkDeivce, a logical handle to the PhysicalDevice with capabilities specified during construction.
+    /// Device encapsulates VkDevice, a logical handle to the PhysicalDevice with capabilities specified during construction.
     class VSG_DECLSPEC Device : public Inherit<Object, Device>
     {
     public:

--- a/include/vsg/vk/DeviceFeatures.h
+++ b/include/vsg/vk/DeviceFeatures.h
@@ -18,8 +18,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// DeviceFeatures is a container class for setting up Vulkan features structures to be passed in vsg::Device creation.
-    /// Automatically deletes associated created feature structures on destructions.
+    /// DeviceFeatures is a container class for setting up Vulkan feature structures to be passed in vsg::Device creation.
+    /// Automatically deletes associated created feature structures on destruction.
     class VSG_DECLSPEC DeviceFeatures : public Inherit<Object, DeviceFeatures>
     {
     public:

--- a/include/vsg/vk/Framebuffer.h
+++ b/include/vsg/vk/Framebuffer.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Framebuffer encapsulates vkFramebuffer used a rendering target associated with Window or for render to texture
+    /// Framebuffer encapsulates VkFramebuffer, used as a rendering target associated with a Window or for render to texture
     class VSG_DECLSPEC Framebuffer : public Inherit<Object, Framebuffer>
     {
     public:

--- a/include/vsg/vk/Instance.h
+++ b/include/vsg/vk/Instance.h
@@ -37,13 +37,13 @@ namespace vsg
     /// return names of layers that are supported from the desired list.
     extern VSG_DECLSPEC Names validateInstancelayerNames(const Names& names);
 
-    /// Instance encapsulate the vkInstance.
+    /// Instance encapsulates the VkInstance.
     class VSG_DECLSPEC Instance : public Inherit<Object, Instance>
     {
     public:
         Instance(Names instanceExtensions, Names layers, uint32_t vulkanApiVersion = VK_API_VERSION_1_0, AllocationCallbacks* allocator = nullptr);
 
-        /// Vulkan apiVersion used when creating the VkInstaance
+        /// Vulkan apiVersion used when creating the VkInstance
         const uint32_t apiVersion = VK_API_VERSION_1_0;
 
         operator VkInstance() const { return _instance; }

--- a/include/vsg/vk/MemoryBufferPools.h
+++ b/include/vsg/vk/MemoryBufferPools.h
@@ -23,7 +23,7 @@ namespace vsg
 {
 
     /// MemoryBufferPools manages a pool of vsg::DeviceMemory and vsg::Buffer that use them.
-    /// Methods are providing for getting Buffer from the pool, sharing memory to make better use of device memory.
+    /// Methods are provided for getting Buffer from the pool, sharing memory to make better use of device memory.
     class VSG_DECLSPEC MemoryBufferPools : public Inherit<Object, MemoryBufferPools>
     {
     public:

--- a/include/vsg/vk/PhysicalDevice.h
+++ b/include/vsg/vk/PhysicalDevice.h
@@ -18,7 +18,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
     /// PhysicalDevice encapsulates VkPhysicalDevice
-    /// Maps to a Vulkan capable physical device, like a dedicated graphics car or integrated GPU.
+    /// Maps to a Vulkan capable physical device, like a dedicated graphics card or integrated GPU.
     class VSG_DECLSPEC PhysicalDevice : public Inherit<Object, PhysicalDevice>
     {
     public:

--- a/include/vsg/vk/RenderPass.h
+++ b/include/vsg/vk/RenderPass.h
@@ -74,7 +74,7 @@ namespace vsg
         /// multiview support requires Vulkan 1.2 or later.
         uint32_t viewMask = 0;
 
-        /// maps to VkSubpassDescriptionDepthStencilResolve, requires Vulkan 1.2 or later.
+        /// maps to VkSubpassDescriptionDepthStencilResolve, requires Vulkan 1.2 or later or an extension.
         VkResolveModeFlagBits depthResolveMode = VK_RESOLVE_MODE_NONE;
         VkResolveModeFlagBits stencilResolveMode = VK_RESOLVE_MODE_NONE;
         std::vector<AttachmentReference> depthStencilResolveAttachments;
@@ -102,8 +102,8 @@ namespace vsg
         const Dependencies dependencies;
         const CorrelatedViewMasks correlatedViewMasks;
 
-        /// Maximum VkAttachmentDescription.samples value of the assigned attachments.
-        /// Used for be deciding if multisampling is required and the value to use when setting up the GraphicsPipeline's vsg::MultisampleState
+        /// Maximum VkAttachmentDescription::samples value of the assigned attachments.
+        /// Used for deciding if multisampling is required and the value to use when setting up the GraphicsPipeline's vsg::MultisampleState
         const VkSampleCountFlagBits maxSamples;
 
     protected:

--- a/include/vsg/vk/ResourceRequirements.h
+++ b/include/vsg/vk/ResourceRequirements.h
@@ -25,7 +25,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    /// ResourceRequirements provides a container for various Vulkan resource requirements that be used to help guide allocation of resources.
+    /// ResourceRequirements provides a container for various Vulkan resource requirements that can be used to help guide allocation of resources.
     class VSG_DECLSPEC ResourceRequirements
     {
     public:

--- a/include/vsg/vk/Semaphore.h
+++ b/include/vsg/vk/Semaphore.h
@@ -16,7 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 namespace vsg
 {
-    /// Semaphore encapsulates VkSemaphore that is used to synchronize completion of vulkan commands with start of other vulkan command submissions.
+    /// Semaphore encapsulates VkSemaphore that is used to synchronize completion of vulkan commands with the start of other vulkan command submissions.
     class VSG_DECLSPEC Semaphore : public Inherit<Object, Semaphore>
     {
     public:

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -71,7 +71,7 @@ namespace vsg
         }
     };
 
-    /// MatrixStack used internally by vsg::State to manage stack of project or modelview matrices
+    /// MatrixStack used internally by vsg::State to manage stack of projection or modelview matrices
     class MatrixStack
     {
     public:
@@ -223,7 +223,7 @@ namespace vsg
         }
     };
 
-    /// vsg::State used by vsg::RecordTraversal to manage state stacks, projection, modelview matrix and frustum stacks.
+    /// vsg::State is used by vsg::RecordTraversal to manage state stacks, projection and modelview matrices and frustum stacks.
     class State : public Inherit<Object, State>
     {
     public:

--- a/include/vsg/vk/SubmitCommands.h
+++ b/include/vsg/vk/SubmitCommands.h
@@ -55,7 +55,7 @@ namespace vsg
         }
     }
 
-    /// convenience template function for submitting Vulkan commands to a queue and wait for completion.
+    /// convenience template function for submitting Vulkan commands to a queue and waiting for completion.
     template<typename F>
     void submitCommandsToQueue(CommandPool* commandPool, Queue* queue, F function)
     {

--- a/include/vsg/vk/Surface.h
+++ b/include/vsg/vk/Surface.h
@@ -29,7 +29,7 @@ namespace vsg
         Instance* getInstance() { return _instance; }
         const Instance* getInstance() const { return _instance; }
 
-        /// Release the VkSurfaceKHR so it's no longer managed this vsg::Surface object, caller/3rd party libs are subsequently responsible for deletion of the VkSurfaceKHR.
+        /// Release the VkSurfaceKHR so it's no longer managed by this vsg::Surface object, caller/3rd party libs are subsequently responsible for deletion of the VkSurfaceKHR.
         /// This method should only be called when adapting the VulkanSceneGraph to work with 3rd party Vulkan creation,
         /// in normal usage this method should not be called as the VkSurfaceKHR will be cleaned up safely and automatically in the destructor when the vsg::Surface is deleted.
         void release()

--- a/include/vsg/vk/vk_buffer.h
+++ b/include/vsg/vk/vk_buffer.h
@@ -22,7 +22,7 @@ namespace vsg
 
 #if VSG_MAX_DEVICES <= 1
 
-    /// vk_buffer that manages a single logical device support.
+    /// vk_buffer that manages a single logical device supported.
     template<class T>
     struct vk_buffer
     {

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -322,7 +322,7 @@ if(MSVC)
 
     SET_OUTPUT_DIR_PROPERTY(vsg "")
 
-    option(ENABLE_MP_FLAG "Turning on this option will add the multi-processor flag in MSVC for VSG and it's included projects" ON)
+    option(ENABLE_MP_FLAG "Turning on this option will add the multi-processor flag in MSVC for VSG and its included projects" ON)
 
     if(ENABLE_MP_FLAG)
         target_compile_options(vsg PRIVATE "/MP")

--- a/src/vsg/app/CommandGraph.cpp
+++ b/src/vsg/app/CommandGraph.cpp
@@ -98,7 +98,7 @@ void CommandGraph::record(CommandBuffers& recordedCommandBuffers, ref_ptr<FrameS
     // or select index when maps to a dormant CommandBuffer
     VkCommandBuffer vk_commandBuffer = *commandBuffer;
 
-    // need to set up the command
+    // need to set up the command buffer
     // if we are nested within a CommandBuffer already then use VkCommandBufferInheritanceInfo
     VkCommandBufferBeginInfo beginInfo = {};
     beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;

--- a/src/vsg/app/CompileTraversal.cpp
+++ b/src/vsg/app/CompileTraversal.cpp
@@ -308,7 +308,7 @@ void CompileTraversal::apply(View& view)
 {
     for (auto& context : contexts)
     {
-        // if context is associated with a view make sure we only apply it if it matches with view, oherwsie we skip this context
+        // if context is associated with a view make sure we only apply it if it matches with view, otherwise we skip this context
         auto context_view = context->view.ref_ptr();
         if (context_view && context_view.get() != &view) continue;
 

--- a/src/vsg/app/RecordAndSubmitTask.cpp
+++ b/src/vsg/app/RecordAndSubmitTask.cpp
@@ -68,7 +68,7 @@ size_t RecordAndSubmitTask::index(size_t relativeFrameIndex) const
     return relativeFrameIndex < _indices.size() ? _indices[relativeFrameIndex] : _indices.size();
 }
 
-/// fence() and fence(0) return the Fence for the frame currently being rendered, fence(1) return the previous frame's Fence etc.
+/// fence() and fence(0) return the Fence for the frame currently being rendered, fence(1) returns the previous frame's Fence etc.
 Fence* RecordAndSubmitTask::fence(size_t relativeFrameIndex)
 {
     size_t i = index(relativeFrameIndex);
@@ -254,7 +254,7 @@ void vsg::updateTasks(RecordAndSubmitTasks& tasks, ref_ptr<CompileManager> compi
         }
     }
 
-    /// handle any need Bin needs
+    /// handle any new Bin needs
     for (auto& [const_view, binDetails] : compileResult.views)
     {
         auto view = const_cast<vsg::View*>(const_view);

--- a/src/vsg/app/RecordTraversal.cpp
+++ b/src/vsg/app/RecordTraversal.cpp
@@ -213,7 +213,7 @@ void RecordTraversal::apply(const PagedLOD& plod)
                 auto previousRequestCount = plod.requestCount.fetch_add(1);
                 if (previousRequestCount == 0)
                 {
-                    // we are first request so tell the databasePager about it
+                    // we are the first request so tell the databasePager about it
                     _databasePager->request(ref_ptr<PagedLOD>(const_cast<PagedLOD*>(&plod)));
                 }
                 else

--- a/src/vsg/app/RenderGraph.cpp
+++ b/src/vsg/app/RenderGraph.cpp
@@ -142,7 +142,7 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
     VkCommandBuffer vk_commandBuffer = *(recordTraversal.getState()->_commandBuffer);
     vkCmdBeginRenderPass(vk_commandBuffer, &renderPassInfo, contents);
 
-    // traverse the command buffer to place the commands into the command buffer.
+    // traverse the subgraph to place commands into the command buffer.
     traverse(recordTraversal);
 
     vkCmdEndRenderPass(vk_commandBuffer);

--- a/src/vsg/app/SecondaryCommandGraph.cpp
+++ b/src/vsg/app/SecondaryCommandGraph.cpp
@@ -104,7 +104,7 @@ void SecondaryCommandGraph::record(CommandBuffers& recordedCommandBuffers, ref_p
     // or select index when maps to a dormant CommandBuffer
     VkCommandBuffer vk_commandBuffer = *commandBuffer;
 
-    // need to set up the command
+    // need to set up the command buffer
     // if we are nested within a CommandBuffer already then use VkCommandBufferInheritanceInfo
     VkCommandBufferBeginInfo beginInfo = {};
     beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;

--- a/src/vsg/app/TransferTask.cpp
+++ b/src/vsg/app/TransferTask.cpp
@@ -62,7 +62,7 @@ size_t TransferTask::index(size_t relativeFrameIndex) const
     return relativeFrameIndex < _indices.size() ? _indices[relativeFrameIndex] : _indices.size();
 }
 
-/// fence() and fence(0) return the Fence for the frame currently being rendered, fence(1) return the previous frame's Fence etc.
+/// fence() and fence(0) return the Fence for the frame currently being rendered, fence(1) returns the previous frame's Fence etc.
 Fence* TransferTask::fence(size_t relativeFrameIndex)
 {
     size_t i = index(relativeFrameIndex);

--- a/src/vsg/app/View.cpp
+++ b/src/vsg/app/View.cpp
@@ -16,7 +16,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
-// thread safe container for managing the deviceID for each vsg;:View
+// thread safe container for managing the deviceID for each vsg::View
 static std::mutex s_ViewCountMutex;
 static std::vector<bool> s_ActiveViews;
 

--- a/src/vsg/app/Viewer.cpp
+++ b/src/vsg/app/Viewer.cpp
@@ -80,7 +80,7 @@ void Viewer::removeWindow(ref_ptr<Window> window)
 
     _windows.erase(itr);
 
-    // create a a new list of ComnandGraphs not associated with removed window
+    // create a new list of CommandGraphs not associated with removed window
     CommandGraphs commandGraphs;
     for (auto& task : recordAndSubmitTasks)
     {
@@ -115,7 +115,7 @@ bool Viewer::active() const
 
     if (!viewerIsActive)
     {
-        // don't exit mainloop while the any devices are still active
+        // don't exit mainloop while any devices are still active
         deviceWaitIdle();
         return false;
     }
@@ -254,7 +254,7 @@ void Viewer::compile(ref_ptr<ResourceHints> hints)
         vsg::ref_ptr<vsg::CompileTraversal> compile;
     };
 
-    // find which devices are available and the resources required for then,
+    // find which devices are available and the resources required for them
     using DeviceResourceMap = std::map<ref_ptr<vsg::Device>, DeviceResources>;
     DeviceResourceMap deviceResourceMap;
     for (auto& task : recordAndSubmitTasks)
@@ -348,7 +348,7 @@ void Viewer::compile(ref_ptr<ResourceHints> hints)
         }
     }
 
-    // assign dynamic data to transfer trask
+    // assign dynamic data to transfer tasks
     for (auto& task : recordAndSubmitTasks)
     {
         auto& deviceResource = deviceResourceMap[task->device];
@@ -488,7 +488,7 @@ void Viewer::assignRecordAndSubmitTaskAndPresentation(CommandGraphs in_commandGr
         }
         else
         {
-            // with don't have a presentFamily so this set of commandGraphs aren't associated with a window
+            // we don't have a presentFamily so this set of commandGraphs aren't associated with a window
             // set up Submission with CommandBuffer and signals
             auto recordAndSubmitTask = vsg::RecordAndSubmitTask::create(device, numBuffers);
             recordAndSubmitTask->commandGraphs = commandGraphs;
@@ -518,7 +518,7 @@ void Viewer::addRecordAndSubmitTaskAndPresentation(CommandGraphs commandGraphs)
     // add the new CommandGraphs
     combinedCommandGraphs.insert(combinedCommandGraphs.end(), commandGraphs.begin(), commandGraphs.end());
 
-    // assign the combined CommanGraphs
+    // assign the combined CommandGraphs
     assignRecordAndSubmitTaskAndPresentation(combinedCommandGraphs);
 }
 
@@ -618,7 +618,7 @@ void Viewer::setupThreading()
 
                     data->recordCompletedBarrier->arrive_and_wait();
 
-                    // primary thread finishes the task, submitting all the command buffers recorded by the primary and all secondary threads to it's queue
+                    // primary thread finishes the task, submitting all the command buffers recorded by the primary and all secondary threads to its queue
                     CommandBuffers localRecordedCommandBuffers;
                     for (const auto& commandBuffers : data->orderedRecordedCommandBuffers)
                         localRecordedCommandBuffers.insert(localRecordedCommandBuffers.end(), commandBuffers.begin(), commandBuffers.end());
@@ -724,9 +724,9 @@ void Viewer::recordAndSubmit()
 #if 1
     if (_threading)
 #else
-    // follows is a workaround for an odd "Possible data race during write of size 1" warning that valgrind tool=helgrind reports
-    // on the first call to vkBeginCommandBuffer despite them being done on independent command buffers.  This could well be a driver bug or a false position.
-    // if you want to quiet this warning then change the #if above to #if 0 as render the first three frames single threaded avoids the warning.
+    // The following is a workaround for an odd "Possible data race during write of size 1" warning that valgrind tool=helgrind reports
+    // on the first call to vkBeginCommandBuffer despite them being done on independent command buffers.  This could well be a driver bug or a false positive.
+    // If you want to quieten this warning then change the #if above to #if 0 as rendering the first three frames single threaded avoids the warning.
     if (_threading && _frameStamp->frameCount > 2)
 #endif
     {

--- a/src/vsg/app/Window.cpp
+++ b/src/vsg/app/Window.cpp
@@ -262,7 +262,7 @@ void Window::buildSwapchain()
 {
     if (_swapchain)
     {
-        // make sure all operations on the device have stopped before we go deleting associated resources
+        // make sure all operations on the device have stopped before we go on deleting associated resources
         vkDeviceWaitIdle(*_device);
 
         // clean up previous swap chain before we begin creating a new one.
@@ -276,7 +276,7 @@ void Window::buildSwapchain()
         _multisampleImageView.reset();
     }
 
-    // is width and height even required here as the surface appear to control it.
+    // is width and height even required here as the surface appears to control it?
     _swapchain = Swapchain::create(_physicalDevice, _device, _surface, _extent2D.width, _extent2D.height, _traits->swapchainPreferences, _swapchain);
 
     // pass back the extents used by the swap chain.
@@ -430,7 +430,7 @@ VkResult Window::acquireNextImage(uint64_t timeout)
 
     if (!_availableSemaphore) _availableSemaphore = vsg::Semaphore::create(_device, _traits->imageAvailableSemaphoreWaitFlag);
 
-    // check the dimensions of the swapchain and window extents are consistent, if nit return a VK_ERROR_OUT_OF_DATE_KHR;
+    // check the dimensions of the swapchain and window extents are consistent, if not return a VK_ERROR_OUT_OF_DATE_KHR
     if (_swapchain->getExtent() != _extent2D) return VK_ERROR_OUT_OF_DATE_KHR;
 
     uint32_t imageIndex;
@@ -438,7 +438,7 @@ VkResult Window::acquireNextImage(uint64_t timeout)
 
     if (result == VK_SUCCESS)
     {
-        // the acquired image's semaphore must be available now so make it the new _availableSemaphore and set it's entry to the one to use of the next frame by swapping ref_ptr<>'s
+        // the acquired image's semaphore must be available now so make it the new _availableSemaphore and set its entry to the one to use for the next frame by swapping ref_ptr<>'s
         _availableSemaphore.swap(_frames[imageIndex].imageAvailableSemaphore);
 
         // shift up previous frame indices

--- a/src/vsg/app/WindowTraits.cpp
+++ b/src/vsg/app/WindowTraits.cpp
@@ -87,7 +87,7 @@ void WindowTraits::defaults()
     vkEnumerateInstanceVersion(&vulkanVersion);
 #endif
 
-    // vsg::DeviceFeatures use instance extension
+    // vsg::DeviceFeatures uses the instance extension
     instanceExtensionNames.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
     // provide anisotropic filtering as standard.

--- a/src/vsg/commands/CopyImageViewToWindow.cpp
+++ b/src/vsg/commands/CopyImageViewToWindow.cpp
@@ -35,7 +35,7 @@ void CopyImageViewToWindow::record(CommandBuffer& commandBuffer) const
         imageView->image,
         VkImageSubresourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
 
-    auto ibm_transitionStorageImageToReadSrc = vsg::ImageMemoryBarrier::create(
+    auto imb_transitionStorageImageToReadSrc = vsg::ImageMemoryBarrier::create(
         0, VK_ACCESS_TRANSFER_READ_BIT,
         VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED,
@@ -46,7 +46,7 @@ void CopyImageViewToWindow::record(CommandBuffer& commandBuffer) const
         VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
         0,
         imb_transitionSwapChainToWriteDest,
-        ibm_transitionStorageImageToReadSrc);
+        imb_transitionStorageImageToReadSrc);
 
     pb_transitionStorageImageToReadSrc->record(commandBuffer);
 

--- a/src/vsg/core/Allocator.cpp
+++ b/src/vsg/core/Allocator.cpp
@@ -103,7 +103,7 @@ void* Allocator::allocate(std::size_t size, AllocatorAffinity allocatorAffinity)
         return std::malloc(size);
     }
 
-    // create an MemoryBlocks entry if one doesn't already exist
+    // create a MemoryBlocks entry if one doesn't already exist
     if (allocatorAffinity > allocatorMemoryBlocks.size())
     {
         if (memoryTracking & MEMORY_TRACKING_REPORT_ACTIONS)

--- a/src/vsg/core/ConstVisitor.cpp
+++ b/src/vsg/core/ConstVisitor.cpp
@@ -633,7 +633,7 @@ void ConstVisitor::apply(const TextLayout& value)
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// Vulkan Object
+// Vulkan Objects
 //
 void ConstVisitor::apply(const BufferInfo& value)
 {

--- a/src/vsg/core/Object.cpp
+++ b/src/vsg/core/Object.cpp
@@ -34,7 +34,7 @@ Object::Object(const Object& rhs) :
 {
     if (rhs._auxiliary && rhs._auxiliary->getConnectedObject() == &rhs)
     {
-        // the rhs's rhs._auxiliary is uniquely attached to it, so we need to create our own and copy it's ObjectMap across
+        // the rhs's auxiliary is uniquely attached to it, so we need to create our own and copy its ObjectMap across
         auto& userObjects = getOrCreateAuxiliary()->userObjects;
         userObjects = rhs._auxiliary->userObjects;
     }
@@ -48,7 +48,7 @@ Object& Object::operator=(const Object& rhs)
 
     if (rhs._auxiliary)
     {
-        // the rhs's rhs._auxiliary is uniquely attached to it, so we need to create our own and copy it's ObjectMap across
+        // the rhs's auxiliary is uniquely attached to it, so we need to create our own and copy its ObjectMap across
         auto& userObjects = getOrCreateAuxiliary()->userObjects;
         userObjects = rhs._auxiliary->userObjects;
     }
@@ -129,7 +129,7 @@ void Object::write(Output& output) const
 {
     if (_auxiliary)
     {
-        // we have a unique auxiliary, need to write out it's ObjectMap entries
+        // we have a unique auxiliary, need to write out its ObjectMap entries
         auto& userObjects = _auxiliary->userObjects;
         output.writeValue<uint32_t>("userObjects", userObjects.size());
         for (auto& entry : userObjects)

--- a/src/vsg/core/Version.h.in
+++ b/src/vsg/core/Version.h.in
@@ -49,7 +49,7 @@ extern "C"
     extern VSG_DECLSPEC const char* vsgGetSOVersionString();
 
     /// return 0 if the linked VSG was built as static library (default), 1 if the linked VSG library was built as shared/dynamic library.
-    /// When building against a shared libraryTo ensure the correct selection of VSG_DECLSPEC (provided in vsg/core/Export.h) one must compile with the define VSG_SHARED_LIBRARY
+    /// When building against a shared library, to ensure the correct selection of VSG_DECLSPEC (provided in vsg/core/Export.h) one must compile with the define VSG_SHARED_LIBRARY
     extern VSG_DECLSPEC int vsgBuiltAsSharedLibrary();
 
 #ifdef __cplusplus

--- a/src/vsg/io/DatabasePager.cpp
+++ b/src/vsg/io/DatabasePager.cpp
@@ -56,14 +56,14 @@ ref_ptr<PagedLOD> DatabaseQueue::take_when_available()
     std::chrono::duration waitDuration = std::chrono::milliseconds(100);
     std::unique_lock lock(_mutex);
 
-    // wait to the conditional variable signals that an operation has been added
+    // wait until the conditional variable signals that an operation has been added
     while (_queue.empty() && _status->active())
     {
         // debug("   Waiting on condition variable B size = ", _queue.size());
         _cv.wait_for(lock, waitDuration);
     }
 
-    // if the threads we are associated with should no longer running go for a quick exit and return nothing.
+    // if the threads we are associated with should no longer be running go for a quick exit and return nothing.
     if (_queue.empty() || _status->cancel())
     {
         // debug("DatabaseQueue::take_when_available() C empty");
@@ -207,7 +207,7 @@ void DatabasePager::request(ref_ptr<PagedLOD> plod)
     {
         if (compare_exchange(plod->requestStatus, PagedLOD::NoRequest, PagedLOD::ReadRequest))
         {
-            // debug("DatabasePager::request(", plod.get(), ") adding to requeQueue ", plod->filename, ", ", plod->priority, " plod=", plod.get());
+            // debug("DatabasePager::request(", plod.get(), ") adding to requestQueue ", plod->filename, ", ", plod->priority, " plod=", plod.get());
             _requestQueue->add(plod);
         }
         else

--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -167,7 +167,7 @@ Path vsg::findFile(const Path& filename, const Options* options)
             // if appropriate use the filename directly if it exists.
             if (options->checkFilenameHint == Options::CHECK_ORIGINAL_FILENAME_EXISTS_FIRST && fileExists(filename)) return filename;
 
-            // search for the file if the in the specific paths.
+            // search for the file in the options specific paths.
             if (auto path = findFile(filename, options->paths)) return path;
 
             // if appropriate use the filename directly if it exists.
@@ -197,7 +197,7 @@ bool vsg::makeDirectory(const Path& path)
 
         if (directory_to_create.size() == 2 && directory_to_create[1] == ':')
         {
-            // ignore a C: style drive prefixes
+            // ignore C: style drive prefixes
             continue;
         }
 
@@ -209,7 +209,7 @@ bool vsg::makeDirectory(const Path& path)
         {
             if (errno != EEXIST)
             {
-                // quietly ignore a mkdir on a file that already exists as this can happen safely during a filling in a filecache.
+                // quietly ignore a mkdir on a file that already exists as this can happen safely during filling in a filecache.
                 debug("mkdir(", directory_to_create, ") failed. errno = ", errno);
             }
             return false;

--- a/src/vsg/io/convert_utf.cpp
+++ b/src/vsg/io/convert_utf.cpp
@@ -17,7 +17,7 @@ using namespace vsg;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
-// copy between UTF9 <-> UF16
+// copy between UTF8 <-> UTF16
 //
 // https://en.wikipedia.org/wiki/UTF-8
 // https://en.wikipedia.org/wiki/UTF-16

--- a/src/vsg/io/tile.cpp
+++ b/src/vsg/io/tile.cpp
@@ -164,7 +164,7 @@ vsg::ref_ptr<vsg::Object> tile::read_root(vsg::ref_ptr<const vsg::Options> optio
 
                     auto plod = vsg::PagedLOD::create();
                     plod->bound = bound;
-                    plod->children[0] = vsg::PagedLOD::Child{0.25, {}};       // external child visible when it's bound occupies more than 1/4 of the height of the window
+                    plod->children[0] = vsg::PagedLOD::Child{0.25, {}};       // external child visible when its bound occupies more than 1/4 of the height of the window
                     plod->children[1] = vsg::PagedLOD::Child{0.0, tile_node}; // visible always
                     plod->filename = vsg::make_string(x, " ", y, " 0.tile");
                     plod->options = Options::create_if(options, *options);
@@ -192,7 +192,7 @@ vsg::ref_ptr<vsg::Object> tile::read_root(vsg::ref_ptr<const vsg::Options> optio
     group->accept(collectResourceRequirements);
     group->setObject("ResourceHints", collectResourceRequirements.createResourceHints(tileMultiplier));
 
-    // assign the EllipsoidModel so that the overall geometry of the database can be used as guide for clipping and navigation.
+    // assign the EllipsoidModel so that the overall geometry of the database can be used as a guide for clipping and navigation.
     group->setObject("EllipsoidModel", settings->ellipsoidModel);
 
     return group;
@@ -253,7 +253,7 @@ vsg::ref_ptr<vsg::Object> tile::read_subtile(uint32_t x, uint32_t y, uint32_t lo
                     {
                         auto plod = vsg::PagedLOD::create();
                         plod->bound = bound;
-                        plod->children[0] = vsg::PagedLOD::Child{settings->lodTransitionScreenHeightRatio, {}}; // external child visible when it's bound occupies more than 1/4 of the height of the window
+                        plod->children[0] = vsg::PagedLOD::Child{settings->lodTransitionScreenHeightRatio, {}}; // external child visible when its bound occupies more than 1/4 of the height of the window
                         plod->children[1] = vsg::PagedLOD::Child{0.0, tile_node};                               // visible always
                         plod->filename = vsg::make_string(tileID.local_x, " ", tileID.local_y, " ", local_lod, ".tile");
                         plod->options = Options::create_if(options, *options);
@@ -507,7 +507,7 @@ vsg::ref_ptr<vsg::Node> tile::createTextureQuad(const vsg::dbox& tile_extents, v
          {1.0f, 1.0f, 1.0f},
          {1.0f, 1.0f, 1.0f}}); // VK_FORMAT_R32G32B32_SFLOAT, VK_VERTEX_INPUT_RATE_VERTEX, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_SHARING_MODE_EXCLUSIVE
 
-    uint8_t origin = textureData->properties.origin; // in Vulkan the origin is by default top left.
+    uint8_t origin = textureData->properties.origin; // in Vulkan the origin is top left by default.
     float left = 0.0f;
     float right = 1.0f;
     float top = (origin == vsg::TOP_LEFT) ? 0.0f : 1.0f;

--- a/src/vsg/io/write.cpp
+++ b/src/vsg/io/write.cpp
@@ -23,7 +23,7 @@ bool vsg::write(ref_ptr<Object> object, const Path& filename, ref_ptr<const Opti
     bool fileWritten = false;
     if (options)
     {
-        // don't write the file if it's already contained in the ObjectCache
+        // don't write the file if it's already contained in the SharedObjects
         if (options->sharedObjects && options->sharedObjects->contains(filename, options)) return true;
 
         if (!options->readerWriters.empty())

--- a/src/vsg/maths/maths_transform.cpp
+++ b/src/vsg/maths/maths_transform.cpp
@@ -203,7 +203,7 @@ dmat4 vsg::inverse(const dmat4& m)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //
-// compute determinate of a matrix
+// compute determinant of a matrix
 //
 template<class T>
 T t_determinant(const t_mat4<T>& m)
@@ -317,14 +317,14 @@ t_sphere<T> t_computeFrustumBound(const t_mat4<T>& m)
     // TODO : depth range should probably be 0 to 1 for Vulkan, rather than -1 to 1 for OpenGL.
     //
 
-    // compute the a2 the radius squared of the near plane relative to the near planes mid point
+    // compute a2, the radius squared of the near plane relative to the near planes mid point
     vec_type near_center = inv_m * vec_type(0.0, 0.0, -1.0);
     value_type a2 = length2(inv_m * vec_type(-1.0, -1.0, -1.0) - near_center);
     update_radius2(a2, near_center, inv_m * vec_type(1.0, -1.0, -1.0));
     update_radius2(a2, near_center, inv_m * vec_type(1.0, 1.0, -1.0));
     update_radius2(a2, near_center, inv_m * vec_type(-1.0, 1.0, -1.0));
 
-    // compute the b2 the radius squared of the far plane relative to the far planes mid point
+    // compute b2, the radius squared of the far plane relative to the far planes mid point
     vec_type far_center = inv_m * vec_type(0.0, 0.0, 1.0);
     value_type b2 = length2(inv_m * vec_type(-1.0, -1.0, 1.0) - far_center);
     update_radius2(b2, far_center, inv_m * vec_type(1.0, -1.0, 1.0));
@@ -381,7 +381,7 @@ bool vsg::transform(CoordinateConvention source, CoordinateConvention destinatio
                        0.0, 0.0, 1.0, 0.0,
                        0.0, 0.0, 0.0, 1.0);
         }
-        else // destination most be Z_UP
+        else // destination must be Z_UP
         {
             matrix.set(0.0, 0.0, 1.0, 0.0,
                        0.0, 1.0, 0.0, 0.0,
@@ -398,7 +398,7 @@ bool vsg::transform(CoordinateConvention source, CoordinateConvention destinatio
                        0.0, 0.0, 1.0, 0.0,
                        0.0, 0.0, 0.0, 1.0);
         }
-        else // destination most be Z_UP
+        else // destination must be Z_UP
         {
             matrix.set(1.0, 0.0, 0.0, 0.0,
                        0.0, 0.0, 1.0, 0.0,
@@ -415,7 +415,7 @@ bool vsg::transform(CoordinateConvention source, CoordinateConvention destinatio
                        1.0, 0.0, 0.0, 0.0,
                        0.0, 0.0, 0.0, 1.0);
         }
-        else // destination most be Y_UP
+        else // destination must be Y_UP
         {
             matrix.set(1.0, 0.0, 0.0, 0.0,
                        0.0, 0.0, -1.0, 0.0,

--- a/src/vsg/nodes/PagedLOD.cpp
+++ b/src/vsg/nodes/PagedLOD.cpp
@@ -45,7 +45,7 @@ int PagedLOD::compare(const Object& rhs_object) const
 
     if ((result = compare_value(bound, rhs.bound)) != 0) return result;
 
-    // compre the children vector
+    // compare the children vector
     auto rhs_itr = rhs.children.begin();
     for (auto lhs_itr = children.begin(); lhs_itr != children.end(); ++lhs_itr, ++rhs_itr)
     {

--- a/src/vsg/platform/android/Android_Window.cpp
+++ b/src/vsg/platform/android/Android_Window.cpp
@@ -55,7 +55,7 @@ namespace vsgAndroid
             auto result = vkCreateAndroidSurfaceKHR(*instance, &surfaceCreateInfo, _instance->getAllocationCallbacks(), &_surface);
             if (result != VK_SUCCESS)
             {
-                throw Exception{"Failed to created AndroidSurface.", result};
+                throw Exception{"Failed to create AndroidSurface.", result};
             }
         }
     };
@@ -255,7 +255,7 @@ KeyboardMap::KeyboardMap()
 
             /*
         * Auxiliary Functions; note the duplicate definitions for left and right
-        * function keys;  Sun keyboards and a few other manufactures have such
+        * function keys;  Sun keyboards and a few other manufacturers have such
         * function key groups on the left and/or right sides of the keyboard.
         * We've not found a keyboard with more than 35 function keys total.
         */
@@ -339,7 +339,7 @@ Android_Window::Android_Window(vsg::ref_ptr<WindowTraits> traits) :
         _window = nativeWindow;
     }
 
-    // we could get the width height from the window?
+    // we could get the width and height from the window?
     uint32_t finalWidth = traits->width;
     uint32_t finalHeight = traits->height;
 

--- a/src/vsg/platform/ios/iOS_Window.mm
+++ b/src/vsg/platform/ios/iOS_Window.mm
@@ -527,7 +527,7 @@ vsgiOS::KeyboardMap::KeyboardMap()
 
         /*
     * Auxiliary Functions; note the duplicate definitions for left and right
-    * function keys;  Sun keyboards and a few other manufactures have such
+    * function keys;  Sun keyboards and a few other manufacturers have such
     * function key groups on the left and/or right sides of the keyboard.
     * We've not found a keyboard with more than 35 function keys total.
     */

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -26,7 +26,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #import <Cocoa/Cocoa.h>
 #import <QuartzCore/CAMetalLayer.h>
 
-// this a carbon header, we should try to avoid
+// this is a carbon header, we should try to avoid it
 #import <Carbon/Carbon.h>
 
 using namespace vsg;
@@ -456,7 +456,7 @@ namespace vsgMacOS
 
 KeyboardMap::KeyboardMap()
 {
-    // An explanation of mapping from uppercase to lowercase
+    // An explanation of mapping from uppercase to lowercase:
     // The map _vk2vsg represents mapping from MacOS produced keycode
     // of the key that was physically pressed to the vsg character
     // that is produced when the key is pressed and no modifiers are active.
@@ -588,9 +588,9 @@ void KeyboardMap::getModifierKeyChanges(NSEvent* anEvent, ModifierKeyChanges& ch
     _lastFlags = modifierFlags; // this must come after the xor.
 
     // The below code could likely be accomplished with just bit masks but the if statements are clearer.
-    // Work out any mod keys such as ctrl, alt, shift etc. are pressed
+    // Work out if any mod keys such as ctrl, alt, shift etc. are pressed
     // There must be a way to differentiate between left and right modifier keys on Mac
-    // But for now I do not know how do do so. Hence for all modifier keys the "left" key is chosen.
+    // But for now I do not know how to do so. Hence for all modifier keys the "left" key is chosen.
     if (changedFlags & NSEventModifierFlagOption)
     {
         if (modifierFlags & NSEventModifierFlagOption)
@@ -680,7 +680,7 @@ bool KeyboardMap::getKeySymbol(NSEvent* anEvent, vsg::KeySymbol& keySymbol, vsg:
     keySymbol = itr->second;
     modifiedKeySymbol = keySymbol;
 
-    // Work out any mod keys such as ctrl, alt, shift etc. are pressed
+    // Work out if any mod keys such as ctrl, alt, shift etc. are pressed
     uint16_t modifierMask = 0;
     if (modifierFlags & NSEventModifierFlagOption) modifierMask |= vsg::KeyModifier::MODKEY_Alt;
     if (modifierFlags & NSEventModifierFlagControl) modifierMask |= vsg::KeyModifier::MODKEY_Control;
@@ -776,7 +776,7 @@ MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
     auto devicePixelScale = _traits->hdpi ? [_window backingScaleFactor] : 1.0f;
     [_metalLayer setContentsScale:devicePixelScale];
 
-    // we could get the width height from the window?
+    // we could get the width and height from the window?
     uint32_t finalwidth = traits->width * devicePixelScale;
     uint32_t finalheight = traits->height * devicePixelScale;
 
@@ -920,7 +920,7 @@ bool MacOS_Window::handleNSEvent(NSEvent* anEvent)
         // keyboard events
         case NSEventTypeFlagsChanged:
         {
-            // This event type is triggered when ever a ctrl, alt etc keys are pressed.
+            // This event type is triggered whenever ctrl, alt etc keys are pressed.
             // Not sure why this is not just a KeyUp or KeyDown event.
             // both the modified and unmodified symbols for ctrl, alt, option, etc are the same
             // no modifiers for the modifiers themselves.

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -434,7 +434,7 @@ Win32_Window::Win32_Window(vsg::ref_ptr<WindowTraits> traits) :
         SetFocus(_window);
     }
 
-    // get client rect to find final width height of the view
+    // get client rect to find final width and height of the view
     RECT clientRect;
     ::GetClientRect(_window, &clientRect);
 

--- a/src/vsg/platform/xcb/Xcb_Window.cpp
+++ b/src/vsg/platform/xcb/Xcb_Window.cpp
@@ -320,7 +320,7 @@ Xcb_Window::Xcb_Window(vsg::ref_ptr<WindowTraits> traits) :
         // close connection
         if (openConnection) xcb_disconnect(_connection);
 
-        throw Exception{"Failed to created Window, unable able to establish xcb connection.", VK_ERROR_INVALID_EXTERNAL_HANDLE};
+        throw Exception{"Failed to create Window, unable to establish xcb connection.", VK_ERROR_INVALID_EXTERNAL_HANDLE};
     }
 
     // get the screen
@@ -490,7 +490,7 @@ Xcb_Window::Xcb_Window(vsg::ref_ptr<WindowTraits> traits) :
 
     xcb_flush(_connection);
 
-    // sleep to give the window manage time to do any repositing and resizing
+    // sleep to give the window manager time to do any repositioning and resizing
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     // get the dimensions of the final window.
@@ -630,7 +630,7 @@ bool Xcb_Window::pollEvents(UIEvents& events)
         case (XCB_CONFIGURE_NOTIFY): {
             auto configure = reinterpret_cast<const xcb_configure_notify_event_t*>(event);
 
-            // Xcb configure events x,y values can be behave differently on different window managers so use getWindowGeometry(..) to avoid inconsistencies
+            // Xcb configure events x,y values can behave differently on different window managers so use getWindowGeometry(..) to avoid inconsistencies
             int32_t x = configure->x;
             int32_t y = configure->y;
             uint32_t width = configure->width;
@@ -706,7 +706,7 @@ bool Xcb_Window::pollEvents(UIEvents& events)
 
             if (button_press->same_screen)
             {
-                // X11/Xvb treat scroll wheel up/down as button 4 and 5 so handle these as such
+                // X11/Xcb treat scroll wheel up/down as button 4 and 5 so handle these as such
                 if (button_press->detail == 4)
                 {
                     bufferedEvents.emplace_back(vsg::ScrollWheelEvent::create(this, event_time, vsg::vec3(0.0f, 1.0f, 0.0f)));

--- a/src/vsg/raytracing/RayTracingPipeline.cpp
+++ b/src/vsg/raytracing/RayTracingPipeline.cpp
@@ -204,7 +204,7 @@ RayTracingPipeline::Implementation::Implementation(Context& context, RayTracingP
     }
     else
     {
-        throw Exception{"Error: vsg::Pipeline::createGraphics(...) failed to create VkPipeline.", result};
+        throw Exception{"Error: vsg::RayTracingPipeline failed to create VkPipeline.", result};
     }
 }
 

--- a/src/vsg/state/ArrayState.cpp
+++ b/src/vsg/state/ArrayState.cpp
@@ -460,8 +460,6 @@ void BillboardArrayState::apply(const VertexInputState& vas)
     getAttributeDetails(vas, position_attribute_location, positionAttribute);
 }
 
-#include <vsg/io/Logger.h>
-
 ref_ptr<const vec3Array> BillboardArrayState::vertexArray(uint32_t instanceIndex)
 {
     struct GetValue : public ConstVisitor

--- a/src/vsg/state/Buffer.cpp
+++ b/src/vsg/state/Buffer.cpp
@@ -107,7 +107,7 @@ bool Buffer::compile(Device* device)
 
     if (VkResult result = vkCreateBuffer(*device, &bufferInfo, device->getAllocationCallbacks(), &vd.buffer); result != VK_SUCCESS)
     {
-        throw Exception{"Error: Failed to create vkBuffer.", result};
+        throw Exception{"Error: Failed to create VkBuffer.", result};
     }
 
     return true;

--- a/src/vsg/state/BufferInfo.cpp
+++ b/src/vsg/state/BufferInfo.cpp
@@ -99,10 +99,10 @@ void BufferInfo::copyDataToBuffer(uint32_t deviceID)
         {
             warn("BufferInfo::copyDataToBuffer() cannot copy data. DeviceMemory does not support direct memory mapping.");
 
+            // you can use dynamic data updates provided by vsg::TransferTask or alternatively, you can implement the following steps:
             // 1. allocate staging buffer
             // 2. copy to staging buffer
             // 3. transfer from staging buffer to device local buffer - use CopyAndReleaseBuffer
-
             return;
         }
 
@@ -110,7 +110,7 @@ void BufferInfo::copyDataToBuffer(uint32_t deviceID)
         VkResult result = dm->map(offset, range, 0, &buffer_data);
         if (result != 0)
         {
-            warn("BufferInfo::copyDataToBuffer() cannot copy data. VkMapMemory(..) failed with result = ", result);
+            warn("BufferInfo::copyDataToBuffer() cannot copy data. vkMapMemory(..) failed with result = ", result);
             return;
         }
 

--- a/src/vsg/state/ComputePipeline.cpp
+++ b/src/vsg/state/ComputePipeline.cpp
@@ -110,7 +110,7 @@ ComputePipeline::Implementation::Implementation(Context& context, Device* device
 
     if (VkResult result = vkCreateComputePipelines(*device, VK_NULL_HANDLE, 1, &pipelineInfo, _device->getAllocationCallbacks(), &_pipeline); result != VK_SUCCESS)
     {
-        throw Exception{"Error: vsg::Pipeline::createCompute(...) failed to create VkPipeline.", result};
+        throw Exception{"Error: vsg::ComputePipeline failed to create VkPipeline.", result};
     }
 }
 

--- a/src/vsg/state/DescriptorBuffer.cpp
+++ b/src/vsg/state/DescriptorBuffer.cpp
@@ -161,7 +161,7 @@ void DescriptorBuffer::compile(Context& context)
                     }
                     else
                     {
-                        warn("DescriptorBuffer::compile(..) unable to allocate bufferInfo with within associated Buffer.");
+                        warn("DescriptorBuffer::compile(..) unable to allocate bufferInfo within associated Buffer.");
                     }
                 }
             }

--- a/src/vsg/state/DescriptorSet.cpp
+++ b/src/vsg/state/DescriptorSet.cpp
@@ -128,7 +128,7 @@ DescriptorSet::Implementation::~Implementation()
 
 void DescriptorSet::Implementation::assign(Context& context, const Descriptors& in_descriptors)
 {
-    // should we doing anything about previous _descriptor that may have been assigned?
+    // should we do anything about previous _descriptors that may have been assigned?
     _descriptors = in_descriptors;
 
     if (_descriptors.empty()) return;

--- a/src/vsg/state/GraphicsPipeline.cpp
+++ b/src/vsg/state/GraphicsPipeline.cpp
@@ -190,7 +190,7 @@ GraphicsPipeline::Implementation::Implementation(Context& context, Device* devic
 
     if (result != VK_SUCCESS)
     {
-        throw Exception{"Error: vsg::Pipeline::createGraphics(...) failed to create VkPipeline.", result};
+        throw Exception{"Error: vsg::GraphicsPipeline failed to create VkPipeline.", result};
     }
 }
 

--- a/src/vsg/state/Image.cpp
+++ b/src/vsg/state/Image.cpp
@@ -203,7 +203,7 @@ void Image::compile(Device* device)
 
     if (VkResult result = vkCreateImage(*vd.device, &info, vd.device->getAllocationCallbacks(), &vd.image); result != VK_SUCCESS)
     {
-        throw Exception{"Error: Failed to create vkImage.", result};
+        throw Exception{"Error: Failed to create VkImage.", result};
     }
 }
 
@@ -221,7 +221,7 @@ void Image::compile(Context& context)
 
     if (!deviceMemory)
     {
-        throw Exception{"Error: allocate memory to reserve slot.", VK_ERROR_OUT_OF_DEVICE_MEMORY};
+        throw Exception{"Error: Image failed to reserve slot from deviceMemoryBufferPools.", VK_ERROR_OUT_OF_DEVICE_MEMORY};
     }
 
     vd.requiresDataCopy = data.valid();

--- a/src/vsg/state/ImageInfo.cpp
+++ b/src/vsg/state/ImageInfo.cpp
@@ -96,7 +96,7 @@ uint32_t vsg::computeNumMipMapLevels(const Data* data, const Sampler* sampler)
     uint32_t mipLevels = 1;
     if (sampler)
     {
-        // clamp the mipLevels so that its no larger than what the data dimensions support
+        // clamp the mipLevels so that it's no larger than what the data dimensions support
         uint32_t maxDimension = std::max({data->width(), data->height(), data->depth()});
         if (sampler->maxLod == VK_LOD_CLAMP_NONE)
         {
@@ -145,9 +145,9 @@ void ImageInfo::computeNumMipMapLevels()
         auto mipLevels = vsg::computeNumMipMapLevels(data, sampler);
 
         const auto& mipmapOffsets = image->data->computeMipmapOffsets();
-        bool generatMipmaps = (mipLevels > 1) && (mipmapOffsets.size() <= 1);
+        bool generateMipmaps = (mipLevels > 1) && (mipmapOffsets.size() <= 1);
 
-        if (generatMipmaps)
+        if (generateMipmaps)
         {
             // check that the data isn't compressed.
             const auto& properties = data->properties;
@@ -161,6 +161,6 @@ void ImageInfo::computeNumMipMapLevels()
         image->mipLevels = mipLevels;
         imageView->subresourceRange.levelCount = mipLevels;
 
-        if (generatMipmaps) image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        if (generateMipmaps) image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
 }

--- a/src/vsg/state/ImageView.cpp
+++ b/src/vsg/state/ImageView.cpp
@@ -136,7 +136,7 @@ void ImageView::compile(Device* device)
 
     if (VkResult result = vkCreateImageView(*vd.device, &info, vd.device->getAllocationCallbacks(), &vd.imageView); result != VK_SUCCESS)
     {
-        throw Exception{"Error: Failed to create vkImageView.", result};
+        throw Exception{"Error: Failed to create VkImageView.", result};
     }
 }
 
@@ -165,7 +165,7 @@ void ImageView::compile(Context& context)
 
     if (VkResult result = vkCreateImageView(*vd.device, &info, vd.device->getAllocationCallbacks(), &vd.imageView); result != VK_SUCCESS)
     {
-        throw Exception{"Error: Failed to create vkImageView.", result};
+        throw Exception{"Error: Failed to create VkImageView.", result};
     }
 }
 
@@ -241,11 +241,11 @@ void vsg::transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetIm
     const auto valueSize = properties.stride; // data->valueSize();
 
     bool useDataMipmaps = (mipLevels > 1) && (mipmapOffsets.size() > 1);
-    bool generatMipmaps = (mipLevels > 1) && (mipmapOffsets.size() <= 1);
+    bool generateMipmaps = (mipLevels > 1) && (mipmapOffsets.size() <= 1);
 
     auto vk_textureImage = textureImage->vk(device->deviceID);
 
-    if (generatMipmaps)
+    if (generateMipmaps)
     {
         VkFormatProperties props;
         vkGetPhysicalDeviceFormatProperties(*(device->getPhysicalDevice()), properties.format, &props);
@@ -253,7 +253,7 @@ void vsg::transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetIm
 
         if (!isBlitPossible)
         {
-            generatMipmaps = false;
+            generateMipmaps = false;
         }
     }
 
@@ -341,7 +341,7 @@ void vsg::transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetIm
     vkCmdCopyBufferToImage(commandBuffer, stagingBuffer->vk(device->deviceID), vk_textureImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                            static_cast<uint32_t>(regions.size()), regions.data());
 
-    if (generatMipmaps)
+    if (generateMipmaps)
     {
         VkImageMemoryBarrier barrier = {};
         barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;

--- a/src/vsg/state/Sampler.cpp
+++ b/src/vsg/state/Sampler.cpp
@@ -108,7 +108,7 @@ Sampler::Implementation::Implementation(Device* device, const VkSamplerCreateInf
 {
     if (VkResult result = vkCreateSampler(*device, &createSamplerInfo, _device->getAllocationCallbacks(), &_sampler); result != VK_SUCCESS)
     {
-        throw Exception{"Error: Failed to create vkSampler.", result};
+        throw Exception{"Error: Failed to create VkSampler.", result};
     }
 }
 

--- a/src/vsg/state/ShaderModule.cpp
+++ b/src/vsg/state/ShaderModule.cpp
@@ -132,7 +132,7 @@ void ShaderModule::write(Output& output) const
     output.writeObject("hints", hints);
     output.write("source", source);
     output.writeValue<uint32_t>("code", code.size());
-    output.writePropertyName(""); // convenient way of forcing an indent to the appropriate column when writing out to ascii, doesn't require a matching matchPropertyName() in ShaderModel::read(..).
+    output.writePropertyName(""); // convenient way of forcing an indent to the appropriate column when writing out to ascii, doesn't require a matching readPropertyName() in ShaderModule::read(..).
     output.write(code.size(), code.data());
     output.writeEndOfLine();
 }

--- a/src/vsg/text/CpuLayoutTechnique.cpp
+++ b/src/vsg/text/CpuLayoutTechnique.cpp
@@ -231,7 +231,7 @@ ref_ptr<Node> CpuLayoutTechnique::createRenderingSubgraph(ref_ptr<ShaderSet> sha
     else
         drawIndexed->indexCount = static_cast<uint32_t>(quads.size() * 6);
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     if (!stategroup)
     {
         stategroup = StateGroup::create();

--- a/src/vsg/text/GpuLayoutTechnique.cpp
+++ b/src/vsg/text/GpuLayoutTechnique.cpp
@@ -192,7 +192,7 @@ void GpuLayoutTechnique::setup(Text* text, uint32_t minimumAllocation, ref_ptr<c
 
     ref_ptr<StateGroup> stateGroup = scenegraph.cast<StateGroup>();
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     if (!stateGroup)
     {
         stateGroup = StateGroup::create();

--- a/src/vsg/ui/Keyboard.cpp
+++ b/src/vsg/ui/Keyboard.cpp
@@ -18,7 +18,7 @@ using namespace vsg;
 
 void Keyboard::apply(KeyPressEvent& keyPress)
 {
-    //std::cout<<"Keyboard::apply(KeyReleaseEvent& keyRelease)"<<std::endl;
+    //std::cout<<"Keyboard::apply(KeyPressEvent& keyPress)"<<std::endl;
 
     auto keyState_itr = keyState.find(keyPress.keyBase);
     if (keyState_itr != keyState.end())

--- a/src/vsg/ui/PlayEvents.cpp
+++ b/src/vsg/ui/PlayEvents.cpp
@@ -38,7 +38,7 @@ bool PlayEvents::dispatchFrameEvents(vsg::UIEvents& viewer_events)
     });
 
     // clear the list of frameEvents that we will want to pass to the viewer
-    // to be filled in be the PlayUIEvents::apply(..) methods.
+    // to be filled in by the PlayUIEvents::apply(..) methods.
     frameEnd = false;
     frameEvents.clear();
 

--- a/src/vsg/ui/PrintEvents.cpp
+++ b/src/vsg/ui/PrintEvents.cpp
@@ -53,7 +53,7 @@ void PrintEvents::apply(UIEvent& event)
 
 void PrintEvents::apply(FrameEvent& event)
 {
-    print(event) << " : franeCount = " << event.frameStamp->frameCount << std::endl;
+    print(event) << " : frameCount = " << event.frameStamp->frameCount << std::endl;
 }
 
 void PrintEvents::apply(ExposeWindowEvent& event)

--- a/src/vsg/utils/Builder.cpp
+++ b/src/vsg/utils/Builder.cpp
@@ -126,7 +126,7 @@ ref_ptr<StateGroup> Builder::createStateGroup(const StateInfo& stateInfo)
     else
         graphicsPipelineConfig->init();
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     auto stateGroup = vsg::StateGroup::create();
     graphicsPipelineConfig->copyTo(stateGroup, sharedObjects);
     return stateGroup;
@@ -195,7 +195,7 @@ ref_ptr<Node> Builder::createBox(const GeometryInfo& info, const StateInfo& stat
     auto positions = instancePositions(info, instanceCount);
     auto colors = instanceColors(info, instanceCount);
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     auto scenegraph = createStateGroup(stateInfo);
 
     auto dx = info.dx;
@@ -336,7 +336,7 @@ ref_ptr<Node> Builder::createCapsule(const GeometryInfo& info, const StateInfo& 
     auto colors = instanceColors(info, instanceCount);
     auto [t_origin, t_scale, t_top] = y_texcoord(stateInfo).value;
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     auto scenegraph = createStateGroup(stateInfo);
 
     auto dx = info.dx * 0.5f;
@@ -565,7 +565,7 @@ ref_ptr<Node> Builder::createCone(const GeometryInfo& info, const StateInfo& sta
     auto colors = instanceColors(info, instanceCount);
     auto [t_origin, t_scale, t_top] = y_texcoord(stateInfo).value;
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     auto scenegraph = createStateGroup(stateInfo);
 
     auto dx = info.dx * 0.5f;
@@ -775,7 +775,7 @@ ref_ptr<Node> Builder::createCylinder(const GeometryInfo& info, const StateInfo&
     auto colors = instanceColors(info, instanceCount);
     auto [t_origin, t_scale, t_top] = y_texcoord(stateInfo).value;
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     auto scenegraph = createStateGroup(stateInfo);
 
     auto dx = info.dx * 0.5f;
@@ -1022,7 +1022,7 @@ ref_ptr<Node> Builder::createDisk(const GeometryInfo& info, const StateInfo& sta
     auto colors = instanceColors(info, instanceCount);
     auto [t_origin, t_scale, t_top] = y_texcoord(stateInfo).value;
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     auto scenegraph = createStateGroup(stateInfo);
 
     auto dx = info.dx * 0.5f;
@@ -1205,7 +1205,7 @@ ref_ptr<Node> Builder::createSphere(const GeometryInfo& info, const StateInfo& s
     auto colors = instanceColors(info, instanceCount);
     auto [t_origin, t_scale, t_top] = y_texcoord(stateInfo).value;
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     auto scenegraph = createStateGroup(stateInfo);
 
     auto dx = info.dx * 0.5f;
@@ -1314,7 +1314,7 @@ ref_ptr<Node> Builder::createHeightField(const GeometryInfo& info, const StateIn
     auto colors = instanceColors(info, instanceCount);
     auto [t_origin, t_scale, t_top] = y_texcoord(stateInfo).value;
 
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     auto scenegraph = createStateGroup(stateInfo);
 
     auto dx = info.dx;

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -423,7 +423,7 @@ void GraphicsPipelineConfigurator::init()
 
 void GraphicsPipelineConfigurator::copyTo(ref_ptr<StateGroup> stateGroup, ref_ptr<SharedObjects> sharedObjects)
 {
-    // create StateGroup as the root of the scene/command graph to hold the GraphicsProgram, and binding of Descriptors to decorate the whole graph
+    // create StateGroup as the root of the scene/command graph to hold the GraphicsPipeline, and binding of Descriptors to decorate the whole graph
     if (sharedObjects) sharedObjects->share(bindGraphicsPipeline);
 
     stateGroup->add(bindGraphicsPipeline);

--- a/src/vsg/utils/LineSegmentIntersector.cpp
+++ b/src/vsg/utils/LineSegmentIntersector.cpp
@@ -256,14 +256,14 @@ bool LineSegmentIntersector::intersectDraw(uint32_t firstVertex, uint32_t vertex
     uint32_t lastIndex = instanceCount > 1 ? (firstInstance + instanceCount) : firstInstance + 1;
     for (uint32_t instanceIndex = firstInstance; instanceIndex < lastIndex; ++instanceIndex)
     {
-        TriangleIntersector<double> triIntsector(*this, ls.start, ls.end, arrayState.vertexArray(instanceIndex));
-        if (!triIntsector.vertices) return false;
+        TriangleIntersector<double> triIntersector(*this, ls.start, ls.end, arrayState.vertexArray(instanceIndex));
+        if (!triIntersector.vertices) return false;
 
         uint32_t endVertex = int((firstVertex + vertexCount) / 3.0f) * 3;
 
         for (uint32_t i = firstVertex; i < endVertex; i += 3)
         {
-            triIntsector.intersect(i, i + 1, i + 2);
+            triIntersector.intersect(i, i + 1, i + 2);
         }
     }
 
@@ -281,10 +281,10 @@ bool LineSegmentIntersector::intersectDrawIndexed(uint32_t firstIndex, uint32_t 
     uint32_t lastIndex = instanceCount > 1 ? (firstInstance + instanceCount) : firstInstance + 1;
     for (uint32_t instanceIndex = firstInstance; instanceIndex < lastIndex; ++instanceIndex)
     {
-        TriangleIntersector<double> triIntsector(*this, ls.start, ls.end, arrayState.vertexArray(instanceIndex));
-        if (!triIntsector.vertices) continue;
+        TriangleIntersector<double> triIntersector(*this, ls.start, ls.end, arrayState.vertexArray(instanceIndex));
+        if (!triIntersector.vertices) continue;
 
-        triIntsector.instanceIndex = instanceIndex;
+        triIntersector.instanceIndex = instanceIndex;
 
         uint32_t endIndex = int((firstIndex + indexCount) / 3.0f) * 3;
 
@@ -292,14 +292,14 @@ bool LineSegmentIntersector::intersectDrawIndexed(uint32_t firstIndex, uint32_t 
         {
             for (uint32_t i = firstIndex; i < endIndex; i += 3)
             {
-                triIntsector.intersect(ushort_indices->at(i), ushort_indices->at(i + 1), ushort_indices->at(i + 2));
+                triIntersector.intersect(ushort_indices->at(i), ushort_indices->at(i + 1), ushort_indices->at(i + 2));
             }
         }
         else if (uint_indices)
         {
             for (uint32_t i = firstIndex; i < endIndex; i += 3)
             {
-                triIntsector.intersect(uint_indices->at(i), uint_indices->at(i + 1), uint_indices->at(i + 2));
+                triIntersector.intersect(uint_indices->at(i), uint_indices->at(i + 1), uint_indices->at(i + 2));
             }
         }
     }

--- a/src/vsg/utils/LoadPagedLOD.cpp
+++ b/src/vsg/utils/LoadPagedLOD.cpp
@@ -70,7 +70,7 @@ void LoadPagedLOD::apply(CullNode& node)
 
 void LoadPagedLOD::apply(Transform& transform)
 {
-    debug("apply(Transform& transform) Need to do transform modelview matrix");
+    debug("apply(Transform& transform) Need to transform modelview matrix");
 
     modelviewMatrixStack.emplace(transform.transform(modelviewMatrixStack.top()));
 

--- a/src/vsg/utils/ShaderSet.cpp
+++ b/src/vsg/utils/ShaderSet.cpp
@@ -224,7 +224,7 @@ ref_ptr<ArrayState> ShaderSet::getSuitableArrayState(const std::set<std::string>
 {
     // not all defines are relevant to the provided ArrayState
     // so check each one against the entries in the definesArrayState
-    // are relevant to the final matching.
+    // relevant to the final matching.
     std::set<std::string> relevant_defines;
     for (auto& define : defines)
     {

--- a/src/vsg/utils/SharedObjects.cpp
+++ b/src/vsg/utils/SharedObjects.cpp
@@ -98,7 +98,7 @@ void SharedObjects::prune()
     }
     _defaults.clear();
 
-    // prune SharedObjects that don't have an external references (referenceCount != 1)
+    // prune SharedObjects that don't have external references (referenceCount == 1)
     bool prunedObjects = false;
     do
     {

--- a/src/vsg/vk/Device.cpp
+++ b/src/vsg/vk/Device.cpp
@@ -72,7 +72,7 @@ Device::Device(PhysicalDevice* physicalDevice, const QueueSettings& queueSetting
     {
         if (queueSetting.queueFamilyIndex < 0) continue;
 
-        // check to see if the queueFamilyIndex has already been referenced or us unique
+        // check to see if the queueFamilyIndex has already been referenced or is unique
         bool unique = true;
         for (auto& existingInfo : queueCreateInfos)
         {
@@ -95,7 +95,7 @@ Device::Device(PhysicalDevice* physicalDevice, const QueueSettings& queueSetting
             if (queueCreateInfo.queueCount > supportedQueueCount)
             {
                 queueCreateInfo.queueCount = supportedQueueCount;
-                debug("Device::Device() creation failed to create request queueCount.");
+                debug("Device::Device() creation failed to create requested queueCount.");
             }
         }
         else
@@ -137,7 +137,7 @@ Device::Device(PhysicalDevice* physicalDevice, const QueueSettings& queueSetting
         throw Exception{"Error: vsg::Device::create(...) failed to create logical device.", result};
     }
 
-    // allocated the requested queues
+    // allocate the requested queues
     for (auto queueInfo : queueCreateInfos)
     {
         for (uint32_t queueIndex = 0; queueIndex < queueInfo.queueCount; ++queueIndex)

--- a/src/vsg/vk/DeviceMemory.cpp
+++ b/src/vsg/vk/DeviceMemory.cpp
@@ -43,7 +43,7 @@ DeviceMemory::DeviceMemory(Device* device, const VkMemoryRequirements& memRequir
     }
     if (i >= memProperties.memoryTypeCount)
     {
-        throw Exception{"Error: vsg::DeviceMemory::create(...) failed to create DeviceMemory, not usage memory type found.", VK_ERROR_FORMAT_NOT_SUPPORTED};
+        throw Exception{"Error: vsg::DeviceMemory::create(...) failed to create DeviceMemory, no usable memory type found.", VK_ERROR_FORMAT_NOT_SUPPORTED};
     }
     uint32_t memoryTypeIndex = i;
 

--- a/src/vsg/vk/Swapchain.cpp
+++ b/src/vsg/vk/Swapchain.cpp
@@ -104,7 +104,7 @@ VkPresentModeKHR vsg::selectSwapPresentMode(const SwapChainSupportDetails& detai
         if (availablePresentMode == preferredPresentMode) return availablePresentMode;
     }
 
-    // requested presetnMode not available so fallback for checking of VK_PRESENT_MODE_MAILBOX_KHR available
+    // requested presentMode not available so fallback to checking if VK_PRESENT_MODE_MAILBOX_KHR available
     for (auto availablePresentMode : details.presentModes)
     {
         if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR) return availablePresentMode;
@@ -132,7 +132,7 @@ VkPresentModeKHR vsg::selectSwapPresentMode(const SwapChainSupportDetails& detai
 //
 namespace vsg
 {
-    // helper class that disabled the automatic clear up of the swap chain image as the swap chain itself manages it's lifetime
+    // helper class that disables the automatic clean up of the swap chain image as the swap chain itself manages its lifetime
     class SwapchainImage : public Inherit<Image, SwapchainImage>
     {
     public:
@@ -171,7 +171,7 @@ Swapchain::Swapchain(PhysicalDevice* physicalDevice, Device* device, Surface* su
     uint32_t imageCount = std::max(preferences.imageCount, details.capabilities.minImageCount);                        // Vulkan spec requires minImageCount to be 1 or greater
     if (details.capabilities.maxImageCount > 0) imageCount = std::min(imageCount, details.capabilities.maxImageCount); // Vulkan spec specifies 0 as being unlimited number of images
 
-    // apply the selected settings back to preferences to calling code can determine the active settings.
+    // apply the selected settings back to preferences so calling code can determine the active settings.
     preferences.imageCount = imageCount;
     preferences.presentMode = presentMode;
     preferences.surfaceFormat = surfaceFormat;


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed typos, grammar and semantic errors in comments and variable names without changing the API. Removed misplaced `#include <vsg/io/Logger.h>` in the middle of a source file.

* The most common error was `it's` in place of `its`.
* The following comments' meaning couldn't be deduced:
** `// allocate memory with out export memory info extension` (ImageView.cpp)
** `// or select index when maps to a dormant CommandBuffer` (CommandGraph.cpp, SecondaryCommandGraph.cpp)

## Type of change

## How Has This Been Tested?

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
