### PR TITLE
renamed "Uniform" to "DescriptorBuffer"

### DIFF
--- a/include/vsg/state/DescriptorBuffer.h
+++ b/include/vsg/state/DescriptorBuffer.h
@@ -19,7 +19,7 @@ namespace vsg
 {
 
     /// DescriptorBuffer is a Descriptor class that encapsulates the bufferInfoList used to set VkWriteDescriptorSet::pBufferInfo settings
-    /// DescriptorBuffer is a means for passing uniforms to shaders.
+    /// DescriptorBuffer is a means for passing uniform and storage buffers to shaders.
     class VSG_DECLSPEC DescriptorBuffer : public Inherit<Descriptor, DescriptorBuffer>
     {
     public:

--- a/include/vsg/state/StateCommand.h
+++ b/include/vsg/state/StateCommand.h
@@ -17,7 +17,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 namespace vsg
 {
 
-    /// Base class for Vulkan commands associated with state, such as binding graphics pipelines and descriptor sets (textures and uniforms).
+    /// Base class for Vulkan commands associated with state, such as binding graphics
+    /// pipelines and descriptor sets for textures, uniform buffers and storage buffers.
     /// StateCommands can be attached directly as nodes in the scene graph, or more typically assigned to StateGroup nodes to enable push/popping of state.
     class VSG_DECLSPEC StateCommand : public Inherit<Command, StateCommand>
     {

--- a/include/vsg/utils/GraphicsPipelineConfigurator.h
+++ b/include/vsg/utils/GraphicsPipelineConfigurator.h
@@ -45,18 +45,25 @@ namespace vsg
         bool two_sided = false;
 
         bool enableTexture(const std::string& name);
-        bool enableUniform(const std::string& name);
+        bool enableBuffer(const std::string& name);
 
         bool assignTexture(const std::string& name, ref_ptr<Data> textureData = {}, ref_ptr<Sampler> sampler = {}, uint32_t dstArrayElement = 0);
         bool assignTexture(const std::string& name, const ImageInfoList& imageInfoList, uint32_t dstArrayElement = 0);
 
-        bool assignUniform(const std::string& name, ref_ptr<Data> data = {}, uint32_t dstArrayElement = 0);
-        bool assignUniform(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement = 0);
+        bool assignBuffer(const std::string& name, ref_ptr<Data> data = {}, uint32_t dstArrayElement = 0);
+        bool assignBuffer(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement = 0);
 
         bool assignDescriptor(uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Descriptor> descriptor);
 
-        /// call after all the textures/uniforms have been explictly assigned to add in textures/uniforms descriptors that are enabled by default (define == "").
+        /// call after all the textures and buffers have been explictly assigned to add in texture/buffer descriptors that are enabled by default (define == "").
         bool assignDefaults();
+
+        /// deprecated. use enableBuffer() instead
+        bool enableUniform(const std::string& name);
+        /// deprecated. use assignBuffer() instead
+        bool assignUniform(const std::string& name, ref_ptr<Data> data = {}, uint32_t dstArrayElement = 0);
+        /// deprecated. use assignBuffer() instead
+        bool assignUniform(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement = 0);
 
         std::set<std::string> assigned;
         std::set<std::string> defines;
@@ -105,11 +112,11 @@ namespace vsg
 
         bool enableArray(const std::string& name, VkVertexInputRate vertexInputRate, uint32_t stride, VkFormat format = VK_FORMAT_UNDEFINED);
         bool enableTexture(const std::string& name);
-        bool enableUniform(const std::string& name);
+        bool enableBuffer(const std::string& name);
 
         bool assignArray(DataList& arrays, const std::string& name, VkVertexInputRate vertexInputRate, ref_ptr<Data> array);
         bool assignTexture(const std::string& name, ref_ptr<Data> textureData = {}, ref_ptr<Sampler> sampler = {});
-        bool assignUniform(const std::string& name, ref_ptr<Data> data = {});
+        bool assignBuffer(const std::string& name, ref_ptr<Data> data = {});
 
         // setup by assign calls
         ref_ptr<ShaderCompileSettings> shaderHints;
@@ -127,6 +134,11 @@ namespace vsg
         ref_ptr<PipelineLayout> layout;
         ref_ptr<GraphicsPipeline> graphicsPipeline;
         ref_ptr<BindGraphicsPipeline> bindGraphicsPipeline;
+
+        /// deprecated. use enableUniform() instead
+        bool enableUniform(const std::string& name);
+        /// deprecated. use assignBuffer() instead
+        bool assignUniform(const std::string& name, ref_ptr<Data> data = {});
 
     protected:
         void _assignShaderSetSettings();

--- a/include/vsg/utils/GraphicsPipelineConfigurator.h
+++ b/include/vsg/utils/GraphicsPipelineConfigurator.h
@@ -58,11 +58,13 @@ namespace vsg
         /// call after all the textures and buffers have been explictly assigned to add in texture/buffer descriptors that are enabled by default (define == "").
         bool assignDefaults();
 
-        /// deprecated. use enableBuffer() instead
+        [[deprecated("use enableBuffer()")]]
         bool enableUniform(const std::string& name);
-        /// deprecated. use assignBuffer() instead
+
+        [[deprecated("use assignBuffer()")]]
         bool assignUniform(const std::string& name, ref_ptr<Data> data = {}, uint32_t dstArrayElement = 0);
-        /// deprecated. use assignBuffer() instead
+
+        [[deprecated("use assignBuffer()")]]
         bool assignUniform(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement = 0);
 
         std::set<std::string> assigned;
@@ -135,9 +137,10 @@ namespace vsg
         ref_ptr<GraphicsPipeline> graphicsPipeline;
         ref_ptr<BindGraphicsPipeline> bindGraphicsPipeline;
 
-        /// deprecated. use enableUniform() instead
+        [[deprecated("use enableBuffer()")]]
         bool enableUniform(const std::string& name);
-        /// deprecated. use assignBuffer() instead
+
+        [[deprecated("use assignBuffer()")]]
         bool assignUniform(const std::string& name, ref_ptr<Data> data = {});
 
     protected:

--- a/include/vsg/utils/GraphicsPipelineConfigurator.h
+++ b/include/vsg/utils/GraphicsPipelineConfigurator.h
@@ -45,26 +45,29 @@ namespace vsg
         bool two_sided = false;
 
         bool enableTexture(const std::string& name);
-        bool enableBuffer(const std::string& name);
+        bool enableDescriptorBuffer(const std::string& name);
 
         bool assignTexture(const std::string& name, ref_ptr<Data> textureData = {}, ref_ptr<Sampler> sampler = {}, uint32_t dstArrayElement = 0);
         bool assignTexture(const std::string& name, const ImageInfoList& imageInfoList, uint32_t dstArrayElement = 0);
 
-        bool assignBuffer(const std::string& name, ref_ptr<Data> data = {}, uint32_t dstArrayElement = 0);
-        bool assignBuffer(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement = 0);
+        bool assignDescriptorBuffer(const std::string& name, ref_ptr<Data> data = {}, uint32_t dstArrayElement = 0);
+        bool assignDescriptorBuffer(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement = 0);
 
         bool assignDescriptor(uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Descriptor> descriptor);
 
         /// call after all the textures and buffers have been explictly assigned to add in texture/buffer descriptors that are enabled by default (define == "").
         bool assignDefaults();
 
-        [[deprecated("use enableBuffer()")]]
+        /// deprecated: use enableDescriptorBuffer()
+        [[deprecated("use enableDescriptorBuffer()")]]
         bool enableUniform(const std::string& name);
 
-        [[deprecated("use assignBuffer()")]]
+        /// deprecated: use assignDescriptorBuffer()
+        [[deprecated("use assignDescriptorBuffer()")]]
         bool assignUniform(const std::string& name, ref_ptr<Data> data = {}, uint32_t dstArrayElement = 0);
 
-        [[deprecated("use assignBuffer()")]]
+        /// deprecated: use assignDescriptorBuffer()
+        [[deprecated("use assignDescriptorBuffer()")]]
         bool assignUniform(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement = 0);
 
         std::set<std::string> assigned;
@@ -114,11 +117,11 @@ namespace vsg
 
         bool enableArray(const std::string& name, VkVertexInputRate vertexInputRate, uint32_t stride, VkFormat format = VK_FORMAT_UNDEFINED);
         bool enableTexture(const std::string& name);
-        bool enableBuffer(const std::string& name);
+        bool enableDescriptorBuffer(const std::string& name);
 
         bool assignArray(DataList& arrays, const std::string& name, VkVertexInputRate vertexInputRate, ref_ptr<Data> array);
         bool assignTexture(const std::string& name, ref_ptr<Data> textureData = {}, ref_ptr<Sampler> sampler = {});
-        bool assignBuffer(const std::string& name, ref_ptr<Data> data = {});
+        bool assignDescriptorBuffer(const std::string& name, ref_ptr<Data> data = {});
 
         // setup by assign calls
         ref_ptr<ShaderCompileSettings> shaderHints;
@@ -137,10 +140,12 @@ namespace vsg
         ref_ptr<GraphicsPipeline> graphicsPipeline;
         ref_ptr<BindGraphicsPipeline> bindGraphicsPipeline;
 
-        [[deprecated("use enableBuffer()")]]
+        /// deprecated: use enableDescriptorBuffer()
+        [[deprecated("use enableDescriptorBuffer()")]]
         bool enableUniform(const std::string& name);
 
-        [[deprecated("use assignBuffer()")]]
+        /// deprecated: use assignDescriptorBuffer()
+        [[deprecated("use assignDescriptorBuffer()")]]
         bool assignUniform(const std::string& name, ref_ptr<Data> data = {});
 
     protected:

--- a/include/vsg/utils/ShaderSet.h
+++ b/include/vsg/utils/ShaderSet.h
@@ -178,15 +178,18 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        /// deprecated. use descriptorBindings
+        /// deprecated: use descriptorBindings
         std::vector<DescriptorBinding>& uniformBindings = descriptorBindings;
 
+        /// deprecated: use addDescriptorBinding()
         [[deprecated("use addDescriptorBinding()")]]
         void addUniformBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data);
 
+        /// deprecated: use getDescriptorBinding()
         [[deprecated("use getDescriptorBinding()")]]
         DescriptorBinding& getUniformBinding(const std::string& name);
 
+        /// deprecated: use getDescriptorBinding()
         [[deprecated("use getDescriptorBinding()")]]
         const DescriptorBinding& getUniformBinding(const std::string& name) const;
 
@@ -207,7 +210,7 @@ namespace vsg
     /// create a ShaderSet for Physics Based Rendering
     extern VSG_DECLSPEC ref_ptr<ShaderSet> createPhysicsBasedRenderingShaderSet(ref_ptr<const Options> options = {});
 
-    /// deprecated. use vsg::DescriptorBinding
+    /// deprecated: use vsg::DescriptorBinding
     using UniformBinding = DescriptorBinding;
 
 } // namespace vsg

--- a/include/vsg/utils/ShaderSet.h
+++ b/include/vsg/utils/ShaderSet.h
@@ -35,7 +35,7 @@ namespace vsg
     };
     VSG_type_name(vsg::AttributeBinding);
 
-    struct VSG_DECLSPEC UniformBinding
+    struct VSG_DECLSPEC BufferBinding
     {
         std::string name;
         std::string define;
@@ -46,11 +46,11 @@ namespace vsg
         VkShaderStageFlags stageFlags = 0;
         ref_ptr<Data> data;
 
-        int compare(const UniformBinding& rhs) const;
+        int compare(const BufferBinding& rhs) const;
 
         explicit operator bool() const noexcept { return !name.empty(); }
     };
-    VSG_type_name(vsg::UniformBinding);
+    VSG_type_name(vsg::BufferBinding);
 
     struct VSG_DECLSPEC PushConstantRange
     {
@@ -116,7 +116,7 @@ namespace vsg
         ShaderStages stages;
 
         std::vector<AttributeBinding> attributeBindings;
-        std::vector<UniformBinding> uniformBindings;
+        std::vector<BufferBinding> bufferBindings;
         std::vector<PushConstantRange> pushConstantRanges;
         std::vector<DefinesArrayState> definesArrayStates; // put more constrained ArrayState matches first so they are matched first.
         std::set<std::string> optionalDefines;
@@ -133,8 +133,8 @@ namespace vsg
         /// add an attribute binding, Not thread safe, should only be called when initially setting up the ShaderSet
         void addAttributeBinding(std::string name, std::string define, uint32_t location, VkFormat format, ref_ptr<Data> data);
 
-        /// add an uniform binding. Not thread safe, should only be called when initially setting up the ShaderSet
-        void addUniformBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data);
+        /// add a uniform, storage or texture binding. Not thread safe, should only be called when initially setting up the ShaderSet
+        void addBufferBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data);
 
         /// add a push constant range. Not thread safe, should only be called when initially setting up the ShaderSet
         void addPushConstantRange(std::string name, std::string define, VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size);
