### PR TITLE
Store the ImageInfo for font textures in the font

### DIFF
--- a/include/vsg/text/Font.h
+++ b/include/vsg/text/Font.h
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/core/Data.h>
 #include <vsg/io/Options.h>
+#include <vsg/state/ImageInfo.h>
 #include <vsg/text/GlyphMetrics.h>
 #include <vsg/utils/SharedObjects.h>
 
@@ -35,6 +36,8 @@ namespace vsg
         ref_ptr<GlyphMetricsArray> glyphMetrics;
         ref_ptr<uintArray> charmap;
         ref_ptr<SharedObjects> sharedObjects;
+        ref_ptr<ImageInfo> atlasImageInfo;
+        ref_ptr<ImageInfo> glyphImageInfo;
 
         /// get the index into the glyphMetrics array for the glyph associated with specified charcode
         uint32_t glyphIndexForCharcode(uint32_t charcode) const
@@ -42,6 +45,8 @@ namespace vsg
             if (charmap && charcode < charmap->size()) return charmap->at(charcode);
             return 0;
         }
+        void createFontImages();
+    protected:
     };
     VSG_type_name(vsg::Font);
 

--- a/src/vsg/text/Font.cpp
+++ b/src/vsg/text/Font.cpp
@@ -56,3 +56,41 @@ void Font::write(Output& output) const
         output.writeObject("options", options);
     }
 }
+
+void Font::createFontImages()
+{
+    if (!atlasImageInfo)
+    {
+        auto sampler = Sampler::create();
+        sampler->magFilter = VK_FILTER_LINEAR;
+        sampler->minFilter = VK_FILTER_LINEAR;
+        sampler->mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+        sampler->addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+        sampler->addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+        sampler->addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+        sampler->borderColor = VK_BORDER_COLOR_INT_TRANSPARENT_BLACK;
+        sampler->anisotropyEnable = VK_TRUE;
+        sampler->maxAnisotropy = 16.0f;
+        sampler->maxLod = 12.0;
+        atlasImageInfo = ImageInfo::create(sampler, atlas);
+    }
+    if (!glyphImageInfo)
+    {
+        auto glyphMetricSampler = Sampler::create();
+        glyphMetricSampler->magFilter = VK_FILTER_NEAREST;
+        glyphMetricSampler->minFilter = VK_FILTER_NEAREST;
+        glyphMetricSampler->mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+        glyphMetricSampler->addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        glyphMetricSampler->addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        glyphMetricSampler->addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+        glyphMetricSampler->unnormalizedCoordinates = VK_TRUE;
+
+        uint32_t stride = sizeof(vec4);
+        uint32_t numVec4PerGlyph = static_cast<uint32_t>(sizeof(GlyphMetrics) / sizeof(vec4));
+        uint32_t numGlyphs = static_cast<uint32_t>(glyphMetrics->valueCount());
+
+        auto glyphMetricsProxy = vec4Array2D::create(glyphMetrics, 0, stride, numVec4PerGlyph, numGlyphs,
+                                                     Data::Properties{VK_FORMAT_R32G32B32A32_SFLOAT});
+        glyphImageInfo = ImageInfo::create(glyphMetricSampler, glyphMetricsProxy);
+    }
+}

--- a/src/vsg/text/GpuLayoutTechnique.cpp
+++ b/src/vsg/text/GpuLayoutTechnique.cpp
@@ -213,41 +213,12 @@ void GpuLayoutTechnique::setup(Text* text, uint32_t minimumAllocation, ref_ptr<c
         {
             config->shaderHints->defines.insert("BILLBOARD");
         }
-
-        // set up sampler for atlas.
-        auto sampler = Sampler::create();
-        sampler->magFilter = VK_FILTER_LINEAR;
-        sampler->minFilter = VK_FILTER_LINEAR;
-        sampler->mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-        sampler->addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-        sampler->addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-        sampler->addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-        sampler->borderColor = VK_BORDER_COLOR_INT_TRANSPARENT_BLACK;
-        sampler->anisotropyEnable = VK_TRUE;
-        sampler->maxAnisotropy = 16.0f;
-        sampler->maxLod = 12.0;
-
-        if (sharedObjects) sharedObjects->share(sampler);
-
-        auto glyphMetricSampler = Sampler::create();
-        glyphMetricSampler->magFilter = VK_FILTER_NEAREST;
-        glyphMetricSampler->minFilter = VK_FILTER_NEAREST;
-        glyphMetricSampler->mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-        glyphMetricSampler->addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-        glyphMetricSampler->addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-        glyphMetricSampler->addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-        glyphMetricSampler->unnormalizedCoordinates = VK_TRUE;
-
-        if (sharedObjects) sharedObjects->share(glyphMetricSampler);
-
-        uint32_t stride = sizeof(vec4);
-        uint32_t numVec4PerGlyph = static_cast<uint32_t>(sizeof(GlyphMetrics) / sizeof(vec4));
-        uint32_t numGlyphs = static_cast<uint32_t>(text->font->glyphMetrics->valueCount());
-
-        auto glyphMetricsProxy = vec4Array2D::create(text->font->glyphMetrics, 0, stride, numVec4PerGlyph, numGlyphs, Data::Properties{VK_FORMAT_R32G32B32A32_SFLOAT});
-
-        config->assignTexture("textureAtlas", text->font->atlas, sampler);
-        config->assignTexture("glyphMetrics", glyphMetricsProxy, glyphMetricSampler);
+        if (!text->font->atlasImageInfo)
+        {
+            text->font->createFontImages();
+        }
+        config->assignTexture("textureAtlas", {text->font->atlasImageInfo}, 0);
+        config->assignTexture("glyphMetrics", {text->font->glyphImageInfo}, 0);
 
         config->assignDescriptor("textLayout", layoutValue);
         config->assignDescriptor("text", textArray);


### PR DESCRIPTION
This is in place of only storing the Data for the font texture and relying on SharedObjects to find an already created font texture. The font glyph metrics weren't stored as data at all, but were recreated on every creation of a GpuLayoutTechnique.

At the moment this change results in a massive memory savings in complex scenes. There seems to be a bug in SharedObjects in that it can't pick up the images in a font if they are recreated on each use, resulting in gigabytes of extra texture use. Even if SharedObjects is fixed, it is cleaner to store the images in the font.

The glyph metrics texture should probably be a storage buffer instead.

If this is accepted, then the code in vsgXchange that creates a font using freetype should probably change to call createFontImages().