### PR TITLE
Fix typo and elaborate Windows instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -243,9 +243,16 @@ So now we have the Vulkan SDK installed and findable by CMake so we can go ahead
     mkdir build & cd build
     cmake .. -G "Visual Studio 15 2017 Win64"
     cmake .. -G "Visual Studio 16 2019" -A x64
-    cmake .. -G "Visual Studio 19 2022" -A x64
+    cmake .. -G "Visual Studio 17 2022" -A x64
 
-After running CMake open the generated VSG.sln file and build the All target. Once built you can run the install target. If you are using the default CMake install path (in Program Files folder), ensure you have started Visual Studio as administrator otherwise the install will fail.
+After running CMake open the generated VSG.sln file and build the All target. Different build configs can be selected from the dropdown at the top of the window. Once built you can run the install target. If you are using the default CMake install path (in Program Files folder), ensure you have started Visual Studio as administrator otherwise the install will fail.
+
+Alternatively, you can build from the command line with
+
+    cmake --build .
+    cmake --install .
+
+As above, you must be running from an elevated shell to install to Program Files, but unlike via the VS GUI, can append `--prefix Path\To\Another\Directory` to the install command to specify another directory. Different build configs can be specified by appending the `config` argument (e.g. `--config RelWithDebInfo`) to the above commands and rerunning them.
 
 It's recommended at this point that you add the VSG install path to your CMAKE_PREFIX_PATH, this will allow other CMake projects, like the vsgExamples project to find your VSG installation. CMAKE_PREFIX_PATH can be set as an environment variable on your system.
 


### PR DESCRIPTION
# Pull Request Template

## Description

I don't believe this fixes anything on the issue tracker.

There was a typo in the `-G` parameter for Visual Studio 2022 - it said `19` instead of `17`.

I felt it was prudent to mention how to build different build configs, and also how to build from the command line.

## Type of change

Please delete options that are not relevant.

- [x] This change ~~requires~~ *is* a documentation update

## How Has This Been Tested?

I built the VSG from PowerShell with MSVC 2022 without opening the GUI.

## Checklist:

- [x] My code follows the style guidelines of this project (as far as I can tell - there seems to be no formatting guide for Markdown, so I just matched the style of the rest of the file)
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ N/A
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ N/A
- [ ] ~~New and existing unit tests pass locally with my changes~~ N/A
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~ N/A
