### PR TITLE
Properly implemented vsg::getDirectoryContents on the Windows platform

### DIFF
--- a/src/vsg/io/FileSystem.cpp
+++ b/src/vsg/io/FileSystem.cpp
@@ -292,17 +292,17 @@ FILE* vsg::fopen(const Path& path, const char* mode)
 // Microsoft API for reading directories
 Paths vsg::getDirectoryContents(const Path& directoryName)
 {
-    LPDWORD strLength = 0;
-    PWSTR linkName = nullptr;
+    WIN32_FIND_DATAW ffd;
 
-    auto handle = FindFirstFileNameW(directoryName.c_str(), 0, strLength, linkName);
+    auto searchFolder = directoryName / "*";
+    auto handle = FindFirstFileW(searchFolder.c_str(), &ffd);
     if (handle == INVALID_HANDLE_VALUE) return {};
 
     Paths paths;
     do
     {
-        paths.push_back(linkName);
-    } while (FindNextFileNameW(handle, strLength, linkName));
+        paths.push_back(ffd.cFileName);
+    } while (FindNextFileW(handle, &ffd) != 0);
 
     FindClose(handle);
 


### PR DESCRIPTION
## Description

This change uses the **FindFirstFileW/FindNextFileW** API function pair (with correct parameters) instead of **FindFirstFileNameW/FindNextFileNameW** (which only enumerates hard links and was using invalid parameters)

Fixes #905

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested this locally using a modified 'vsgviewer' example as there doesn't seem to be an example dedicated to Path/Paths/Filesystem classes/functions.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
