### PR TITLE
Change assignDescriptor and assignTexture to template functions

### DIFF
--- a/include/vsg/utils/GraphicsPipelineConfigurator.h
+++ b/include/vsg/utils/GraphicsPipelineConfigurator.h
@@ -113,8 +113,22 @@ namespace vsg
         bool enableTexture(const std::string& name);
 
         bool assignArray(DataList& arrays, const std::string& name, VkVertexInputRate vertexInputRate, ref_ptr<Data> array);
-        bool assignDescriptor(const std::string& name, ref_ptr<Data> data = {});
-        bool assignTexture(const std::string& name, ref_ptr<Data> textureData = {}, ref_ptr<Sampler> sampler = {});
+
+        template<typename ...Args>
+        bool assignDescriptor(Args && ...args)
+        {
+            descriptorConfigurator = vsg::DescriptorConfigurator::create_if(!descriptorConfigurator,
+                                                                            shaderSet);
+            return descriptorConfigurator->assignDescriptor(std::forward<Args>(args)...);
+        }
+
+        template<typename ...Args>
+        bool assignTexture(Args && ...args)
+        {
+            descriptorConfigurator = vsg::DescriptorConfigurator::create_if(!descriptorConfigurator,
+                                                                            shaderSet);
+            return descriptorConfigurator->assignTexture(std::forward<Args>(args)...);
+        }
 
         [[deprecated("use enableDescriptor(..)")]] bool enableUniform(const std::string& name) { return enableDescriptor(name); }
 

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -422,7 +422,7 @@ bool GraphicsPipelineConfigurator::assignArray(DataList& arrays, const std::stri
     }
     return false;
 }
-
+#if 0
 bool GraphicsPipelineConfigurator::assignTexture(const std::string& name, ref_ptr<Data> textureData, ref_ptr<Sampler> sampler)
 {
     if (!descriptorConfigurator) descriptorConfigurator = DescriptorConfigurator::create(shaderSet);
@@ -434,7 +434,7 @@ bool GraphicsPipelineConfigurator::assignDescriptor(const std::string& name, ref
     if (!descriptorConfigurator) descriptorConfigurator = DescriptorConfigurator::create(shaderSet);
     return descriptorConfigurator->assignDescriptor(name, data);
 }
-
+#endif
 int GraphicsPipelineConfigurator::compare(const Object& rhs_object) const
 {
     int result = Object::compare(rhs_object);


### PR DESCRIPTION
This makes all the overloads provided by DescriptorConfigurator available to users of GraphicsPipelineConfigurator.
