### PR TITLE
[FIXED] simplified check for a single entry in AnimationPath's locations map

### DIFF
--- a/src/vsg/utils/AnimationPath.cpp
+++ b/src/vsg/utils/AnimationPath.cpp
@@ -32,7 +32,7 @@ AnimationPath::Location AnimationPath::computeLocation(double time) const
     if (locations.empty()) return {};
 
     // check for single entry in locations map
-    if (locations.begin() == locations.rbegin().base()) return locations.begin()->second;
+    if (locations.size() == 1) return locations.begin()->second;
 
     if (mode == REPEAT)
     {


### PR DESCRIPTION
## Description

This fixed a needlessly complicated check whether AnimationPath's locations map contains a single entry. In fact I think the original code never worked. std::map::size is constant complexity so even if comparing iterators might be faster I don't think this is a big deal.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Using a modified vsgbuilder example.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
