### PR TITLE
t_quat::set: return a zero rotation instead of a zero quaternion

### DIFF
--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -98,7 +98,7 @@ namespace vsg
             if (len < epsilon)
             {
                 // ~zero length axis, so reset rotation to zero.
-                *this = {};
+                set(0, 0, 0, 1);
                 return;
             }
 


### PR DESCRIPTION
It could be argued that the default constructor for quaternion should return a zero rotation i.e. {0, 0, 0, 1}, but I decided not to go there.
