### PR TITLE
Use the correct store operation for the shadow map attachment

### DIFF
--- a/src/vsg/state/ViewDependentState.cpp
+++ b/src/vsg/state/ViewDependentState.cpp
@@ -406,7 +406,7 @@ void ViewDependentState::compile(Context& context)
             attachments[0].format = shadowDepthImage->format;
             attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
             attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-            attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+            attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
             attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
             attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;


### PR DESCRIPTION
This doesn't make a visual difference on NVidia or AMD, but without the OP_STORE, the implementation can do whatever it wants with the result. RenderDoc spams "dont care" all over the attachment.
