### PR TITLE
[FIX] AnimationPath will now also load/store its 'mode' property.

### DIFF
--- a/src/vsg/utils/AnimationPath.cpp
+++ b/src/vsg/utils/AnimationPath.cpp
@@ -75,6 +75,9 @@ void AnimationPath::read(Input& input)
 {
     vsg::Object::read(input);
 
+    if (input.version_greater_equal(1, 0, 10))
+        input.readValue<uint32_t>("mode", mode);
+    
     auto numLocations = input.readValue<uint32_t>("NumLocations");
 
     locations.clear();
@@ -93,6 +96,9 @@ void AnimationPath::read(Input& input)
 void AnimationPath::write(Output& output) const
 {
     vsg::Object::write(output);
+
+    if (output.version_greater_equal(1, 0, 10))
+        output.writeValue<uint32_t>("mode", mode);
 
     output.writeValue<uint32_t>("NumLocations", locations.size());
     for (auto& [time, location] : locations)


### PR DESCRIPTION
## Description

With this change the AnimationPath class will also read/write its 'mode' member; existing files will remain valid (their 'mode' member will not be changed).

Fixes #972

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Using a modified vsgViewer example

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
