### PR TITLE
Allocate DescriptorBuffer memory from pools

### DIFF
--- a/src/vsg/state/BufferInfo.cpp
+++ b/src/vsg/state/BufferInfo.cpp
@@ -107,7 +107,7 @@ void BufferInfo::copyDataToBuffer(uint32_t deviceID)
         }
 
         void* buffer_data;
-        VkResult result = dm->map(offset, range, 0, &buffer_data);
+        VkResult result = dm->map(buffer->getMemoryOffset(deviceID) + offset, range, 0, &buffer_data);
         if (result != 0)
         {
             warn("BufferInfo::copyDataToBuffer() cannot copy data. vkMapMemory(..) failed with result = ", result);

--- a/src/vsg/state/DescriptorBuffer.cpp
+++ b/src/vsg/state/DescriptorBuffer.cpp
@@ -11,6 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/core/compare.h>
+#include <vsg/core/Exception.h>
 #include <vsg/io/Logger.h>
 #include <vsg/io/Options.h>
 #include <vsg/state/DescriptorBuffer.h>
@@ -177,15 +178,16 @@ void DescriptorBuffer::compile(Context& context)
                 if (bufferInfo->buffer->getDeviceMemory(deviceID) == nullptr)
                 {
                     auto memRequirements = bufferInfo->buffer->getMemoryRequirements(deviceID);
-                    auto memory = vsg::DeviceMemory::create(context.device, memRequirements, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-                    auto [allocated, offset] = memory->reserve(bufferInfo->buffer->size);
-                    if (allocated)
+                    auto [deviceMemory, offset]
+                        = context.deviceMemoryBufferPools->reserveMemory(memRequirements,
+                                                                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                    if (deviceMemory)
                     {
-                        bufferInfo->buffer->bind(memory, offset);
+                        bufferInfo->buffer->bind(deviceMemory, offset);
                     }
                     else
                     {
-                        warn("DescriptorBuffer::compile(..) unable to allocate buffer within associated DeviceMemory.");
+                        throw Exception{"Error: DescriptorBuffer::compile(..) unable to allocate buffer."};
                     }
                 }
             }


### PR DESCRIPTION
Allocate buffers that usually contain uniform data from memory pools, instead of directly calling vkAllocateMemory. Some drivers have very low limits on the number of Vulkan memory objects that can be allocated.

This fixes #942.
