### PR TITLE
Add ninja-related files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,11 @@ CMakeScripts
 Makefile
 cmake_install.cmake
 install_manifest.txt
+*.ninja
+.ninja_log
+.ninja_deps
+.cmake/
+compile_commands.json
 
 
 # Compiled Object files


### PR DESCRIPTION
Some of them may also be relevant for other CMake generators when certain settings are used. I believe `.cmake` and `compile_commands.json` aren't Ninja-specific and are used by IDE integration for other things, too.