### PR TITLE
[FIXED] valueCount for array mipmaps read from vsg::Data

### DIFF
--- a/include/vsg/commands/CopyAndReleaseImage.h
+++ b/include/vsg/commands/CopyAndReleaseImage.h
@@ -40,7 +40,6 @@ namespace vsg
             uint32_t width = 0;
             uint32_t height = 0;
             uint32_t depth = 0;
-            Data::MipmapOffsets mipmapOffsets;
 
             void record(CommandBuffer& commandBuffer) const;
         };

--- a/include/vsg/core/Data.h
+++ b/include/vsg/core/Data.h
@@ -189,8 +189,11 @@ namespace vsg
         uint32_t stride() const { return properties.stride ? properties.stride : static_cast<uint32_t>(valueSize()); }
 
         using MipmapOffsets = std::vector<size_t>;
-        MipmapOffsets computeMipmapOffsets() const;
-        static size_t computeValueCountIncludingMipmaps(size_t w, size_t h, size_t d, uint32_t maxNumMipmaps);
+        // Note, computeMipmapOffsets will naively interpret the data dimensions as the image dimensions
+        // and return incorrect values for layered images.
+        MipmapOffsets computeMipmapOffsets() const; // deprecated
+        static size_t computeValueCountIncludingMipmaps(size_t w, size_t h, size_t d, uint32_t maxNumMipmaps); // deprecated
+        static size_t computeValueCountIncludingMipmaps(size_t w, size_t h, size_t d, uint32_t maxNumMipmaps, uint32_t arrayLayers);
 
         /// increment the ModifiedCount to signify the data has been modified
         void dirty() { ++_modifiedCount; }

--- a/include/vsg/state/ImageInfo.h
+++ b/include/vsg/state/ImageInfo.h
@@ -99,6 +99,18 @@ namespace vsg
     extern VSG_DECLSPEC FormatTraits getFormatTraits(VkFormat format, bool default_one = true);
 
     /// return the number of mip map levels specified by Data/Sampler.
-    extern VSG_DECLSPEC uint32_t computeNumMipMapLevels(const Data* data, const Sampler* sampler);
+    extern VSG_DECLSPEC uint32_t computeNumMipMapLevels(const Data* data, const Sampler* sampler); // deprecated
+    extern VSG_DECLSPEC uint32_t computeNumMipMapLevels(uint32_t w, uint32_t h, uint32_t d, const Sampler* sampler);
+    /// return the size of a full mipmap chain for dimensions.
+    /// equivalent to: log2(max(w,h,d))+1
+    /// See Vulkan spec 12.3.2 "Image Miplevel Sizing"
+    extern VSG_DECLSPEC uint32_t computeNumMipMapLevels(uint32_t w, uint32_t h, uint32_t d);
+
+    /// return the number of mipLevels that can be read from vsg::Data for this vsg::Image.
+    extern VSG_DECLSPEC uint32_t computeNumMipMapLevels(const vsg::Data::Properties& properties, const Image* image);
+
+    /// return the number of Data values required for Image including mipmaps
+    /// Note, Data::valueCount() doesn't support layers correctly
+    extern VSG_DECLSPEC size_t computeValueCount(const vsg::Data::Properties& properties, const Image* image);
 
 } // namespace vsg

--- a/include/vsg/state/ImageView.h
+++ b/include/vsg/state/ImageView.h
@@ -68,6 +68,6 @@ namespace vsg
     extern VSG_DECLSPEC ref_ptr<ImageView> createImageView(Device* device, ref_ptr<Image> image, VkImageAspectFlags aspectFlags);
 
     /// convenience function that uploads staging buffer data to device including mipmaps.
-    extern VSG_DECLSPEC void transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetImageLayout, Data::Properties properties, uint32_t width, uint32_t height, uint32_t depth, uint32_t mipLevels, const Data::MipmapOffsets& mipmapOffsets, ref_ptr<Buffer> stagingBuffer, VkDeviceSize stagingBufferOffset, VkCommandBuffer vk_commandBuffer, vsg::Device* device);
+    extern VSG_DECLSPEC void transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetImageLayout, const Data::Properties& properties, uint32_t width, uint32_t height, uint32_t depth, ref_ptr<Buffer> stagingBuffer, VkDeviceSize stagingBufferOffset, VkCommandBuffer vk_commandBuffer, vsg::Device* device);
 
 } // namespace vsg