@@ -142,14 +142,14 @@ namespace vsg
         /// get the AttributeBinding associated with name
         AttributeBinding& getAttributeBinding(const std::string& name);
 
-        /// get the UniformBinding associated with name
-        UniformBinding& getUniformBinding(const std::string& name);
+        /// get the BufferBinding (uniform, storage or texture) associated with name
+        BufferBinding& getBufferBinding(const std::string& name);
 
         /// get the const AttributeBinding associated with name
         const AttributeBinding& getAttributeBinding(const std::string& name) const;
 
-        /// get the const UniformBinding associated with name
-        const UniformBinding& getUniformBinding(const std::string& name) const;
+        /// get the const BufferBinding (uniform, storage or texture) associated with name
+        const BufferBinding& getBufferBinding(const std::string& name) const;
 
         /// get the first ArrayState that has matches with defines in the specified list of defines.
         ref_ptr<ArrayState> getSuitableArrayState(const std::set<std::string>& defines) const;
@@ -157,7 +157,7 @@ namespace vsg
         /// get the ShaderStages variant that uses specified ShaderCompileSettings.
         ShaderStages getShaderStages(ref_ptr<ShaderCompileSettings> scs = {});
 
-        /// return the <minimum_set, maximum_set+1> range of set numbers encompassing UniformBindings
+        /// return the <minimum_set, maximum_set+1> range of set numbers encompassing BufferBindings
         std::pair<uint32_t, uint32_t> descriptorSetRange() const;
 
         /// create the descriptor set layout.
