### PR TITLE
Fix plane position and normal constructor

### DIFF
--- a/include/vsg/maths/plane.h
+++ b/include/vsg/maths/plane.h
@@ -67,7 +67,7 @@ namespace vsg
             value{normal.x, normal.y, normal.z, in_p} {}
 
         constexpr t_plane(const normal_type& position, const normal_type& normal) :
-            value{normal.x, normal.y, normal.z, -(position * normal)} {}
+            value{normal.x, normal.y, normal.z, -dot(position, normal)} {}
 
         template<typename R>
         constexpr explicit t_plane(const t_plane<R>& v) :


### PR DESCRIPTION
It wouldn't actually compile, but thanks to SFINAE, it wasn't emitting an error unless you actually tried using it, which apparently nothing was. The initialiser wanted to receive a float, but because VSG's `operator*` works component-wise, it was getting a vector. I assume this was just an oversight when copying stuff from OSG where `operator*` is a dot product.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```cpp
vsg::plane reflectionPlane(vsg::vec3(0.0f, 5.0f, 0.0f), vsg::vec3(0.0f, -1.0f, 0.0f));
```

This line previously wouldn't compile, and now it does.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
