### PR TITLE
[FIX] fixed reporting of modifier keys on the Windows platform

### DIFF
--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -88,6 +88,15 @@ namespace vsgWin32
             if (keyState[VK_CAPITAL] & 0x01) modifierMask |= vsg::KeyModifier::MODKEY_CapsLock;
             if (keyState[VK_NUMLOCK] & 0x01) modifierMask |= vsg::KeyModifier::MODKEY_NumLock;
 
+            // Check if the modifier keys are down (these are non-toggle keys, so the high-order bit is relevant!)
+            // again, vsg only has a side-independent modifier
+            if (keyState[VK_LSHIFT] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Shift;
+            if (keyState[VK_LSHIFT] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Shift;
+            if (keyState[VK_LCONTROL] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Control;
+            if (keyState[VK_RCONTROL] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Control;
+            if (keyState[VK_LMENU] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Alt;
+            if (keyState[VK_LMENU] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Alt;
+
             // This is the final keyModifier
             keyModifier = static_cast<vsg::KeyModifier>(modifierMask);
 


### PR DESCRIPTION
## Description

This change fixes the issue that modifier keys (Shift/Ctrl/Alt) were not being reported as being pressed (if a different key, say 'n', was being pressed/released).

Fixes #919

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I used the vsgInput and vsgIntersection examples

**Test Configuration**:
* OS: Windows 10

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