@@ -178,11 +178,18 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
+        /// deprecated. use addBufferBinding() instead
+        void addUniformBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data);
+        /// deprecated. use getBufferBinding() instead
+        BufferBinding& getUniformBinding(const std::string& name);
+        /// deprecated. use getBufferBinding() instead
+        const BufferBinding& getUniformBinding(const std::string& name) const;
+
     protected:
         virtual ~ShaderSet();
 
         AttributeBinding _nullAttributeBinding;
-        UniformBinding _nullUniformBinding;
+        BufferBinding _nullBufferBinding;
     };
     VSG_type_name(vsg::ShaderSet);
 

--- a/include/vsg/utils/ShaderSet.h
+++ b/include/vsg/utils/ShaderSet.h
@@ -35,7 +35,7 @@ namespace vsg
     };
     VSG_type_name(vsg::AttributeBinding);
 
-    struct VSG_DECLSPEC BufferBinding
+    struct VSG_DECLSPEC DescriptorBinding
     {
         std::string name;
         std::string define;
@@ -46,11 +46,11 @@ namespace vsg
         VkShaderStageFlags stageFlags = 0;
         ref_ptr<Data> data;
 
-        int compare(const BufferBinding& rhs) const;
+        int compare(const DescriptorBinding& rhs) const;
 
         explicit operator bool() const noexcept { return !name.empty(); }
     };
-    VSG_type_name(vsg::BufferBinding);
+    VSG_type_name(vsg::DescriptorBinding);
 
     struct VSG_DECLSPEC PushConstantRange
     {
@@ -116,7 +116,7 @@ namespace vsg
         ShaderStages stages;
 
         std::vector<AttributeBinding> attributeBindings;
-        std::vector<BufferBinding> bufferBindings;
+        std::vector<DescriptorBinding> descriptorBindings;
         std::vector<PushConstantRange> pushConstantRanges;
         std::vector<DefinesArrayState> definesArrayStates; // put more constrained ArrayState matches first so they are matched first.
         std::set<std::string> optionalDefines;
@@ -134,7 +134,7 @@ namespace vsg
         void addAttributeBinding(std::string name, std::string define, uint32_t location, VkFormat format, ref_ptr<Data> data);
 
         /// add a uniform, storage or texture binding. Not thread safe, should only be called when initially setting up the ShaderSet
-        void addBufferBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data);
+        void addDescriptorBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data);
 
         /// add a push constant range. Not thread safe, should only be called when initially setting up the ShaderSet
         void addPushConstantRange(std::string name, std::string define, VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size);
@@ -142,14 +142,14 @@ namespace vsg
         /// get the AttributeBinding associated with name
         AttributeBinding& getAttributeBinding(const std::string& name);
 
-        /// get the BufferBinding (uniform, storage or texture) associated with name
-        BufferBinding& getBufferBinding(const std::string& name);
+        /// get the DescriptorBinding (uniform, storage or texture) associated with name
+        DescriptorBinding& getDescriptorBinding(const std::string& name);
 
         /// get the const AttributeBinding associated with name
         const AttributeBinding& getAttributeBinding(const std::string& name) const;
 
-        /// get the const BufferBinding (uniform, storage or texture) associated with name
-        const BufferBinding& getBufferBinding(const std::string& name) const;
+        /// get the const DescriptorBinding (uniform, storage or texture) associated with name
+        const DescriptorBinding& getDescriptorBinding(const std::string& name) const;
 
         /// get the first ArrayState that has matches with defines in the specified list of defines.
         ref_ptr<ArrayState> getSuitableArrayState(const std::set<std::string>& defines) const;
@@ -157,7 +157,7 @@ namespace vsg
         /// get the ShaderStages variant that uses specified ShaderCompileSettings.
         ShaderStages getShaderStages(ref_ptr<ShaderCompileSettings> scs = {});
 
-        /// return the <minimum_set, maximum_set+1> range of set numbers encompassing BufferBindings
+        /// return the <minimum_set, maximum_set+1> range of set numbers encompassing DescriptorBindings
         std::pair<uint32_t, uint32_t> descriptorSetRange() const;
 
         /// create the descriptor set layout.
