### PR TITLE
[FIXED] AnimationPath would always repeat, ignoring its mode setting

### DIFF
--- a/include/vsg/utils/AnimationPath.h
+++ b/include/vsg/utils/AnimationPath.h
@@ -68,9 +68,10 @@ namespace vsg
         ref_ptr<Object> object;
         ref_ptr<AnimationPath> path;
         KeySymbol resetKey = KEY_Space;
-        clock::time_point start_point;
+        clock::time_point animationStartPoint;
+        clock::time_point periodStartPoint;
         unsigned int frameCount = 0;
-        double time = 0.0;
+        double totalTime = 0.0;
         bool printFrameStatsToConsole = false;
 
         void apply(Camera& camera) override;


### PR DESCRIPTION
## Description

This change fixes the issue that an AnimationPath would always repeat, even if its mode member was set to REPEAT or FORWARD_AND_BACK. This was caused by the needs of the (diagnostic) feature to display the framecount/framerate, which clamped the animation's total running time to the animation's period (ie run length). This change introduces a dedicated time point that tracks the current period's start time so that there's no need to reset the animation's start point (it's still reset using the (configurable) 'reset' key).

Fixes #930

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I used a modified vsgBuilder sample, where I created an AnimationPath

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
