### PR TITLE
[UPDATED] ImageView to use VK_REMAINING_MIP_LEVELS

### DIFF
--- a/src/vsg/state/ImageInfo.cpp
+++ b/src/vsg/state/ImageInfo.cpp
@@ -159,7 +159,6 @@ void ImageInfo::computeNumMipMapLevels()
         }
 
         image->mipLevels = mipLevels;
-        imageView->subresourceRange.levelCount = mipLevels;
 
         if (generateMipmaps) image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }

--- a/src/vsg/state/ImageView.cpp
+++ b/src/vsg/state/ImageView.cpp
@@ -62,7 +62,7 @@ ImageView::ImageView(ref_ptr<Image> in_image) :
         format = image->format;
         subresourceRange.aspectMask = computeAspectFlagsForFormat(image->format);
         subresourceRange.baseMipLevel = 0;
-        subresourceRange.levelCount = image->mipLevels;
+        subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
         subresourceRange.baseArrayLayer = 0;
         subresourceRange.layerCount = image->arrayLayers;
     }
@@ -86,7 +86,7 @@ ImageView::ImageView(ref_ptr<Image> in_image, VkImageAspectFlags aspectFlags) :
         format = image->format;
         subresourceRange.aspectMask = aspectFlags;
         subresourceRange.baseMipLevel = 0;
-        subresourceRange.levelCount = image->mipLevels;
+        subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
         subresourceRange.baseArrayLayer = 0;
         subresourceRange.layerCount = image->arrayLayers;
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Added use of VK_REMAINING_MIP_LEVELS constant to avoid the need to modify VkImageSubresourceRange in ImageInfo::computeNumMipMapLevels().

## Type of change

## How Has This Been Tested?

Tested as a part of an upcoming PR.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