@@ -178,18 +178,23 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        /// deprecated. use addBufferBinding() instead
+        /// deprecated. use descriptorBindings
+        std::vector<DescriptorBinding>& uniformBindings = descriptorBindings;
+
+        [[deprecated("use addDescriptorBinding()")]]
         void addUniformBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data);
-        /// deprecated. use getBufferBinding() instead
-        BufferBinding& getUniformBinding(const std::string& name);
-        /// deprecated. use getBufferBinding() instead
-        const BufferBinding& getUniformBinding(const std::string& name) const;
+
+        [[deprecated("use getDescriptorBinding()")]]
+        DescriptorBinding& getUniformBinding(const std::string& name);
+
+        [[deprecated("use getDescriptorBinding()")]]
+        const DescriptorBinding& getUniformBinding(const std::string& name) const;
 
     protected:
         virtual ~ShaderSet();
 
         AttributeBinding _nullAttributeBinding;
-        BufferBinding _nullBufferBinding;
+        DescriptorBinding _nullDescriptorBinding;
     };
     VSG_type_name(vsg::ShaderSet);
 
@@ -201,5 +206,8 @@ namespace vsg
 
     /// create a ShaderSet for Physics Based Rendering
     extern VSG_DECLSPEC ref_ptr<ShaderSet> createPhysicsBasedRenderingShaderSet(ref_ptr<const Options> options = {});
+
+    /// deprecated. use vsg::DescriptorBinding
+    using UniformBinding = DescriptorBinding;
 
 } // namespace vsg

--- a/src/vsg/io/tile.cpp
+++ b/src/vsg/io/tile.cpp
@@ -327,7 +327,7 @@ void tile::init(vsg::ref_ptr<const vsg::Options> options)
         _graphicsPipelineConfig->enableTexture("displacementMap");
     }
 #endif
-    _graphicsPipelineConfig->enableBuffer("material");
+    _graphicsPipelineConfig->enableDescriptorBuffer("material");
 
     _graphicsPipelineConfig->enableArray("vsg_Vertex", VK_VERTEX_INPUT_RATE_VERTEX, 12, VK_FORMAT_R32G32B32_SFLOAT);
     _graphicsPipelineConfig->enableArray("vsg_Normal", VK_VERTEX_INPUT_RATE_VERTEX, 12, VK_FORMAT_R32G32B32_SFLOAT);

--- a/src/vsg/io/tile.cpp
+++ b/src/vsg/io/tile.cpp
@@ -334,7 +334,7 @@ void tile::init(vsg::ref_ptr<const vsg::Options> options)
     _graphicsPipelineConfig->enableArray("vsg_TexCoord0", VK_VERTEX_INPUT_RATE_VERTEX, 8, VK_FORMAT_R32G32_SFLOAT);
     _graphicsPipelineConfig->enableArray("vsg_Color", VK_VERTEX_INPUT_RATE_INSTANCE, 16, VK_FORMAT_R32G32B32A32_SFLOAT);
 
-    if (auto& materialBinding = _shaderSet->getBufferBinding("material"))
+    if (auto& materialBinding = _shaderSet->getDescriptorBinding("material"))
     {
         ref_ptr<Data> mat = materialBinding.data;
         if (!mat) mat = vsg::PhongMaterialValue::create();

--- a/src/vsg/io/tile.cpp
+++ b/src/vsg/io/tile.cpp
@@ -327,14 +327,14 @@ void tile::init(vsg::ref_ptr<const vsg::Options> options)
         _graphicsPipelineConfig->enableTexture("displacementMap");
     }
 #endif
-    _graphicsPipelineConfig->enableUniform("material");
+    _graphicsPipelineConfig->enableBuffer("material");
 
     _graphicsPipelineConfig->enableArray("vsg_Vertex", VK_VERTEX_INPUT_RATE_VERTEX, 12, VK_FORMAT_R32G32B32_SFLOAT);
     _graphicsPipelineConfig->enableArray("vsg_Normal", VK_VERTEX_INPUT_RATE_VERTEX, 12, VK_FORMAT_R32G32B32_SFLOAT);
     _graphicsPipelineConfig->enableArray("vsg_TexCoord0", VK_VERTEX_INPUT_RATE_VERTEX, 8, VK_FORMAT_R32G32_SFLOAT);
     _graphicsPipelineConfig->enableArray("vsg_Color", VK_VERTEX_INPUT_RATE_INSTANCE, 16, VK_FORMAT_R32G32B32A32_SFLOAT);
 
