### PR TITLE
Add is_compatible to Visitor and ConstVisitor

### DIFF
--- a/include/vsg/core/ConstVisitor.h
+++ b/include/vsg/core/ConstVisitor.h
@@ -403,6 +403,8 @@ namespace vsg
 
         // general classes
         virtual void apply(const FrameStamp&);
+
+        bool is_compatible(const std::type_info& type) const noexcept override { return typeid(ConstVisitor) == type || Object::is_compatible(type); }
     };
 
     // provide Value<>::accept() implementation

--- a/include/vsg/core/Visitor.h
+++ b/include/vsg/core/Visitor.h
@@ -403,6 +403,8 @@ namespace vsg
 
         // general classes
         virtual void apply(FrameStamp&);
+
+        bool is_compatible(const std::type_info& type) const noexcept override { return typeid(Visitor) == type || Object::is_compatible(type); }
     };
 
     // provide Value<>::accept() implementation


### PR DESCRIPTION
## Description

Add is_compatible to Visitor and ConstVisitor to fix cast from vsg::Object to vsg::Visitor/vsg::ConstVisitor

Fixes  #1089

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Sample in the issue #1089 works

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
