### PR TITLE
Update vec2.h to compile with GCC 13.2

### DIFF
--- a/include/vsg/maths/vec2.h
+++ b/include/vsg/maths/vec2.h
@@ -25,6 +25,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/core/type_name.h>
 
+#include <bits/stdint-uintn.h>
 #include <cmath>
 #include <type_traits>
 

--- a/include/vsg/maths/vec2.h
+++ b/include/vsg/maths/vec2.h
@@ -25,8 +25,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/core/type_name.h>
 
-#include <bits/stdint-uintn.h>
 #include <cmath>
+#include <stdint.h>
 #include <type_traits>
 
 namespace vsg

--- a/include/vsg/maths/vec2.h
+++ b/include/vsg/maths/vec2.h
@@ -26,7 +26,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/type_name.h>
 
 #include <cmath>
-#include <stdint.h>
+#include <cstdint>
 #include <type_traits>
 
 namespace vsg


### PR DESCRIPTION
This fixes a build issue with GCC 13.2 on Ubuntu Mantic as shown below.

```
223/342] Building CXX object components/CMakeFiles/components.dir/view/scene.cpp.o
FAILED: components/CMakeFiles/components.dir/view/scene.cpp.o 
/usr/bin/c++ -DBOOST_NO_CXX11_SCOPED_ENUMS=ON -DBT_USE_DOUBLE_PRECISION -DGLOBAL_CONFIG_PATH=\"/usr/local/etc\" -DGLOBAL_DATA_PATH=\"/usr/local/share/games\" -DMYGUI_DONT_REPLACE_NULLPTR -DMYGUI_STATIC -D__STDC_CONSTANT_MACROS -I/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/components -I/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include -I/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/_deps/vsg-build/include -I/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsgXchange/include -I/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/_deps/vsgxchange-build/include -isystem /home/psi29a/Workspace/vsgopenmw/extern/sol_config -isystem /home/psi29a/Workspace/vsgopenmw/extern/sol3 -isystem /usr/include/luajit-2.1 -isystem /usr/include/bullet -isystem /usr/include/AL -isystem /home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/mygui/MyGUIEngine/include -isystem /usr/include/SDL2 -isystem /home/psi29a/Workspace/vsgopenmw/. -isystem /usr/include/recastnavigation -Wall -Wextra -Wundef -Wextra-semi -Wno-unused-parameter -pedantic -Wno-long-long -Wnon-virtual-dtor -Wunused -Wno-mismatched-tags  -Wno-unused-but-set-parameter -Wduplicated-branches -Wduplicated-cond -Wlogical-op -O2 -g -DNDEBUG -std=c++20 -fdiagnostics-color=always   -fPIC -MD -MT components/CMakeFiles/components.dir/view/scene.cpp.o -MF components/CMakeFiles/components.dir/view/scene.cpp.o.d -o components/CMakeFiles/components.dir/view/scene.cpp.o -c /home/psi29a/Workspace/vsgopenmw/components/view/scene.cpp
In file included from /home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec3.h:26,
                 from /home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/sphere.h:26,
                 from /home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/plane.h:26,
                 from /home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/mat4.h:15,
                 from /home/psi29a/Workspace/vsgopenmw/components/pipeline/viewdata.hpp:4,
                 from /home/psi29a/Workspace/vsgopenmw/components/view/scene.hpp:4,
                 from /home/psi29a/Workspace/vsgopenmw/components/view/scene.cpp:1:
/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec2.h:143:27: error: ‘uint8_t’ was not declared in this scope
  143 |     using ubvec2 = t_vec2<uint8_t>;  //  unsigned 8 bit integer 2D vector
      |                           ^~~~~~~
/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec2.h:29:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   28 | #include <cmath>
  +++ |+#include <cstdint>
   29 | #include <type_traits>
/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec2.h:143:34: error: template argument 1 is invalid
  143 |     using ubvec2 = t_vec2<uint8_t>;  //  unsigned 8 bit integer 2D vector
      |                                  ^
/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec2.h:144:27: error: ‘uint16_t’ was not declared in this scope
  144 |     using usvec2 = t_vec2<uint16_t>; //  unsigned 16 bit integer 2D vector
      |                           ^~~~~~~~
/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec2.h:144:27: note: ‘uint16_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec2.h:144:35: error: template argument 1 is invalid
  144 |     using usvec2 = t_vec2<uint16_t>; //  unsigned 16 bit integer 2D vector
      |                                   ^
/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec2.h:145:27: error: ‘uint32_t’ was not declared in this scope
  145 |     using uivec2 = t_vec2<uint32_t>; //  unsigned 32 bit integer 2D vector
      |                           ^~~~~~~~
/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec2.h:145:27: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/psi29a/Workspace/vsgopenmw/cmake-build-relwithdebinfo/extern/fetched/vsg/include/vsg/maths/vec2.h:145:35: error: template argument 1 is invalid
  145 |     using uivec2 = t_vec2<uint32_t>; //  unsigned 32 bit integer 2D vector
      |                                   ^
```

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
