### PR TITLE
Prevent self-destructing build system

### DIFF
--- a/cmake/vsgMacros.cmake
+++ b/cmake/vsgMacros.cmake
@@ -280,11 +280,12 @@ macro(vsg_add_target_clobber)
         else()
             if (NOT TARGET clobber)
                 add_custom_target(clobber)
+                set_target_properties(clobber PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD TRUE)
             endif()
             add_custom_target(clobber-${PROJECT_NAME}
                 COMMAND ${GIT_EXECUTABLE} -C ${PROJECT_SOURCE_DIR} clean -d -f -x
             )
-            set_target_properties(clobber-${PROJECT_NAME} PROPERTIES FOLDER "${PROJECT_NAME} Folder")
+            set_target_properties(clobber-${PROJECT_NAME} PROPERTIES FOLDER "${PROJECT_NAME} Folder" EXCLUDE_FROM_DEFAULT_BUILD TRUE)
             add_dependencies(clobber clobber-${PROJECT_NAME})
         endif()
     endif()
@@ -401,11 +402,12 @@ macro(vsg_add_target_uninstall)
     endif()
     if (NOT TARGET uninstall)
         add_custom_target(uninstall)
+        set_target_properties(uninstall PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD TRUE)
     endif()
     add_custom_target(uninstall-${PROJECT_NAME}
         COMMAND ${CMAKE_COMMAND} -P ${DIR}/uninstall.cmake
     )
-    set_target_properties(uninstall-${PROJECT_NAME} PROPERTIES FOLDER "${PROJECT_NAME} Folder")
+    set_target_properties(uninstall-${PROJECT_NAME} PROPERTIES FOLDER "${PROJECT_NAME} Folder" EXCLUDE_FROM_DEFAULT_BUILD TRUE)
     add_dependencies(uninstall uninstall-${PROJECT_NAME})
 endmacro()
 


### PR DESCRIPTION
## Description

Prevent clobber and uninstall targets running when pressing the *Build Solution* hotkey in Visual Studio.

This function is *usually* analogous to `make all`, but there's a slight difference with when transitive dependencies of things get built, so for consistency, CMake creates an `ALL_BUILD` VS project in the VS solution that does exactly what `make all` would, and leaves the hotkey doing what it normally does.

For under-the-hood reasons, targets that are excluded from all (the `EXCLUDE_FROM_ALL` target property, on by default for custom targets) have `EXCLUDE_FROM_DEFAULT_BUILD` implicitly off if they're a dependency of another target, and implicitly on if they're not. This means that using *Build Solution* skips `uninstall` and `clobber`, but runs `uninstall-vsg` (which will fail if an install hasn't happened yet as `install_manifest.txt` won't exist) and `clobber-vsg` (which wipes out the build system, causing all kinds of havoc).

Explicitly setting `EXCLUDE_FROM_DEFAULT_BUILD` for the overall and project-specific `uninstall` and `clobber` targets prevents them from running when they're not explicitly requested. Unfortunately, thanks to VS being dumb here, this also applies to when you run the overall target - you didn't explicitly request its project-specific dependencies, so they aren't built. You can get around this by using `cmake --build . --target uninstall` instead of running the uninstall project from the VS GUI, though, so it's not a *huge* problem like a surprise `git clean -dxf` can be when the `clobber` target runs unexpectedly.

The only alternatives I've thought of would be entirely removing the `clobber` target (`git clean -dxf` isn't a *wildly* difficult command to remember, and can be a pretty big problem if run accidentally, which is more likely when there's a build system target for it) and modifying the uninstall target so it doesn't fail the whole build, or adding CMake option(s) to disable them (and potentially defaulting it to true when using a VS generator).

Fixes N/A - there's nothing on the tracker for this.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've built the project a bunch of times.

**Test Configuration**:
* Firmware version: N/A
* Hardware: N/A
* Toolchain: VS 17 2022, CMake 3.27.4
* SDK: N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
