### PR TITLE
Specify an unused color attachment for the shadow passes

### DIFF
--- a/src/vsg/state/ViewDependentState.cpp
+++ b/src/vsg/state/ViewDependentState.cpp
@@ -412,9 +412,11 @@ void ViewDependentState::compile(Context& context)
             attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
             attachments[0].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
 
+            AttachmentReference ignoreColorReference = {VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED};
             AttachmentReference depthReference = {0, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
             RenderPass::Subpasses subpassDescription(1);
             subpassDescription[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+            subpassDescription[0].colorAttachments.emplace_back(ignoreColorReference);
             subpassDescription[0].depthStencilAttachments.emplace_back(depthReference);
 
             RenderPass::Dependencies dependencies(2);


### PR DESCRIPTION
Without this, the shadow pass was causing this validation error:

    Objects: 1
        [0] 0x2d15fe00000000bf, type: 15, name: NULL
UNASSIGNED-CoreValidation-Shader-OutputNotConsumed(WARN / SPEC): msgNum: 101294395 - Validation Warning: [ UNASSIGNED-CoreValidation-Shader-OutputNotConsumed ] Object 0: handle = 0x997e220000000624, type = VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0x609a13b | fragment shader writes to output location 0 with no matching attachment

