### PR TITLE
[FIXED] mipmap device support checks

### DIFF
--- a/include/vsg/core/Array2D.h
+++ b/include/vsg/core/Array2D.h
@@ -51,6 +51,7 @@ namespace vsg
         {
             if (_width != 0 && _height != 0)
             {
+                // note, doesn't allocate space for mipmaps
                 _data = _allocate(_width * _height);
                 auto dest_v = _data;
                 for (auto& v : rhs) *(dest_v++) = v;
@@ -60,6 +61,7 @@ namespace vsg
 
         Array2D(uint32_t width, uint32_t height, Properties in_properties = {}) :
             Data(in_properties, sizeof(value_type)),
+            // note, doesn't allocate space for mipmaps
             _data(_allocate(width * height)),
             _width(width),
             _height(height) { dirty(); }
@@ -72,6 +74,7 @@ namespace vsg
 
         Array2D(uint32_t width, uint32_t height, const value_type& value, Properties in_properties = {}) :
             Data(in_properties, sizeof(value_type)),
+            // note, doesn't allocate space for mipmaps
             _data(_allocate(width * height)),
             _width(width),
             _height(height)

--- a/include/vsg/core/Array3D.h
+++ b/include/vsg/core/Array3D.h
@@ -136,6 +136,7 @@ namespace vsg
 
             if (input.matchPropertyName("data"))
             {
+                // TODO: need to adapt dimensions for array imageViewType
                 size_t new_size = computeValueCountIncludingMipmaps(w, h, d, properties.maxNumMipmaps);
 
                 if (_data) // if data exists already may be able to reuse it
@@ -184,6 +185,7 @@ namespace vsg
             output.writeEndOfLine();
         }
 
+        // TODO: need to adapt dimensions for array imageViewType
         size_t size() const { return (properties.maxNumMipmaps <= 1) ? (static_cast<size_t>(_width) * _height * _depth) : computeValueCountIncludingMipmaps(_width, _height, _depth, properties.maxNumMipmaps); }
 
         bool available() const { return _data != nullptr; }

--- a/include/vsg/state/Image.h
+++ b/include/vsg/state/Image.h
@@ -33,13 +33,15 @@ namespace vsg
         /// Vulkan VkImage handle
         VkImage vk(uint32_t deviceID) const { return _vulkanData[deviceID].image; }
 
-        /// VkImageCreateInfo settings
+        /// optional Data that was used to initialize createInfo
         ref_ptr<Data> data;
+
+        /// VkImageCreateInfo settings
         VkImageCreateFlags flags = 0;
         VkImageType imageType = VK_IMAGE_TYPE_2D;
         VkFormat format = VK_FORMAT_UNDEFINED;
         VkExtent3D extent = {0, 0, 0};
-        uint32_t mipLevels = 0;
+        uint32_t mipLevels = 0; // Note, if generated mipmaps are requested and supported by the Device then the mipLevels are calculated for that Device and Image::mipLevels is ignored.
         uint32_t arrayLayers = 0;
         VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT;
         VkImageTiling tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -70,6 +72,9 @@ namespace vsg
         virtual void compile(Device* device);
         virtual void compile(Context& context);
 
+        bool requestGenerateMipLevels(Device* device, uint32_t mipLevels);
+        uint32_t getMipLevels(Device* device);
+
     protected:
         virtual ~Image();
 
@@ -82,6 +87,7 @@ namespace vsg
             ref_ptr<Device> device;
             bool requiresDataCopy = false;
             ModifiedCount copiedModifiedCount;
+            uint32_t generateMipLevels = 0;
 
             void release();
         };

--- a/include/vsg/state/ImageInfo.h
+++ b/include/vsg/state/ImageInfo.h
@@ -30,7 +30,6 @@ namespace vsg
             imageView(in_imageView),
             imageLayout(in_imageLayout)
         {
-            computeNumMipMapLevels();
         }
 
         // Convenience constructor that creates a vsg::ImageView and vsg::Image to represent the data on the GPU.
@@ -43,8 +42,6 @@ namespace vsg
             image->usage |= (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
             imageView = ImageView::create(image);
-
-            computeNumMipMapLevels();
         }
 
         ImageInfo(const ImageInfo&) = delete;
@@ -54,7 +51,7 @@ namespace vsg
 
         int compare(const Object& rhs_object) const override;
 
-        void computeNumMipMapLevels();
+        void computeNumMipMapLevels(vsg::Device* device);
 
         ref_ptr<Sampler> sampler;
         ref_ptr<ImageView> imageView;

--- a/src/vsg/app/TransferTask.cpp
+++ b/src/vsg/app/TransferTask.cpp
@@ -255,7 +255,7 @@ void TransferTask::_transferImageInfo(VkCommandBuffer vk_commandBuffer, Frame& f
     auto height = data->height();
     auto depth = data->depth();
     auto mipmapOffsets = data->computeMipmapOffsets();
-    uint32_t mipLevels = vsg::computeNumMipMapLevels(data, imageInfo.sampler);
+    uint32_t mipLevels = imageInfo.imageView->image->getMipLevels(device);
 
     auto source_offset = offset;
 

--- a/src/vsg/commands/CopyAndReleaseImage.cpp
+++ b/src/vsg/commands/CopyAndReleaseImage.cpp
@@ -50,7 +50,7 @@ void CopyAndReleaseImage::add(const CopyData& cd)
 
 void CopyAndReleaseImage::add(ref_ptr<BufferInfo> src, ref_ptr<ImageInfo> dest)
 {
-    add(CopyData(src, dest, vsg::computeNumMipMapLevels(src->data, dest->sampler)));
+    add(CopyData(src, dest, dest->imageView->image->mipLevels));
 }
 
 void CopyAndReleaseImage::add(ref_ptr<BufferInfo> src, ref_ptr<ImageInfo> dest, uint32_t numMipMapLevels)
@@ -60,7 +60,7 @@ void CopyAndReleaseImage::add(ref_ptr<BufferInfo> src, ref_ptr<ImageInfo> dest, 
 
 void CopyAndReleaseImage::copy(ref_ptr<Data> data, ref_ptr<ImageInfo> dest)
 {
-    copy(data, dest, vsg::computeNumMipMapLevels(data, dest->sampler));
+    copy(data, dest, dest->imageView->image->mipLevels);
 }
 
 void CopyAndReleaseImage::copy(ref_ptr<Data> data, ref_ptr<ImageInfo> dest, uint32_t numMipMapLevels)

--- a/src/vsg/state/DescriptorImage.cpp
+++ b/src/vsg/state/DescriptorImage.cpp
@@ -104,7 +104,7 @@ void DescriptorImage::compile(Context& context)
 
     for (auto& imageInfo : imageInfoList)
     {
-        imageInfo->computeNumMipMapLevels();
+        imageInfo->computeNumMipMapLevels(context.device);
 
         if (imageInfo->sampler) imageInfo->sampler->compile(context);
         if (imageInfo->imageView)
@@ -115,7 +115,7 @@ void DescriptorImage::compile(Context& context)
             if (imageView.image && imageView.image->syncModifiedCount(context.deviceID))
             {
                 auto& image = *imageView.image;
-                context.copy(image.data, imageInfo, image.mipLevels);
+                context.copy(image.data, imageInfo, image.getMipLevels(context.device));
             }
         }
     }

--- a/src/vsg/state/ImageView.cpp
+++ b/src/vsg/state/ImageView.cpp
@@ -64,7 +64,7 @@ ImageView::ImageView(ref_ptr<Image> in_image) :
         subresourceRange.baseMipLevel = 0;
         subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
         subresourceRange.baseArrayLayer = 0;
-        subresourceRange.layerCount = image->arrayLayers;
+        subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
     }
 }
 
