### PR TITLE
Support for util ShaderCompilerSettings to Visitor and ConstVisitor

### DIFF
--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -130,6 +130,7 @@ namespace vsg
 
     // forward declare util classes
     class AnimationPath;
+    class ShaderCompileSettings;
 
     // forward declare viewer classes
     class Camera;
@@ -382,6 +383,7 @@ namespace vsg
 
         // utils
         virtual void apply(const AnimationPath&);
+        virtual void apply(const ShaderCompileSettings&);
 
         // viewer
         virtual void apply(const Camera&);

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -130,6 +130,7 @@ namespace vsg
 
     // forward declare util classes
     class AnimationPath;
+    class ShaderCompileSettings;
 
     // forward declare viewer classes
     class Camera;
@@ -382,6 +383,7 @@ namespace vsg
 
         // utils
         virtual void apply(AnimationPath&);
+        virtual void apply(ShaderCompileSettings&);
 
         // viewer
         virtual void apply(Camera&);

--- a/src/vsg/core/ConstVisitor.cpp
+++ b/src/vsg/core/ConstVisitor.cpp
@@ -922,6 +922,10 @@ void ConstVisitor::apply(const AnimationPath& animationPath)
 {
     apply(static_cast<const Object&>(animationPath));
 }
+void ConstVisitor::apply(const ShaderCompileSettings& shaderCompileSettings)
+{
+    apply(static_cast<const Object&>(shaderCompileSettings));
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //

--- a/src/vsg/core/Visitor.cpp
+++ b/src/vsg/core/Visitor.cpp
@@ -922,6 +922,10 @@ void Visitor::apply(AnimationPath& animationPath)
 {
     apply(static_cast<Object&>(animationPath));
 }
+void Visitor::apply(ShaderCompileSettings& shaderCompileSettings)
+{
+    apply(static_cast<Object&>(shaderCompileSettings));
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
Visitor for ShaderCompilerSettings class as used in GraphicsPipelineConfigurator::traverse()

- [X] New feature (non-breaking change which adds functionality)

This change allows a GraphicsPipelineConfigurator Visitor to apply to the shader hints:

```
struct SetPipelineStates : public vsg::Visitor
{
    void apply(vsg::Object& object) { object.traverse(*this); }
    void apply(vsg::ShaderCompileSettings& scs)
    {
        scs.defines.insert("VSG_TWO_SIDED_LIGHTING");
    }
} sps;
auto gpConf = vsg::GraphicsPipelineConfigurator::create(shaderSet);
gpConf->accept(sps);
```

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings