### PR TITLE
Set version to 1.1.4 so I can do feature test macros for physics allocator affinity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7)
 
 project(vsg
-    VERSION 1.1.3
+    VERSION 1.1.4
     DESCRIPTION "VulkanSceneGraph library"
     LANGUAGES CXX
 )


### PR DESCRIPTION
I don't know if 1.1.4 is the right version as the allocator type option was removed at the same time, and that's a breaking change.