### PR TITLE
[FIXED] infinite loop on VK_ERROR_DEVICE_LOST

### DIFF
--- a/src/vsg/app/Viewer.cpp
+++ b/src/vsg/app/Viewer.cpp
@@ -189,13 +189,19 @@ bool Viewer::acquireNextFrame()
         while ((result = window->acquireNextImage()) != VK_SUCCESS)
         {
             if (result == VK_ERROR_SURFACE_LOST_KHR ||
-                result == VK_ERROR_DEVICE_LOST ||
                 result == VK_ERROR_OUT_OF_DATE_KHR ||
                 result == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT ||
                 result == VK_SUBOPTIMAL_KHR)
             {
                 // force a rebuild of the Swapchain by calling Window::resize();
                 window->resize();
+            }
+            else if (result == VK_ERROR_DEVICE_LOST)
+            {
+                // a lost device can only be recovered by opening a new VkDevice, and success is not guaranteed.
+                // not currently implemented, so exit main loop.
+                warn("window->acquireNextImage() VkResult = VK_ERROR_DEVICE_LOST. Device loss can indicate invalid Vulkan API usage or driver/hardware issues.");
+                break
             }
             else
             {


### PR DESCRIPTION
# Pull Request Template

## Description

Added handling of VK_ERROR_DEVICE_LOST to avoid infinite loop in acquiring next image.

The Vulkan spec 5.2.3. states: "After any such event, the logical device is considered lost. It is not possible to reset the logical device to a non-lost state [...]."

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Waiting for user's feedback

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