--- a/src/vsg/core/Data.cpp
+++ b/src/vsg/core/Data.cpp
@@ -143,9 +143,14 @@ Data::MipmapOffsets Data::computeMipmapOffsets() const
 
 std::size_t Data::computeValueCountIncludingMipmaps(std::size_t w, std::size_t h, std::size_t d, uint32_t numMipmaps)
 {
-    if (numMipmaps <= 1) return w * h * d;
+    return computeValueCountIncludingMipmaps(w, h, d, numMipmaps, 1);
+}
 
-    std::size_t lastPosition = (w * h * d);
+std::size_t Data::computeValueCountIncludingMipmaps(std::size_t w, std::size_t h, std::size_t d, uint32_t numMipmaps, uint32_t arrayLayers)
+{
+    if (numMipmaps <= 1) return w * h * d * arrayLayers;
+
+    std::size_t lastPosition = (w * h * d * arrayLayers);
     while (numMipmaps > 1 && (w > 1 || h > 1 || d > 1))
     {
         --numMipmaps;
@@ -154,7 +159,7 @@ std::size_t Data::computeValueCountIncludingMipmaps(std::size_t w, std::size_t h
         if (h > 1) h /= 2;
         if (d > 1) d /= 2;
 
-        lastPosition += (w * h * d);
+        lastPosition += (w * h * d * arrayLayers);
     }
 
     return lastPosition;

--- a/src/vsg/state/DescriptorImage.cpp
+++ b/src/vsg/state/DescriptorImage.cpp
@@ -118,7 +118,7 @@ void DescriptorImage::compile(Context& context)
             if (imageView.image && imageView.image->syncModifiedCount(context.deviceID))
             {
                 auto& image = *imageView.image;
-                context.copy(image.data, imageInfo, image.mipLevels);
+                context.copy(image.data, imageInfo);
             }
         }
     }

--- a/src/vsg/state/ImageView.cpp
+++ b/src/vsg/state/ImageView.cpp
@@ -200,7 +200,7 @@ ref_ptr<ImageView> vsg::createImageView(Device* device, ref_ptr<Image> image, Vk
     return imageView;
 }
 
-void vsg::transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetImageLayout, Data::Properties properties, uint32_t width, uint32_t height, uint32_t depth, uint32_t mipLevels, const Data::MipmapOffsets& mipmapOffsets, ref_ptr<Buffer> stagingBuffer, VkDeviceSize stagingBufferOffset, VkCommandBuffer commandBuffer, vsg::Device* device)
+void vsg::transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetImageLayout, const Data::Properties& properties, uint32_t width, uint32_t height, uint32_t depth, ref_ptr<Buffer> stagingBuffer, VkDeviceSize stagingBufferOffset, VkCommandBuffer commandBuffer, vsg::Device* device)
 {
     ref_ptr<Image> textureImage(imageView->image);
     auto aspectMask = imageView->subresourceRange.aspectMask;
@@ -240,8 +240,9 @@ void vsg::transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetIm
 
     const auto valueSize = properties.stride; // data->valueSize();
 
-    bool useDataMipmaps = (mipLevels > 1) && (mipmapOffsets.size() > 1);
-    bool generateMipmaps = (mipLevels > 1) && (mipmapOffsets.size() <= 1);
+    uint32_t mipLevels = imageView->image->mipLevels;
+    bool useDataMipmaps = (mipLevels > 1) && (properties.maxNumMipmaps > 1);
+    bool generateMipmaps = (mipLevels > 1) && (properties.maxNumMipmaps <= 1);
 
     auto vk_textureImage = textureImage->vk(device->deviceID);
 


### PR DESCRIPTION
# Pull Request Template

## Description

Added vsg::computeValueCount used in CopyAndReleaseImage / TransferTask to get the correct value count for layered, mipmapped image data.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested converting 2D images to 2D image array.

Tested vsgvalidate array_data_mipmaps:
```
info: array_data_mipmaps test passed
```

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
