### PR TITLE
[ADDED] ClearColorImage and ClearDepthStencilImage

### DIFF
--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -83,6 +83,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/commands/BindVertexBuffers.h>
 #include <vsg/commands/BlitImage.h>
 #include <vsg/commands/ClearAttachments.h>
+#include <vsg/commands/ClearImage.h>
 #include <vsg/commands/Command.h>
 #include <vsg/commands/Commands.h>
 #include <vsg/commands/CopyAndReleaseBuffer.h>

--- a/include/vsg/commands/ClearImage.h
+++ b/include/vsg/commands/ClearImage.h
@@ -1,0 +1,51 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2019 Thomas Hogarth
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/commands/Command.h>
+#include <vsg/state/Image.h>
+
+namespace vsg
+{
+
+    /// ClearColorImage command encapsulates vkCmdClearColorImage functionality and associated settings.
+    class VSG_DECLSPEC ClearColorImage : public Inherit<Command, ClearColorImage>
+    {
+    public:
+        using Ranges = std::vector<VkImageSubresourceRange>;
+
+        vsg::ref_ptr<vsg::Image> image;
+        VkImageLayout imageLayout; // imageLayout must be VK_IMAGE_LAYOUT_GENERAL or VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
+        VkClearColorValue color;
+        Ranges ranges;
+
+        void record(CommandBuffer& commandBuffer) const override;
+    };
+    VSG_type_name(vsg::ClearColorImage);
+
+    /// ClearDepthStencilImage command encapsulates vkCmdClearDepthStencilImage functionality and associated settings.
+    class VSG_DECLSPEC ClearDepthStencilImage : public Inherit<Command, ClearDepthStencilImage>
+    {
+    public:
+        using Ranges = std::vector<VkImageSubresourceRange>;
+
+        vsg::ref_ptr<vsg::Image> image;
+        VkImageLayout imageLayout; // imageLayout must be VK_IMAGE_LAYOUT_GENERAL or VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
+        VkClearDepthStencilValue depthStencil;
+        Ranges ranges;
+
+        void record(CommandBuffer& commandBuffer) const override;
+    };
+    VSG_type_name(vsg::ClearDepthStencilImage);
+
+} // namespace vsg

--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -91,6 +91,8 @@ namespace vsg
     class DynamicState;
     class ResourceHints;
     class ClearAttachments;
+    class ClearColorImage;
+    class ClearDepthStencilImage;
     class QueryPool;
     class ResetQueryPool;
     class BeginQuery;
@@ -341,6 +343,8 @@ namespace vsg
         virtual void apply(const Draw&);
         virtual void apply(const DrawIndexed&);
         virtual void apply(const ClearAttachments&);
+        virtual void apply(const ClearColorImage&);
+        virtual void apply(const ClearDepthStencilImage&);
         virtual void apply(const QueryPool&);
         virtual void apply(const ResetQueryPool&);
         virtual void apply(const BeginQuery&);

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -91,6 +91,8 @@ namespace vsg
     class DynamicState;
     class ResourceHints;
     class ClearAttachments;
+    class ClearColorImage;
+    class ClearDepthStencilImage;
     class QueryPool;
     class ResetQueryPool;
     class BeginQuery;
@@ -341,6 +343,8 @@ namespace vsg
         virtual void apply(Draw&);
         virtual void apply(DrawIndexed&);
         virtual void apply(ClearAttachments&);
+        virtual void apply(ClearColorImage&);
+        virtual void apply(ClearDepthStencilImage&);
         virtual void apply(QueryPool&);
         virtual void apply(ResetQueryPool&);
         virtual void apply(BeginQuery&);

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCES
     commands/CopyAndReleaseBuffer.cpp
     commands/CopyAndReleaseImage.cpp
     commands/ClearAttachments.cpp
+    commands/ClearImage.cpp
     commands/PipelineBarrier.cpp
     commands/Event.cpp
     commands/NextSubPass.cpp

--- a/src/vsg/commands/ClearImage.cpp
+++ b/src/vsg/commands/ClearImage.cpp
@@ -1,0 +1,33 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018 Robert Osfield
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/commands/ClearImage.h>
+#include <vsg/io/Options.h>
+#include <vsg/vk/CommandBuffer.h>
+
+using namespace vsg;
+
+void ClearColorImage::record(CommandBuffer& commandBuffer) const
+{
+    vkCmdClearColorImage(commandBuffer,
+            image->vk(commandBuffer.deviceID),
+            imageLayout, &color,
+            static_cast<uint32_t>(ranges.size()), ranges.data());
+}
+
+void ClearDepthStencilImage::record(CommandBuffer& commandBuffer) const
+{
+    vkCmdClearDepthStencilImage(commandBuffer,
+            image->vk(commandBuffer.deviceID),
+            imageLayout, &depthStencil,
+            static_cast<uint32_t>(ranges.size()), ranges.data());
+}

--- a/src/vsg/core/ConstVisitor.cpp
+++ b/src/vsg/core/ConstVisitor.cpp
@@ -775,6 +775,14 @@ void ConstVisitor::apply(const ClearAttachments& value)
 {
     apply(static_cast<const Command&>(value));
 }
+void ConstVisitor::apply(const ClearColorImage& value)
+{
+    apply(static_cast<const Command&>(value));
+}
+void ConstVisitor::apply(const ClearDepthStencilImage& value)
+{
+    apply(static_cast<const Command&>(value));
+}
 void ConstVisitor::apply(const QueryPool& value)
 {
     apply(static_cast<const Object&>(value));

--- a/src/vsg/core/Visitor.cpp
+++ b/src/vsg/core/Visitor.cpp
@@ -775,6 +775,14 @@ void Visitor::apply(ClearAttachments& value)
 {
     apply(static_cast<Command&>(value));
 }
+void Visitor::apply(ClearColorImage& value)
+{
+    apply(static_cast<Command&>(value));
+}
+void Visitor::apply(ClearDepthStencilImage& value)
+{
+    apply(static_cast<Command&>(value));
+}
 void Visitor::apply(QueryPool& value)
 {
     apply(static_cast<Object&>(value));


### PR DESCRIPTION
# Pull Request Template

## Description

Added encapsulation of vkCmdClearColorImage and vkCmdClearDepthStencilImage

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested ClearColorImage for initializing images before computing on them

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
