### PR TITLE
FIX: handle change aspect change when render area is not full window.

### DIFF
--- a/include/vsg/app/ProjectionMatrix.h
+++ b/include/vsg/app/ProjectionMatrix.h
@@ -58,9 +58,12 @@ namespace vsg
 
         dmat4 transform() const override { return perspective(radians(fieldOfViewY), aspectRatio, nearDistance, farDistance); }
 
-        void changeExtent(const VkExtent2D&, const VkExtent2D& newExtent) override
+        void changeExtent(const VkExtent2D& prevExtent, const VkExtent2D& newExtent) override
         {
-            aspectRatio = static_cast<double>(newExtent.width) / static_cast<double>(newExtent.height);
+            double oldRatio = static_cast<double>(prevExtent.width) / static_cast<double>(prevExtent.height);
+            double newRatio = static_cast<double>(newExtent.width) / static_cast<double>(newExtent.height);
+
+            aspectRatio *= (newRatio / oldRatio);
         }
 
         void read(Input& input) override;


### PR DESCRIPTION
# Description

When the camera viewport is not the full window, the aspect ratio of the perspective projection matrix needs to be adjusted in the same way as the EllipsoidPerspective case.

# Type of change

This is a behavior-changing fix since the aspect ratio was incorrectly calculated when the viewport extent is not exactly the same as the window extent.

# How Has This Been Tested?

I have tested within my own framework built on top of VSG. I could include a minimal example, but I feel it is unneccessary because VSG already has the correct code in EllipsoidPerspective. This PR aligns the behavior of `Perspective::changeExtent()` and `EllipsoidPerspective::changeExtent()`.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

I have considered the following items, but believe no action needs to be taken

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works