### PR TITLE
add deps to allow inclusion of io/Path.h directly

### DIFF
--- a/include/vsg/io/Path.h
+++ b/include/vsg/io/Path.h
@@ -12,9 +12,11 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <vsg/core/Object.h>
 #include <vsg/io/convert_utf.h>
 
 #include <string>
+#include <map>
 
 namespace vsg
 {


### PR DESCRIPTION
Adding "missing" includes to `io/Path.h` so it can be included directly instead of going through `vsg/all.h`.