### PR TITLE
[FIXED] VK_LOD_CLAMP_NONE off-by-one error

### DIFF
--- a/src/vsg/state/ImageInfo.cpp
+++ b/src/vsg/state/ImageInfo.cpp
@@ -100,7 +100,7 @@ uint32_t vsg::computeNumMipMapLevels(const Data* data, const Sampler* sampler)
         uint32_t maxDimension = std::max({data->width(), data->height(), data->depth()});
         if (sampler->maxLod == VK_LOD_CLAMP_NONE)
         {
-            while ((1u << (mipLevels - 1)) < maxDimension)
+            while ((1u << mipLevels) <= maxDimension)
             {
                 ++mipLevels;
             }


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed off-by-one error in VK_LOD_CLAMP_NONE mipLevels calculation for non power of two image dimensions.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Before:
`computeNumMipMapLevels(maxLod=VK_LOD_CLAMP_NONE, image_size=129) = 9`
`computeNumMipMapLevels(maxLod=16, image_size=129) = 8`

After:
`computeNumMipMapLevels(maxLod=VK_LOD_CLAMP_NONE, image_size=129) = 8`
`computeNumMipMapLevels(maxLod=16, image_size=129) = 8`

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
