### PR TITLE
[REMOVED] assignment to Sampler::maxLod

### DIFF
--- a/src/vsg/app/TransferTask.cpp
+++ b/src/vsg/app/TransferTask.cpp
@@ -255,7 +255,7 @@ void TransferTask::_transferImageInfo(VkCommandBuffer vk_commandBuffer, Frame& f
     auto height = data->height();
     auto depth = data->depth();
     auto mipmapOffsets = data->computeMipmapOffsets();
-    uint32_t mipLevels = vsg::computeNumMipMapLevels(data, imageInfo.sampler);
+    uint32_t mipLevels = std::min(vsg::computeNumMipMapLevels(data, imageInfo.sampler), imageInfo.imageView->image->mipLevels);
 
     auto source_offset = offset;
 

--- a/src/vsg/commands/CopyAndReleaseImage.cpp
+++ b/src/vsg/commands/CopyAndReleaseImage.cpp
@@ -30,7 +30,7 @@ CopyAndReleaseImage::~CopyAndReleaseImage()
 CopyAndReleaseImage::CopyData::CopyData(ref_ptr<BufferInfo> src, ref_ptr<ImageInfo> dest, uint32_t numMipMapLevels) :
     source(src),
     destination(dest),
-    mipLevels(numMipMapLevels)
+    mipLevels(std::min(numMipMapLevels, dest->imageView->image->mipLevels))
 {
     if (source->data)
     {

--- a/src/vsg/state/ImageInfo.cpp
+++ b/src/vsg/state/ImageInfo.cpp
@@ -153,8 +153,8 @@ void ImageInfo::computeNumMipMapLevels()
             const auto& properties = data->properties;
             if (properties.blockWidth > 1 || properties.blockHeight > 1 || properties.blockDepth > 1)
             {
-                sampler->maxLod = 0.0f;
                 mipLevels = 1;
+                generateMipmaps = false;
             }
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Removed assignment to possibly shared Sampler during ImageInfo::computeNumMipMapLevels. Fixed handling of Sampler::maxLod values beyond the Image's mipLevels.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested vsgExamples check_mip_support:
```
info: test1 passed
```

Tested application

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
