### PR TITLE
About getAvailability in Descriptor Pool 

### DIFF
--- a/src/vsg/vk/DescriptorPool.cpp
+++ b/src/vsg/vk/DescriptorPool.cpp
@@ -136,7 +136,7 @@ bool DescriptorPool::getAvailability(uint32_t& maxSets, DescriptorPoolSizes& des
                 break;
             }
         }
-        if (itr != descriptorPoolSizes.end())
+        if (itr == descriptorPoolSizes.end())
         {
             descriptorPoolSizes.push_back(VkDescriptorPoolSize{availableType, availableCount});
         }


### PR DESCRIPTION
## Description

DescriptorPool.cpp line 147: change "itr != descriptorPoolSizes.end() " to "itr == descriptorPoolSizes.end()"

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
