### PR TITLE
[FIXED] TransferTask semaphore wait stages

### DIFF
--- a/src/vsg/app/TransferTask.cpp
+++ b/src/vsg/app/TransferTask.cpp
@@ -360,7 +360,7 @@ VkResult TransferTask::transferDynamicData()
 
     if (!semaphore)
     {
-        semaphore = Semaphore::create(device, VK_PIPELINE_STAGE_TRANSFER_BIT);
+        semaphore = Semaphore::create(device, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     }
 
     VkResult result = VK_SUCCESS;
@@ -395,7 +395,7 @@ VkResult TransferTask::transferDynamicData()
 
     vkEndCommandBuffer(vk_commandBuffer);
 
-    // if no regions to copy have been found then commandBuffer will be empty so no need to submit it to queue and use the associated single semaphore
+    // if no regions to copy have been found then commandBuffer will be empty so no need to submit it to queue and signal the associated semaphore
     if (offset > 0)
     {
         // submit the transfer commands


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed semaphore wait stages for transferCompletedSemaphore.

The Vulkan spec 7.4.2 "Semaphore waiting" states: "[...] the second synchronization scope is limited to operations on the pipeline stages determined by the destination stage mask specified by the corresponding element of pWaitDstStageMask."

Note, while waiting in a particular pipeline stage guarantees that any logically later pipeline stages will wait, transfer, graphics and compute pipelines are independent so using a wait stage mask of VK_PIPELINE_STAGE_TRANSFER_BIT doesn't imply waiting of any other pipeline stages.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

General testing

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
