### PR TITLE
[REMOVED] DescriptorSet::Implementation::_descriptors

### DIFF
--- a/include/vsg/state/DescriptorSet.h
+++ b/include/vsg/state/DescriptorSet.h
@@ -79,7 +79,6 @@ namespace vsg
 
             ref_ptr<DescriptorPool> _descriptorPool;
             ref_ptr<DescriptorSetLayout> _descriptorSetLayout;
-            Descriptors _descriptors;
         };
 
     protected:

--- a/src/vsg/state/DescriptorSet.cpp
+++ b/src/vsg/state/DescriptorSet.cpp
@@ -128,21 +128,18 @@ DescriptorSet::Implementation::~Implementation()
 
 void DescriptorSet::Implementation::assign(Context& context, const Descriptors& in_descriptors)
 {
-    // should we do anything about previous _descriptors that may have been assigned?
-    _descriptors = in_descriptors;
+    if (in_descriptors.empty()) return;
 
-    if (_descriptors.empty()) return;
+    VkWriteDescriptorSet* descriptorWrites = context.scratchMemory->allocate<VkWriteDescriptorSet>(in_descriptors.size());
 
-    VkWriteDescriptorSet* descriptorWrites = context.scratchMemory->allocate<VkWriteDescriptorSet>(_descriptors.size());
-
-    for (size_t i = 0; i < _descriptors.size(); ++i)
+    for (size_t i = 0; i < in_descriptors.size(); ++i)
     {
-        _descriptors[i]->assignTo(context, descriptorWrites[i]);
+        in_descriptors[i]->assignTo(context, descriptorWrites[i]);
         descriptorWrites[i].dstSet = _descriptorSet;
     }
 
     auto device = _descriptorPool->getDevice();
-    vkUpdateDescriptorSets(*device, static_cast<uint32_t>(_descriptors.size()), descriptorWrites, 0, nullptr);
+    vkUpdateDescriptorSets(*device, static_cast<uint32_t>(in_descriptors.size()), descriptorWrites, 0, nullptr);
 
     // clean up scratch memory so it can be reused.
     context.scratchMemory->release();


### PR DESCRIPTION
# Pull Request Template

## Description

Removed unnecessary _descriptors container from DescriptorSet::Implementation to reduce memory footprint and facilitate the destruction of resources.

Note, when used in combination with the DescriptorPool::_recyclingList, ref_ptr's held by DescriptorSet::Implementation::_descriptors prevent the descriptors' resources, like buffers and images, from being destroyed unless another, compatible descriptor set allocates from the DescriptorPool::_recyclingList.

The Vulkan spec for vkAllocateDescriptorSets states:

"When a descriptor set is allocated, the initial state is largely uninitialized and all descriptors are undefined [...]. Descriptors also become undefined if the underlying resource or view object is destroyed. Descriptor sets containing undefined descriptors can still be bound and used, subject to [...] all descriptors [...] used must have been populated before the descriptor set is consumed."

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested that the clean-up of old BufferInfo entries from TransferTask::_dynamicDataMap has improved.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