@@ -88,7 +88,7 @@ ImageView::ImageView(ref_ptr<Image> in_image, VkImageAspectFlags aspectFlags) :
         subresourceRange.baseMipLevel = 0;
         subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
         subresourceRange.baseArrayLayer = 0;
-        subresourceRange.layerCount = image->arrayLayers;
+        subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
     }
 }
 
@@ -244,18 +244,6 @@ void vsg::transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetIm
     bool generateMipmaps = (mipLevels > 1) && (mipmapOffsets.size() <= 1);
 
     auto vk_textureImage = textureImage->vk(device->deviceID);
-
-    if (generateMipmaps)
-    {
-        VkFormatProperties props;
-        vkGetPhysicalDeviceFormatProperties(*(device->getPhysicalDevice()), properties.format, &props);
-        const bool isBlitPossible = (props.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT) > 0;
-
-        if (!isBlitPossible)
-        {
-            generateMipmaps = false;
-        }
-    }
 
     // transfer the data.
     VkImageMemoryBarrier preCopyBarrier = {};


### PR DESCRIPTION
# Pull Request Template

## Description

Added check for the device support required for generating mipmaps before the VkImage is allocated, so that it can be allocated with the appropriate mip count, which is now stored per device in Image::_vulkanData.

Removed previously used workaround, a potentially harmful assignment to Sampler::maxLod from within ImageInfo::computeNumMipMapLevels().

Note, the Vulkan spec 34.3. lists required format support. Many formats lack guaranteed support for blit operations. For example, VK_FORMAT_R8G8_SNORM guarantees only SAMPLED_IMAGE and BLIT_SRC support, with support for BLIT_DST being up to the implementation.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested various images with Sampler::maxLod set

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
