### PR TITLE
Fix "build error: 'int8_t' was not declared in this scope" with gcc13 for MinGW

### DIFF
--- a/include/vsg/core/type_name.h
+++ b/include/vsg/core/type_name.h
@@ -12,6 +12,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <cstdint>
 #include <string>
 #include <typeinfo>
 


### PR DESCRIPTION
# Pull Request Template

## Description

The commit from this merge request fixes a build error with gcc13 for MinGW.

Fix #1119

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Rebuild package with this commit applied, see **https://build.opensuse.org/package/show/home:rhabacker:branches:games:mingw64/mingw64-libvsg**

**Test Configuration**:
* Toolchain: openSUSE Tumbleweed
* SDK: sdk-1.3.250.0

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
