### PR TITLE
Option to add the installation of an event filter to an existing Win3…

### DIFF
--- a/include/vsg/app/WindowTraits.h
+++ b/include/vsg/app/WindowTraits.h
@@ -94,6 +94,9 @@ namespace vsg
         std::any nativeWindow;
         std::any systemConnection;
 
+        // If true, then install an event filter for an existing Win32 window
+        bool installEventHandler = false;
+
     protected:
         virtual ~WindowTraits() {}
     };

--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -198,6 +198,7 @@ namespace vsgWin32
 
         HWND _window;
         bool _windowMapped = false;
+        WNDPROC _windowProcedure;
 
         vsg::ref_ptr<KeyboardMap> _keyboard;
     };

--- a/src/vsg/app/WindowTraits.cpp
+++ b/src/vsg/app/WindowTraits.cpp
@@ -51,9 +51,10 @@ WindowTraits::WindowTraits(const WindowTraits& traits) :
     deviceExtensionNames(traits.deviceExtensionNames),
     deviceTypePreferences(traits.deviceTypePreferences),
     deviceFeatures(traits.deviceFeatures),
-    samples(traits.samples) /*,
+    samples(traits.samples)/*,
     nativeWindow(traits.nativeWindow),
-    systemConnection(traits.systemConnection)*/
+    systemConnection(traits.systemConnection)*/,
+    installEventHandler(traits.installEventHandler)
 {
 }
 


### PR DESCRIPTION
When integrating Vulkranscenegraph into an existing Win32 application (MFC program) I noticed that there is no event handler. With the flag installEventHandler in the WindowTraits class, the existing event handler in Win32_Window can be used if required.

The default value of the flag is set to False to avoid unwanted side effects (like in vsgQt).

I have adapted the solution from the Openscenegraph project, as you should recognize.
