### PR TITLE
[FIXED] transferQueue queueFamilyIndex

### DIFF
--- a/src/vsg/app/CompileTraversal.cpp
+++ b/src/vsg/app/CompileTraversal.cpp
@@ -60,6 +60,7 @@ CompileTraversal::~CompileTraversal()
 
 void CompileTraversal::add(ref_ptr<Device> device, const ResourceRequirements& resourceRequirements)
 {
+    // TODO : need to ensure queueFamily matches the main queue's queueFamily, or implement queue family ownership transfer, or defer copy and transfer commands to TransferTask?
     auto queueFamily = device->getPhysicalDevice()->getQueueFamily(queueFlags);
     auto context = Context::create(device, resourceRequirements);
     context->commandPool = CommandPool::create(device, queueFamily, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
@@ -71,6 +72,7 @@ void CompileTraversal::add(Window& window, ref_ptr<ViewportState> viewport, cons
 {
     auto device = window.getOrCreateDevice();
     auto renderPass = window.getOrCreateRenderPass();
+    // TODO : need to ensure queueFamily matches the main queue's queueFamily, or implement queue family ownership transfer, or defer copy and transfer commands to TransferTask?
     auto queueFamily = device->getPhysicalDevice()->getQueueFamily(queueFlags);
     auto context = Context::create(device, resourceRequirements);
     context->renderPass = renderPass;
@@ -91,6 +93,7 @@ void CompileTraversal::add(Window& window, ref_ptr<View> view, const ResourceReq
 {
     auto device = window.getOrCreateDevice();
     auto renderPass = window.getOrCreateRenderPass();
+    // TODO : need to ensure queueFamily matches the main queue's queueFamily, or implement queue family ownership transfer, or defer copy and transfer commands to TransferTask?
     auto queueFamily = device->getPhysicalDevice()->getQueueFamily(queueFlags);
     auto context = Context::create(device, resourceRequirements);
     context->renderPass = renderPass;
@@ -117,6 +120,7 @@ void CompileTraversal::add(Framebuffer& framebuffer, ref_ptr<View> view, const R
 {
     auto device = framebuffer.getDevice();
     auto renderPass = framebuffer.getRenderPass();
+    // TODO : need to ensure queueFamily matches the main queue's queueFamily, or implement queue family ownership transfer, or defer copy and transfer commands to TransferTask?
     auto queueFamily = device->getPhysicalDevice()->getQueueFamily(VK_QUEUE_GRAPHICS_BIT);
     auto context = Context::create(device, resourceRequirements);
     context->renderPass = renderPass;

--- a/src/vsg/app/Viewer.cpp
+++ b/src/vsg/app/Viewer.cpp
@@ -475,7 +475,7 @@ void Viewer::assignRecordAndSubmitTaskAndPresentation(CommandGraphs in_commandGr
         // get main queue used for RecordAndSubmitTask
         ref_ptr<Queue> mainQueue = device->getQueue(deviceQueueFamily.queueFamily);
 
-        // get presentat queue if required/supported
+        // get presentation queue if required/supported
         ref_ptr<Queue> presentQueue;
         if (deviceQueueFamily.presentFamily >= 0) presentQueue = device->getQueue(deviceQueueFamily.presentFamily);
 
@@ -485,6 +485,12 @@ void Viewer::assignRecordAndSubmitTaskAndPresentation(CommandGraphs in_commandGr
         VkQueueFlags transferQueueFlags = VK_QUEUE_TRANSFER_BIT | VK_QUEUE_GRAPHICS_BIT; // use VK_QUEUE_GRAPHICS_BIT to ensure we can blit images
         for (auto& queue : device->getQueues())
         {
+            if (mainQueue->queueFamilyIndex() != queue->queueFamilyIndex())
+            {
+                // need to implement queue family ownership transfer to use a different queue family
+                // see Vulkan spec 7.4.4, "Queue Family Ownership Transfer"
+                continue;
+            }
             if ((queue->queueFlags() & transferQueueFlags) == transferQueueFlags)
             {
                 if (queue != mainQueue)


### PR DESCRIPTION
# Pull Request Template

## Description

Changed transfer queue setup to re-use the main graphics queue's queueFamilyIndex to avoid the need for queue family ownership transfer of resources.

The Vulkan spec 7.7.4 states: "Resources created with a VkSharingMode of VK_SHARING_MODE_EXCLUSIVE must have their ownership explicitly transferred from one queue family to another in order to access their content in a well-defined manner on a queue in a different queue family."

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Only one queue family has been observed until now.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