-    if (auto& materialBinding = _shaderSet->getUniformBinding("material"))
+    if (auto& materialBinding = _shaderSet->getBufferBinding("material"))
     {
         ref_ptr<Data> mat = materialBinding.data;
         if (!mat) mat = vsg::PhongMaterialValue::create();

--- a/src/vsg/state/BufferInfo.cpp
+++ b/src/vsg/state/BufferInfo.cpp
@@ -198,6 +198,7 @@ bool vsg::createBufferAndTransferData(Context& context, const BufferInfoList& bu
 
     VkDeviceSize alignment = 4;
     if (usage == VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT) alignment = device->getPhysicalDevice()->getProperties().limits.minUniformBufferOffsetAlignment;
+    else if (usage == VK_BUFFER_USAGE_STORAGE_BUFFER_BIT) alignment = device->getPhysicalDevice()->getProperties().limits.minStorageBufferOffsetAlignment;
 
     VkDeviceSize totalSize = 0;
     VkDeviceSize offset = 0;
@@ -303,6 +304,7 @@ BufferInfoList vsg::createHostVisibleBuffer(Device* device, const DataList& data
 
     VkDeviceSize alignment = 4;
     if (usage == VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT) alignment = device->getPhysicalDevice()->getProperties().limits.minUniformBufferOffsetAlignment;
+    else if (usage == VK_BUFFER_USAGE_STORAGE_BUFFER_BIT) alignment = device->getPhysicalDevice()->getProperties().limits.minStorageBufferOffsetAlignment;
 
     VkDeviceSize totalSize = 0;
     VkDeviceSize offset = 0;

--- a/src/vsg/text/GpuLayoutTechnique.cpp
+++ b/src/vsg/text/GpuLayoutTechnique.cpp
@@ -249,8 +249,8 @@ void GpuLayoutTechnique::setup(Text* text, uint32_t minimumAllocation, ref_ptr<c
         config->assignTexture("textureAtlas", text->font->atlas, sampler);
         config->assignTexture("glyphMetrics", glyphMetricsProxy, glyphMetricSampler);
 
-        config->assignUniform("textLayout", layoutValue);
-        config->assignUniform("text", textArray);
+        config->assignBuffer("textLayout", layoutValue);
+        config->assignBuffer("text", textArray);
 
         // Set the InputAssemblyState.topology
         struct SetPipelineStates : public Visitor

--- a/src/vsg/text/GpuLayoutTechnique.cpp
+++ b/src/vsg/text/GpuLayoutTechnique.cpp
@@ -249,8 +249,8 @@ void GpuLayoutTechnique::setup(Text* text, uint32_t minimumAllocation, ref_ptr<c
         config->assignTexture("textureAtlas", text->font->atlas, sampler);
         config->assignTexture("glyphMetrics", glyphMetricsProxy, glyphMetricSampler);
 
-        config->assignBuffer("textLayout", layoutValue);
-        config->assignBuffer("text", textArray);
+        config->assignDescriptorBuffer("textLayout", layoutValue);
+        config->assignDescriptorBuffer("text", textArray);
 
         // Set the InputAssemblyState.topology
         struct SetPipelineStates : public Visitor

--- a/src/vsg/utils/Builder.cpp
+++ b/src/vsg/utils/Builder.cpp
@@ -81,7 +81,7 @@ ref_ptr<StateGroup> Builder::createStateGroup(const StateInfo& stateInfo)
         graphicsPipelineConfig->assignTexture("displacementMap", stateInfo.displacementMap, sampler);
     }
 
-    if (auto& materialBinding = activeShaderSet->getBufferBinding("material"))
+    if (auto& materialBinding = activeShaderSet->getDescriptorBinding("material"))
     {
         ref_ptr<Data> mat = materialBinding.data;
         if (!mat) mat = vsg::PhongMaterialValue::create();

--- a/src/vsg/utils/Builder.cpp
+++ b/src/vsg/utils/Builder.cpp
@@ -85,7 +85,7 @@ ref_ptr<StateGroup> Builder::createStateGroup(const StateInfo& stateInfo)
     {
         ref_ptr<Data> mat = materialBinding.data;
         if (!mat) mat = vsg::PhongMaterialValue::create();
-        graphicsPipelineConfig->assignBuffer("material", mat);
+        graphicsPipelineConfig->assignDescriptorBuffer("material", mat);
     }
 
     graphicsPipelineConfig->enableArray("vsg_Vertex", VK_VERTEX_INPUT_RATE_VERTEX, 12);

--- a/src/vsg/utils/Builder.cpp
+++ b/src/vsg/utils/Builder.cpp
@@ -81,11 +81,11 @@ ref_ptr<StateGroup> Builder::createStateGroup(const StateInfo& stateInfo)
         graphicsPipelineConfig->assignTexture("displacementMap", stateInfo.displacementMap, sampler);
     }
 
-    if (auto& materialBinding = activeShaderSet->getUniformBinding("material"))
+    if (auto& materialBinding = activeShaderSet->getBufferBinding("material"))
     {
         ref_ptr<Data> mat = materialBinding.data;
         if (!mat) mat = vsg::PhongMaterialValue::create();
-        graphicsPipelineConfig->assignUniform("material", mat);
+        graphicsPipelineConfig->assignBuffer("material", mat);
     }
 
     graphicsPipelineConfig->enableArray("vsg_Vertex", VK_VERTEX_INPUT_RATE_VERTEX, 12);

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -149,7 +149,7 @@ bool DescriptorConfigurator::assignTexture(const std::string& name, const ImageI
     return false;
 }
 
-bool DescriptorConfigurator::enableBuffer(const std::string& name)
+bool DescriptorConfigurator::enableDescriptorBuffer(const std::string& name)
 {
     if (auto& bufferBinding = shaderSet->getDescriptorBinding(name))
     {
@@ -166,15 +166,15 @@ bool DescriptorConfigurator::enableBuffer(const std::string& name)
     return false;
 }
 
-/// deprecated. use DescriptorConfigurator::enableBuffer() instead
+/// deprecated: use DescriptorConfigurator::enableDescriptorBuffer() instead
 bool DescriptorConfigurator::enableUniform(const std::string& name)
 {
     warn("DescriptorConfigurator::enableUniform() has been deprecated."
-         " Use DescriptorConfigurator::enableBuffer() instead.");
-    return enableBuffer(name);
+         " Use DescriptorConfigurator::enableDescriptorBuffer() instead.");
+    return enableDescriptorBuffer(name);
 }
 
-bool DescriptorConfigurator::assignBuffer(const std::string& name, ref_ptr<Data> data, uint32_t dstArrayElement)
+bool DescriptorConfigurator::assignDescriptorBuffer(const std::string& name, ref_ptr<Data> data, uint32_t dstArrayElement)
 {
     if (auto& bufferBinding = shaderSet->getDescriptorBinding(name))
     {
@@ -190,15 +190,15 @@ bool DescriptorConfigurator::assignBuffer(const std::string& name, ref_ptr<Data>
     return false;
 }
 
-/// deprecated. use DescriptorConfigurator::assignBuffer() instead.
+/// deprecated: use DescriptorConfigurator::assignDescriptorBuffer() instead.
 bool DescriptorConfigurator::assignUniform(const std::string& name, ref_ptr<Data> data, uint32_t dstArrayElement)
 {
     warn("DescriptorConfigurator::assignUniform() has been deprecated."
-         " Use DescriptorConfigurator::assignBuffer() instead.");
-    return assignBuffer(name, data, dstArrayElement);
+         " Use DescriptorConfigurator::assignDescriptorBuffer() instead.");
+    return assignDescriptorBuffer(name, data, dstArrayElement);
 }
 
-bool DescriptorConfigurator::assignBuffer(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement)
+bool DescriptorConfigurator::assignDescriptorBuffer(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement)
 {
     if (auto& bufferBinding = shaderSet->getDescriptorBinding(name))
     {
@@ -214,12 +214,12 @@ bool DescriptorConfigurator::assignBuffer(const std::string& name, const BufferI
     return false;
 }
 
-/// deprecated. use DescriptorConfigurator::assignBuffer() instead.
+/// deprecated: use DescriptorConfigurator::assignDescriptorBuffer() instead.
 bool DescriptorConfigurator::assignUniform(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement)
 {
     warn("DescriptorConfigurator::assignUniform() has been deprecated."
-         " Use DescriptorConfigurator::assignBuffer() instead.");
-    return assignBuffer(name, bufferInfoList, dstArrayElement);
+         " Use DescriptorConfigurator::assignDescriptorBuffer() instead.");
+    return assignDescriptorBuffer(name, bufferInfoList, dstArrayElement);
 }
 
 bool DescriptorConfigurator::assignDescriptor(uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Descriptor> descriptor)
@@ -426,18 +426,18 @@ bool GraphicsPipelineConfigurator::enableTexture(const std::string& name)
     return descriptorConfigurator->enableTexture(name);
 }
 
-bool GraphicsPipelineConfigurator::enableBuffer(const std::string& name)
+bool GraphicsPipelineConfigurator::enableDescriptorBuffer(const std::string& name)
 {
     if (!descriptorConfigurator) descriptorConfigurator = DescriptorConfigurator::create(shaderSet);
-    return descriptorConfigurator->enableBuffer(name);
+    return descriptorConfigurator->enableDescriptorBuffer(name);
 }
 
-/// deprecated. use GraphicsPipelineConfigurator::enableBuffer() instead
+/// deprecated: use GraphicsPipelineConfigurator::enableDescriptorBuffer() instead
 bool GraphicsPipelineConfigurator::enableUniform(const std::string& name)
 {
     warn("GraphicsPipelineConfigurator::enableUniform() has been deprecated."
-         " use GraphicsPipelineConfigurator::enableBuffer() instead.");
-    return enableBuffer(name);
+         " use GraphicsPipelineConfigurator::enableDescriptorBuffer() instead.");
+    return enableDescriptorBuffer(name);
 }
 
 bool GraphicsPipelineConfigurator::assignArray(DataList& arrays, const std::string& name, VkVertexInputRate vertexInputRate, ref_ptr<Data> array)
@@ -462,18 +462,18 @@ bool GraphicsPipelineConfigurator::assignTexture(const std::string& name, ref_pt
     return descriptorConfigurator->assignTexture(name, textureData, sampler);
 }
 
-bool GraphicsPipelineConfigurator::assignBuffer(const std::string& name, ref_ptr<Data> data)
+bool GraphicsPipelineConfigurator::assignDescriptorBuffer(const std::string& name, ref_ptr<Data> data)
 {
     if (!descriptorConfigurator) descriptorConfigurator = DescriptorConfigurator::create(shaderSet);
-    return descriptorConfigurator->assignBuffer(name, data);
+    return descriptorConfigurator->assignDescriptorBuffer(name, data);
 }
 
-/// deprecated. use GraphicsPipelineConfigurator::assignBuffer() instead
+/// deprecated: use GraphicsPipelineConfigurator::assignDescriptorBuffer() instead
 bool GraphicsPipelineConfigurator::assignUniform(const std::string& name, ref_ptr<Data> data)
 {
     warn("GraphicsPipelineConfigurator::assignUniform() has been deprecated."
-         " use GraphicsPipelineConfigurator::assignBuffer() instead.");
-    return assignBuffer(name, data);
+         " use GraphicsPipelineConfigurator::assignDescriptorBuffer() instead.");
+    return assignDescriptorBuffer(name, data);
 }
 
 int GraphicsPipelineConfigurator::compare(const Object& rhs_object) const

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -101,7 +101,7 @@ void DescriptorConfigurator::reset()
 
 bool DescriptorConfigurator::enableTexture(const std::string& name)
 {
-    if (auto& textureBinding = shaderSet->getBufferBinding(name))
+    if (auto& textureBinding = shaderSet->getDescriptorBinding(name))
     {
         assigned.insert(name);
 
@@ -118,7 +118,7 @@ bool DescriptorConfigurator::enableTexture(const std::string& name)
 
 bool DescriptorConfigurator::assignTexture(const std::string& name, ref_ptr<Data> textureData, ref_ptr<Sampler> sampler, uint32_t dstArrayElement)
 {
-    if (auto& textureBinding = shaderSet->getBufferBinding(name))
+    if (auto& textureBinding = shaderSet->getDescriptorBinding(name))
     {
         assigned.insert(name);
 
@@ -135,7 +135,7 @@ bool DescriptorConfigurator::assignTexture(const std::string& name, ref_ptr<Data
 
 bool DescriptorConfigurator::assignTexture(const std::string& name, const ImageInfoList& imageInfoList, uint32_t dstArrayElement)
 {
-    if (auto& textureBinding = shaderSet->getBufferBinding(name))
+    if (auto& textureBinding = shaderSet->getDescriptorBinding(name))
     {
         assigned.insert(name);
 
@@ -151,7 +151,7 @@ bool DescriptorConfigurator::assignTexture(const std::string& name, const ImageI
 
 bool DescriptorConfigurator::enableBuffer(const std::string& name)
 {
-    if (auto& bufferBinding = shaderSet->getBufferBinding(name))
+    if (auto& bufferBinding = shaderSet->getDescriptorBinding(name))
     {
         assigned.insert(name);
 
@@ -176,7 +176,7 @@ bool DescriptorConfigurator::enableUniform(const std::string& name)
 
 bool DescriptorConfigurator::assignBuffer(const std::string& name, ref_ptr<Data> data, uint32_t dstArrayElement)
 {
-    if (auto& bufferBinding = shaderSet->getBufferBinding(name))
+    if (auto& bufferBinding = shaderSet->getDescriptorBinding(name))
     {
         assigned.insert(name);
 
@@ -200,7 +200,7 @@ bool DescriptorConfigurator::assignUniform(const std::string& name, ref_ptr<Data
 
 bool DescriptorConfigurator::assignBuffer(const std::string& name, const BufferInfoList& bufferInfoList, uint32_t dstArrayElement)
 {
-    if (auto& bufferBinding = shaderSet->getBufferBinding(name))
+    if (auto& bufferBinding = shaderSet->getDescriptorBinding(name))
     {
         assigned.insert(name);
 
@@ -248,14 +248,14 @@ bool DescriptorConfigurator::assignDefaults()
     bool assignedDefault = false;
     if (shaderSet)
     {
-        for (auto& bufferBinding : shaderSet->bufferBindings)
+        for (auto& descriptorBinding : shaderSet->descriptorBindings)
         {
-            if (bufferBinding.define.empty() && assigned.count(bufferBinding.name) == 0)
+            if (descriptorBinding.define.empty() && assigned.count(descriptorBinding.name) == 0)
             {
                 bool set_matched = false;
                 for (auto& cds : shaderSet->customDescriptorSetBindings)
                 {
-                    if (cds->set == bufferBinding.set)
+                    if (cds->set == descriptorBinding.set)
                     {
                         set_matched = true;
                         break;
@@ -264,7 +264,7 @@ bool DescriptorConfigurator::assignDefaults()
                 if (!set_matched)
                 {
                     bool isTexture = false;
-                    switch (bufferBinding.descriptorType)
+                    switch (descriptorBinding.descriptorType)
                     {
                     case (VK_DESCRIPTOR_TYPE_SAMPLER):
                     case (VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER):
@@ -278,16 +278,16 @@ bool DescriptorConfigurator::assignDefaults()
 
                     if (isTexture)
                     {
-                        assignDescriptor(bufferBinding.set, bufferBinding.binding, bufferBinding.descriptorType, bufferBinding.descriptorCount, bufferBinding.stageFlags,
-                                         DescriptorImage::create(Sampler::create(), bufferBinding.data, bufferBinding.binding, 0, bufferBinding.descriptorType));
+                        assignDescriptor(descriptorBinding.set, descriptorBinding.binding, descriptorBinding.descriptorType, descriptorBinding.descriptorCount, descriptorBinding.stageFlags,
+                                         DescriptorImage::create(Sampler::create(), descriptorBinding.data, descriptorBinding.binding, 0, descriptorBinding.descriptorType));
                     }
                     else
                     {
-                        assignDescriptor(bufferBinding.set, bufferBinding.binding, bufferBinding.descriptorType, bufferBinding.descriptorCount, bufferBinding.stageFlags,
-                                         DescriptorBuffer::create(bufferBinding.data, bufferBinding.binding, 0, bufferBinding.descriptorType));
+                        assignDescriptor(descriptorBinding.set, descriptorBinding.binding, descriptorBinding.descriptorType, descriptorBinding.descriptorCount, descriptorBinding.stageFlags,
+                                         DescriptorBuffer::create(descriptorBinding.data, descriptorBinding.binding, 0, descriptorBinding.descriptorType));
                     }
 
-                    assigned.insert(bufferBinding.name);
+                    assigned.insert(descriptorBinding.name);
                     assignedDefault = true;
                 }
             }
@@ -471,8 +471,8 @@ bool GraphicsPipelineConfigurator::assignBuffer(const std::string& name, ref_ptr
 /// deprecated. use GraphicsPipelineConfigurator::assignBuffer() instead
 bool GraphicsPipelineConfigurator::assignUniform(const std::string& name, ref_ptr<Data> data)
 {
-    warn("GraphicsPipelineConfigurator::enableUniform() has been deprecated."
-         " use GraphicsPipelineConfigurator::enableBuffer() instead.");
+    warn("GraphicsPipelineConfigurator::assignUniform() has been deprecated."
+         " use GraphicsPipelineConfigurator::assignBuffer() instead.");
     return assignBuffer(name, data);
 }
 

--- a/src/vsg/utils/ShaderSet.cpp
+++ b/src/vsg/utils/ShaderSet.cpp
@@ -180,7 +180,7 @@ void ShaderSet::addDescriptorBinding(std::string name, std::string define, uint3
     descriptorBindings.push_back(DescriptorBinding{name, define, set, binding, descriptorType, descriptorCount, stageFlags, data});
 }
 
-/// deprecated. use ShaderSet::addDescriptorBinding() instead
+/// deprecated: use ShaderSet::addDescriptorBinding() instead
 void ShaderSet::addUniformBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data)
 {
     warn("ShaderSet::addUniformBinding() has been deprecated."
@@ -211,7 +211,7 @@ DescriptorBinding& ShaderSet::getDescriptorBinding(const std::string& name)
     return _nullDescriptorBinding;
 }
 
-/// deprecated. use ShaderSet::getDescriptorBinding() instead
+/// deprecated: use ShaderSet::getDescriptorBinding() instead
 DescriptorBinding& ShaderSet::getUniformBinding(const std::string& name)
 {
     warn("ShaderSet::getUniformBinding() has been deprecated."
@@ -237,7 +237,7 @@ const DescriptorBinding& ShaderSet::getDescriptorBinding(const std::string& name
     return _nullDescriptorBinding;
 }
 
-/// deprecated. use ShaderSet::getDescriptorBinding() instead.
+/// deprecated: use ShaderSet::getDescriptorBinding() instead.
 const DescriptorBinding& ShaderSet::getUniformBinding(const std::string& name) const
 {
     warn("ShaderSet::getUniformBinding() has been deprecated."

--- a/src/vsg/utils/ShaderSet.cpp
+++ b/src/vsg/utils/ShaderSet.cpp
@@ -11,6 +11,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </editor-fold> */
 
 #include <vsg/io/Input.h>
+#include <vsg/io/Logger.h>
 #include <vsg/io/Options.h>
 #include <vsg/io/Output.h>
 #include <vsg/io/read.h>
@@ -47,7 +48,7 @@ int AttributeBinding::compare(const AttributeBinding& rhs) const
     return compare_pointer(data, rhs.data);
 }
 
-int UniformBinding::compare(const UniformBinding& rhs) const
+int BufferBinding::compare(const BufferBinding& rhs) const
 {
     if (name < rhs.name) return -1;
     if (name > rhs.name) return 1;
@@ -174,9 +175,17 @@ void ShaderSet::addAttributeBinding(std::string name, std::string define, uint32
     attributeBindings.push_back(AttributeBinding{name, define, location, format, data});
 }
 
+void ShaderSet::addBufferBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data)
+{
+    bufferBindings.push_back(BufferBinding{name, define, set, binding, descriptorType, descriptorCount, stageFlags, data});
+}
+
+/// deprecated. use ShaderSet::addBufferBinding() instead
 void ShaderSet::addUniformBinding(std::string name, std::string define, uint32_t set, uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, ref_ptr<Data> data)
 {
-    uniformBindings.push_back(UniformBinding{name, define, set, binding, descriptorType, descriptorCount, stageFlags, data});
+    warn("ShaderSet::addUniformBinding() has been deprecated."
+         " use ShaderSet::addBufferBinding() instead.");
+    return addBufferBinding(name, define, set, binding, descriptorType, descriptorCount, stageFlags, data);
 }
 
 void ShaderSet::addPushConstantRange(std::string name, std::string define, VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size)
@@ -193,13 +202,21 @@ const AttributeBinding& ShaderSet::getAttributeBinding(const std::string& name) 
     return _nullAttributeBinding;
 }
 
-UniformBinding& ShaderSet::getUniformBinding(const std::string& name)
+BufferBinding& ShaderSet::getBufferBinding(const std::string& name)
 {
-    for (auto& binding : uniformBindings)
+    for (auto& binding : bufferBindings)
     {
         if (binding.name == name) return binding;
     }
-    return _nullUniformBinding;
+    return _nullBufferBinding;
+}
+
+/// deprecated. use ShaderSet::getBufferBinding() instead
+BufferBinding& ShaderSet::getUniformBinding(const std::string& name)
+{
+    warn("ShaderSet::getUniformBinding() has been deprecated."
+         " use ShaderSet::getBufferBinding() instead.");
+    return getBufferBinding(name);
 }
 
 AttributeBinding& ShaderSet::getAttributeBinding(const std::string& name)
@@ -211,13 +228,21 @@ AttributeBinding& ShaderSet::getAttributeBinding(const std::string& name)
     return _nullAttributeBinding;
 }
 
-const UniformBinding& ShaderSet::getUniformBinding(const std::string& name) const
+const BufferBinding& ShaderSet::getBufferBinding(const std::string& name) const
 {
-    for (auto& binding : uniformBindings)
+    for (auto& binding : bufferBindings)
     {
         if (binding.name == name) return binding;
     }
-    return _nullUniformBinding;
+    return _nullBufferBinding;
+}
+
+/// deprecated. use ShaderSet::getBufferBinding() instead.
+const BufferBinding& ShaderSet::getUniformBinding(const std::string& name) const
+{
+    warn("ShaderSet::getUniformBinding() has been deprecated."
+         " use ShaderSet::getBufferBinding() instead.");
+    return getBufferBinding(name);
 }
 
 ref_ptr<ArrayState> ShaderSet::getSuitableArrayState(const std::set<std::string>& defines) const
@@ -289,7 +314,7 @@ int ShaderSet::compare(const Object& rhs_object) const
     auto& rhs = static_cast<decltype(*this)>(rhs_object);
     if ((result = compare_pointer_container(stages, rhs.stages))) return result;
     if ((result = compare_container(attributeBindings, rhs.attributeBindings))) return result;
-    if ((result = compare_container(uniformBindings, rhs.uniformBindings))) return result;
+    if ((result = compare_container(bufferBindings, rhs.bufferBindings))) return result;
     if ((result = compare_container(pushConstantRanges, rhs.pushConstantRanges))) return result;
     if ((result = compare_container(definesArrayStates, rhs.definesArrayStates))) return result;
     if ((result = compare_container(optionalDefines, rhs.optionalDefines))) return result;
@@ -318,9 +343,9 @@ void ShaderSet::read(Input& input)
         input.readObject("data", binding.data);
     }
 
-    auto num_uniformBindings = input.readValue<uint32_t>("uniformBindings");
-    uniformBindings.resize(num_uniformBindings);
-    for (auto& binding : uniformBindings)
+    auto num_bufferBindings = input.readValue<uint32_t>("bufferBindings");
+    bufferBindings.resize(num_bufferBindings);
+    for (auto& binding : bufferBindings)
     {
         input.read("name", binding.name);
         input.read("define", binding.define);
@@ -397,8 +422,8 @@ void ShaderSet::write(Output& output) const
         output.writeObject("data", binding.data);
     }
 
-    output.writeValue<uint32_t>("uniformBindings", uniformBindings.size());
-    for (auto& binding : uniformBindings)
+    output.writeValue<uint32_t>("bufferBindings", bufferBindings.size());
+    for (auto& binding : bufferBindings)
     {
         output.write("name", binding.name);
         output.write("define", binding.define);
@@ -481,12 +506,12 @@ ref_ptr<ShaderSet> vsg::createPhysicsBasedRenderingShaderSet(ref_ptr<const Optio
 
 std::pair<uint32_t, uint32_t> ShaderSet::descriptorSetRange() const
 {
-    if (uniformBindings.empty()) return {0, 0};
+    if (bufferBindings.empty()) return {0, 0};
 
     uint32_t minimum = std::numeric_limits<uint32_t>::max();
     uint32_t maximum = std::numeric_limits<uint32_t>::min();
 
-    for (auto& binding : uniformBindings)
+    for (auto& binding : bufferBindings)
     {
         if (binding.set < minimum) minimum = binding.set;
         if (binding.set > maximum) maximum = binding.set;
@@ -498,7 +523,7 @@ std::pair<uint32_t, uint32_t> ShaderSet::descriptorSetRange() const
 ref_ptr<DescriptorSetLayout> ShaderSet::createDescriptorSetLayout(const std::set<std::string>& defines, uint32_t set) const
 {
     DescriptorSetLayoutBindings bindings;
-    for (auto& binding : uniformBindings)
+    for (auto& binding : bufferBindings)
     {
         if (binding.set == set)
         {


### PR DESCRIPTION
Using the name "DescriptorBuffer" instead of "Uniform" with ShaderSet and GraphicsPipelineConfigurator better conveys that these methods work with both uniform and storage (and sometimes even image/texture) bindings.

Part of #954 

This is a rename only and no functionality was changed. The public member variable `ShaderSet::uniformBindings` was renamed to `ShaderSet::bufferBindings` and a reference was created to keep the the API from breaking. Also, updated names in the read/write methods are set to be used when the version hits `1.0.10`.

- [x] This change requires a documentation update

## Testing

See the associated storage buffer example: https://github.com/vsg-dev/vsgExamples/tree/master/examples/utils/vsgstoragebuffer

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
