### PR TITLE
Add nullptr constructor overload for ref_ptr

### DIFF
--- a/include/vsg/core/ref_ptr.h
+++ b/include/vsg/core/ref_ptr.h
@@ -60,6 +60,10 @@ namespace vsg
             if (_ptr) _ptr->ref();
         }
 
+        // std::nullptr_t requires extra header
+        ref_ptr(decltype(nullptr)) noexcept :
+            ref_ptr() {}
+
         ~ref_ptr()
         {
             if (_ptr) _ptr->unref();

--- a/src/vsg/state/DescriptorImage.cpp
+++ b/src/vsg/state/DescriptorImage.cpp
@@ -164,7 +164,7 @@ uint32_t DescriptorImage::getNumDescriptors() const
 
 VSG_DECLSPEC ref_ptr<DescriptorImage> vsg::createSamplerDescriptor(ref_ptr<Sampler> sampler, uint32_t dstBinding, uint32_t dstArrayElement)
 {
-    ref_ptr<ImageInfo> imageImageInfo = ImageInfo::create(sampler, ref_ptr<ImageView>(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    ref_ptr<ImageInfo> imageImageInfo = ImageInfo::create(sampler, nullptr, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     return DescriptorImage::create(imageImageInfo, dstBinding, dstArrayElement, VK_DESCRIPTOR_TYPE_SAMPLER);
 }
 
@@ -176,6 +176,6 @@ VSG_DECLSPEC ref_ptr<DescriptorImage> vsg::createCombinedImageSamplerDescriptor(
 
 VSG_DECLSPEC ref_ptr<DescriptorImage> vsg::createSampedImageDescriptor(ref_ptr<Data> image, uint32_t dstBinding, uint32_t dstArrayElement)
 {
-    ref_ptr<ImageInfo> imageImageInfo = ImageInfo::create(ref_ptr<Sampler>(), image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    ref_ptr<ImageInfo> imageImageInfo = ImageInfo::create(nullptr, image, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     return DescriptorImage::create(imageImageInfo, dstBinding, dstArrayElement, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
 }

--- a/src/vsg/state/ViewDependentState.cpp
+++ b/src/vsg/state/ViewDependentState.cpp
@@ -299,7 +299,7 @@ void ViewDependentState::init(ResourceRequirements& requirements)
         depthImageView->subresourceRange.baseArrayLayer = 0;
         depthImageView->subresourceRange.layerCount = maxShadowMaps;
 
-        auto depthImageInfo = ImageInfo::create(vsg::ref_ptr<Sampler>(), depthImageView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL);
+        auto depthImageInfo = ImageInfo::create(nullptr, depthImageView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL);
 
         shadowMapImages = DescriptorImage::create(ImageInfoList{depthImageInfo}, 2, 0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     }
@@ -323,7 +323,7 @@ void ViewDependentState::init(ResourceRequirements& requirements)
         depthImageView->subresourceRange.baseArrayLayer = 0;
         depthImageView->subresourceRange.layerCount = 1;
 
-        auto depthImageInfo = ImageInfo::create(vsg::ref_ptr<Sampler>(), depthImageView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL);
+        auto depthImageInfo = ImageInfo::create(nullptr, depthImageView, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL);
 
         shadowMapImages = DescriptorImage::create(ImageInfoList{depthImageInfo}, 2, 0 , VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     }


### PR DESCRIPTION
This time, use `decltype(nullptr)` instead of `std::nullptr_t` as the latter requires `<cstddef>`. The standard guarantees that these are the same type.

I've actually built this with GCC and libstdc++ this time, so know it doesn't cause problems.