### PR TITLE
[FIXED] duplicate entries in VkDescriptorPoolSizes

### DIFF
--- a/src/vsg/vk/Context.cpp
+++ b/src/vsg/vk/Context.cpp
@@ -167,9 +167,10 @@ void Context::getDescriptorPoolSizesToUse(uint32_t& maxSets, DescriptorPoolSizes
         auto itr = descriptorPoolSizes.begin();
         for (; itr != descriptorPoolSizes.end(); ++itr)
         {
-            if (itr->type == minimum_type && minimum_descriptorCount > itr->descriptorCount)
+            if (itr->type == minimum_type)
             {
-                itr->descriptorCount = minimum_descriptorCount;
+                if (minimum_descriptorCount > itr->descriptorCount)
+                    itr->descriptorCount = minimum_descriptorCount;
                 break;
             }
         }


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed duplicate entries added to the VkDescriptorPoolSizes when the required minimum descriptor count is already met.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Before:

```
info: created VkDescriptorPool, maxSets = 12
info: _availableDescriptorPoolSizes [DescriptorType = Count]
info: 0 = 5
info: 1 = 8
info: 2 = 5
Info: 6 = 15
info: 7 = 16
info: 0 = 5
info: 1 = 8
info: 2 = 5
info: 6 = 15
info: 7 = 16
```

After:
```
info: created VkDescriptorPool, maxSets = 12
info: _availableDescriptorPoolSizes [DescriptorType = Count]
info: 0 = 5
info: 1 = 8
info: 2 = 5
Info: 6 = 15
info: 7 = 16
```

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
