### PR TITLE
Fix typo in Logger info template function

### DIFF
--- a/include/vsg/io/Logger.h
+++ b/include/vsg/io/Logger.h
@@ -259,7 +259,7 @@ namespace vsg
     /// write info message to the current vsg::Logger::instance().
     /// i.e. info("vertex = ", vsg::vec3(x,y,z));
     template<typename... Args>
-    void info(Args... args)
+    void info(Args&&... args)
     {
         Logger::instance()->info(args...);
     }


### PR DESCRIPTION
There's no reason for the argument list to be declared differently from all the other logging functions.

