### PR TITLE
Fix keyboard modifier typos in Update Win32_Window.h

### DIFF
--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -91,11 +91,11 @@ namespace vsgWin32
             // Check if the modifier keys are down (these are non-toggle keys, so the high-order bit is relevant!)
             // again, vsg only has a side-independent modifier
             if (keyState[VK_LSHIFT] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Shift;
-            if (keyState[VK_LSHIFT] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Shift;
+            if (keyState[VK_RSHIFT] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Shift;
             if (keyState[VK_LCONTROL] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Control;
             if (keyState[VK_RCONTROL] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Control;
             if (keyState[VK_LMENU] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Alt;
-            if (keyState[VK_LMENU] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Alt;
+            if (keyState[VK_RMENU] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Alt;
 
             // This is the final keyModifier
             keyModifier = static_cast<vsg::KeyModifier>(modifierMask);


### PR DESCRIPTION
# Pull Request Template

## Description

Typos in vsgWin32::KeyboardMap::getKeySymbol prevented VK_RSHIFT and VK_RMENU key's (Right shift & Right Alt) being mapped to MODKEY_Shift and MODKEY_Alt modifiers.

Previously there were duplicate entries for VK_LSHIFT and VK_LMENU instead of their "R" counterparts.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on windows with master. Keyboard modifiers work correctly for right shift & right alt key presses.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
