### PR TITLE
Avoid duplicate vkCmdBind calls when recording.

### DIFF
--- a/include/vsg/app/RecordTraversal.h
+++ b/include/vsg/app/RecordTraversal.h
@@ -42,6 +42,7 @@ namespace vsg
     class VertexIndexDraw;
     class Geometry;
     class Command;
+    class StateCommand;
     class Commands;
     class CommandBuffer;
     class State;
@@ -145,6 +146,7 @@ namespace vsg
         // Commands
         void apply(const Commands& commands);
         void apply(const Command& command);
+        void apply(const StateCommand&);
 
         // Viewer level nodes
         void apply(const Bin& bin);

--- a/src/vsg/app/RecordTraversal.cpp
+++ b/src/vsg/app/RecordTraversal.cpp
@@ -485,6 +485,13 @@ void RecordTraversal::apply(const Command& command)
     command.record(*(_state->_commandBuffer));
 }
 
+void RecordTraversal::apply(const StateCommand&)
+{
+    // do nothing.
+    // _state stack is populated in RecordTraversal::apply(StateGroup)
+    // and _state->record() is called as needed for all other Commands.
+}
+
 void RecordTraversal::apply(const Bin& bin)
 {
     GPU_INSTRUMENTATION_L1_NCO(instrumentation, *getCommandBuffer(), "Bin", COLOR_RECORD_L1, &bin);


### PR DESCRIPTION
vkCmdBindPipeline and vkCmdBindDescriptorSets (and potentially others) were recorded twice - first with the State stack and then again with the StateCommand which was processed as a Command object. This fix creates a no-op RecordTraversal::apply(StateCommand).

fixes #1170

## Type of change

This *may* be a breaking change. It does not break on the examples I have tested.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Running any of the VSG examples in Renderdoc and looking at the vkCmdBind calls in the first draw call.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
