### PR TITLE
Make it easier to use separate samplers and textures

### DIFF
--- a/include/vsg/state/DescriptorImage.h
+++ b/include/vsg/state/DescriptorImage.h
@@ -27,6 +27,8 @@ namespace vsg
         DescriptorImage(const DescriptorImage& rhs, const CopyOp& copyop = {});
 
         DescriptorImage(ref_ptr<Sampler> sampler, ref_ptr<Data> image, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+        DescriptorImage(ref_ptr<Sampler> sampler, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER);
+        DescriptorImage(ref_ptr<Data> image, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
 
         template<class T>
         DescriptorImage(ref_ptr<Sampler> sampler, ref_ptr<T> image, uint32_t in_dstBinding = 0, uint32_t in_dstArrayElement = 0, VkDescriptorType in_descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) :

--- a/include/vsg/state/DescriptorImage.h
+++ b/include/vsg/state/DescriptorImage.h
@@ -27,8 +27,6 @@ namespace vsg
         DescriptorImage(const DescriptorImage& rhs, const CopyOp& copyop = {});
 
         DescriptorImage(ref_ptr<Sampler> sampler, ref_ptr<Data> image, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-        DescriptorImage(ref_ptr<Sampler> sampler, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER);
-        DescriptorImage(ref_ptr<Data> image, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0, VkDescriptorType descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
 
         template<class T>
         DescriptorImage(ref_ptr<Sampler> sampler, ref_ptr<T> image, uint32_t in_dstBinding = 0, uint32_t in_dstArrayElement = 0, VkDescriptorType in_descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) :
@@ -55,4 +53,7 @@ namespace vsg
     };
     VSG_type_name(vsg::DescriptorImage);
 
+    extern VSG_DECLSPEC ref_ptr<DescriptorImage> createSamplerDescriptor(ref_ptr<Sampler> sampler, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0);
+    extern VSG_DECLSPEC ref_ptr<DescriptorImage> createCombinedImageSamplerDescriptor(ref_ptr<Sampler> sampler, ref_ptr<Data> image, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0);
+    extern VSG_DECLSPEC ref_ptr<DescriptorImage> createSampedImageDescriptor(ref_ptr<Data> image, uint32_t dstBinding = 0, uint32_t dstArrayElement = 0);
 } // namespace vsg

--- a/src/vsg/state/DescriptorImage.cpp
+++ b/src/vsg/state/DescriptorImage.cpp
@@ -42,6 +42,24 @@ DescriptorImage::DescriptorImage(ref_ptr<Sampler> sampler, ref_ptr<Data> data, u
     }
 }
 
+DescriptorImage::DescriptorImage(ref_ptr<Sampler> sampler, uint32_t in_dstBinding, uint32_t in_dstArrayElement, VkDescriptorType in_descriptorType) :
+    Inherit(in_dstBinding, in_dstArrayElement, in_descriptorType)
+{
+    if (sampler)
+    {
+        imageInfoList.push_back(ImageInfo::create(sampler, ref_ptr<ImageView>()));
+    }
+}
+
+DescriptorImage::DescriptorImage(ref_ptr<Data> data, uint32_t in_dstBinding, uint32_t in_dstArrayElement, VkDescriptorType in_descriptorType) :
+    Inherit(in_dstBinding, in_dstArrayElement, in_descriptorType)
+{
+    if (data)
+    {
+        imageInfoList.push_back(ImageInfo::create(ref_ptr<Sampler>(), data));
+    }
+}
+
 DescriptorImage::DescriptorImage(ref_ptr<ImageInfo> imageInfo, uint32_t in_dstBinding, uint32_t in_dstArrayElement, VkDescriptorType in_descriptorType) :
     Inherit(in_dstBinding, in_dstArrayElement, in_descriptorType)
 {

--- a/src/vsg/state/DescriptorImage.cpp
+++ b/src/vsg/state/DescriptorImage.cpp
@@ -42,24 +42,6 @@ DescriptorImage::DescriptorImage(ref_ptr<Sampler> sampler, ref_ptr<Data> data, u
     }
 }
 
-DescriptorImage::DescriptorImage(ref_ptr<Sampler> sampler, uint32_t in_dstBinding, uint32_t in_dstArrayElement, VkDescriptorType in_descriptorType) :
-    Inherit(in_dstBinding, in_dstArrayElement, in_descriptorType)
-{
-    if (sampler)
-    {
-        imageInfoList.push_back(ImageInfo::create(sampler, ref_ptr<ImageView>()));
-    }
-}
-
-DescriptorImage::DescriptorImage(ref_ptr<Data> data, uint32_t in_dstBinding, uint32_t in_dstArrayElement, VkDescriptorType in_descriptorType) :
-    Inherit(in_dstBinding, in_dstArrayElement, in_descriptorType)
-{
-    if (data)
-    {
-        imageInfoList.push_back(ImageInfo::create(ref_ptr<Sampler>(), data));
-    }
-}
-
 DescriptorImage::DescriptorImage(ref_ptr<ImageInfo> imageInfo, uint32_t in_dstBinding, uint32_t in_dstArrayElement, VkDescriptorType in_descriptorType) :
     Inherit(in_dstBinding, in_dstArrayElement, in_descriptorType)
 {
@@ -178,4 +160,22 @@ void DescriptorImage::assignTo(Context& context, VkWriteDescriptorSet& wds) cons
 uint32_t DescriptorImage::getNumDescriptors() const
 {
     return static_cast<uint32_t>(imageInfoList.size());
+}
+
+VSG_DECLSPEC ref_ptr<DescriptorImage> vsg::createSamplerDescriptor(ref_ptr<Sampler> sampler, uint32_t dstBinding, uint32_t dstArrayElement)
+{
+    ref_ptr<ImageInfo> imageImageInfo = ImageInfo::create(sampler, ref_ptr<ImageView>(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    return DescriptorImage::create(imageImageInfo, dstBinding, dstArrayElement, VK_DESCRIPTOR_TYPE_SAMPLER);
+}
+
+VSG_DECLSPEC ref_ptr<DescriptorImage> vsg::createCombinedImageSamplerDescriptor(ref_ptr<Sampler> sampler, ref_ptr<Data> image, uint32_t dstBinding, uint32_t dstArrayElement)
+{
+    ref_ptr<ImageInfo> imageImageInfo = ImageInfo::create(sampler, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    return DescriptorImage::create(imageImageInfo, dstBinding, dstArrayElement, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+}
+
+VSG_DECLSPEC ref_ptr<DescriptorImage> vsg::createSampedImageDescriptor(ref_ptr<Data> image, uint32_t dstBinding, uint32_t dstArrayElement)
+{
+    ref_ptr<ImageInfo> imageImageInfo = ImageInfo::create(ref_ptr<Sampler>(), image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    return DescriptorImage::create(imageImageInfo, dstBinding, dstArrayElement, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
 }


### PR DESCRIPTION
## Description

Vulkan optionally lets you set up textures and samplers separately, and only combine them in the shader, just like is mandatory in older Direct3D versions (I've not checked D3D12, but I'd assume it's optional just like in Vulkan).

This was already possible with the VSG, but was a pain to set up as there was nothing saying which hoops needed to be jumped through. This adds a couple of convenience constructors to DescriptorImage that do the hoop-jumping automatically.

Fixes nothing on the tracker - it seemed faster to just make the PR

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- 🤷 This change requires a documentation update

## How Has This Been Tested?

- [ ] I converted the shadow maps in `ViewDependentState` to use a separate sampler (as soft shadow techniques like PCSS typically require the same texture to be sampled with both a `sampler2D` to access raw depth values and a `sampler2Dshadow` to do hardware-PCF depth comparisons. It still worked.

**Test Configuration**:
* Firmware version: 
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ I think it's self-documenting, at least in comparison to the surrounding code.
- [ ] ~~I have made corresponding changes to the documentation~~ I've not found any documentation for DescriptorImage that goes into enough detail to be affected by this change.
- [ ] ~~My changes generate no new warnings~~ There are no warnings enabled with MSVC - I might fix that at some point.
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ I can't even find tests. Should this line be changed? I've not added anything to vsgExamples yet.
- [ ] ~~New and existing unit tests pass locally with my changes~~ N/A - this just adds functions.
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~ N/A
