### PR TITLE
Added support for the X1/X2 mouse buttons on the Windows platform.

### DIFF
--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -119,16 +119,40 @@ namespace vsgWin32
         return static_cast<vsg::ButtonMask>(mask);
     }
 
-    inline uint32_t getButtonDownEventDetail(UINT buttonMsg)
+    inline uint32_t getButtonDownEventDetail(UINT buttonMsg, WORD wParamHi)
     {
-        return buttonMsg == WM_LBUTTONDOWN ? 1 : (buttonMsg == WM_MBUTTONDOWN ? 2 : buttonMsg == WM_RBUTTONDOWN ? 3
-                                                                                                                : (buttonMsg == WM_XBUTTONDOWN ? 4 : 0)); // need to determine x1, x2
+        switch (buttonMsg)
+        {
+        case WM_LBUTTONDOWN: return 1;
+        case WM_MBUTTONDOWN: return 2;
+        case WM_RBUTTONDOWN: return 3;
+        case WM_XBUTTONDOWN:
+            if (wParamHi == XBUTTON1)
+                return 4;
+            else if (wParamHi == XBUTTON2)
+                return 5;
+            [[fallthrough]];
+        default:
+            return 0;
+        }
     }
 
-    inline uint32_t getButtonUpEventDetail(UINT buttonMsg)
+    inline uint32_t getButtonUpEventDetail(UINT buttonMsg, WORD wParamHi)
     {
-        return buttonMsg == WM_LBUTTONUP ? 1 : (buttonMsg == WM_MBUTTONUP ? 2 : buttonMsg == WM_RBUTTONUP ? 3
-                                                                                                          : (buttonMsg == WM_XBUTTONUP ? 4 : 0));
+        switch (buttonMsg)
+        {
+        case WM_LBUTTONUP: return 1;
+        case WM_MBUTTONUP: return 2;
+        case WM_RBUTTONUP: return 3;
+        case WM_XBUTTONUP:
+             if (wParamHi == XBUTTON1)
+                return 4;
+            else if (wParamHi == XBUTTON2)
+                return 5;
+            [[fallthrough]];
+        default:
+            return 0;
+        }
     }
 
     /// Win32_Window implements Win32 specific window creation, event handling and vulkan Surface setup.

--- a/include/vsg/ui/PointerEvent.h
+++ b/include/vsg/ui/PointerEvent.h
@@ -22,11 +22,11 @@ namespace vsg
     enum ButtonMask : uint16_t
     {
         BUTTON_MASK_OFF = 0,
-        BUTTON_MASK_1 = 256,
-        BUTTON_MASK_2 = 512,
-        BUTTON_MASK_3 = 1024,
-        BUTTON_MASK_4 = 2048, /// mouse wheel up
-        BUTTON_MASK_5 = 4096  /// mouse wheel down
+        BUTTON_MASK_1   = 0x0100, /// left mouse button
+        BUTTON_MASK_2   = 0x0200, /// middle mouse button
+        BUTTON_MASK_3   = 0x0400, /// right mouse button 
+        BUTTON_MASK_4   = 0x0800, /// X1 mouse button
+        BUTTON_MASK_5   = 0x1000  /// X2 mouse button
     };
 
     /// PointerEvent is a base class for mouse pointer events
@@ -77,7 +77,7 @@ namespace vsg
             Inherit(in_window, in_time, in_x, in_y, in_buttonMask),
             button(in_button) {}
 
-        uint32_t button;
+        uint32_t button = 0;
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -566,24 +566,27 @@ LRESULT Win32_Window::handleWin32Messages(UINT msg, WPARAM wParam, LPARAM lParam
     case WM_LBUTTONDOWN:
     case WM_MBUTTONDOWN:
     case WM_RBUTTONDOWN:
+    case WM_XBUTTONDOWN:
     case WM_LBUTTONDBLCLK:
     case WM_MBUTTONDBLCLK:
-    case WM_RBUTTONDBLCLK: {
+    case WM_RBUTTONDBLCLK:
+    case WM_XBUTTONDBLCLK: {
         int32_t mx = GET_X_LPARAM(lParam);
         int32_t my = GET_Y_LPARAM(lParam);
 
-        bufferedEvents.emplace_back(vsg::ButtonPressEvent::create(this, event_time, mx, my, getButtonMask(wParam), getButtonDownEventDetail(msg)));
+        bufferedEvents.emplace_back(vsg::ButtonPressEvent::create(this, event_time, mx, my, getButtonMask(wParam), getButtonDownEventDetail(msg, HIWORD(wParam))));
 
         //::SetCapture(_window);
     }
     break;
     case WM_LBUTTONUP:
     case WM_MBUTTONUP:
-    case WM_RBUTTONUP: {
+    case WM_RBUTTONUP:
+    case WM_XBUTTONUP: {
         int32_t mx = GET_X_LPARAM(lParam);
         int32_t my = GET_Y_LPARAM(lParam);
 
-        bufferedEvents.emplace_back(vsg::ButtonReleaseEvent::create(this, event_time, mx, my, getButtonMask(wParam), getButtonUpEventDetail(msg)));
+        bufferedEvents.emplace_back(vsg::ButtonReleaseEvent::create(this, event_time, mx, my, getButtonMask(wParam), getButtonUpEventDetail(msg, HIWORD(wParam))));
 
         //::ReleaseCapture(); // should only release once all mouse buttons are released ??
         break;


### PR DESCRIPTION
## Description

This change adds (Windows-specific) code to determine whether the X1 or X2 mouse button was clicked. These new buttons are not actually used for anything yet.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

I compiled the 'MyFirstVsgApplication' against my changed VSG library and verified using the debugger that the correct code paths are executed.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
