### PR TITLE
[FIXED] removed warning

### DIFF
--- a/src/vsg/vk/DescriptorPool.cpp
+++ b/src/vsg/vk/DescriptorPool.cpp
@@ -82,7 +82,7 @@ ref_ptr<DescriptorSet::Implementation> DescriptorPool::allocateDescriptorSet(Des
     auto newDescriptorPoolSizes = _availableDescriptorPoolSizes;
     for (auto& [type, descriptorCount] : descriptorPoolSizes)
     {
-        size_t foundDescriptorCount = 0;
+        uint32_t foundDescriptorCount = 0;
         for (auto& [availableType, availableCount] : newDescriptorPoolSizes)
         {
             if (availableType == type)


### PR DESCRIPTION
## Description

5fdf6e910a9b9a74cf4721d96acfa1e26e55d6c5 introduced a new variable, which generates the following warning in MSVS

> warning C4267: 'initializing': conversion from 'size_t' to 'uint32_t', possible loss of data

- [X] Bug fix (non-breaking change which fixes an issue)
