### PR TITLE
Fix button value in ButtonPressEvent and ButtonReleaseEvent when doub…

### DIFF
--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -132,9 +132,13 @@ namespace vsgWin32
     {
         switch (buttonMsg)
         {
+        case WM_LBUTTONDBLCLK:
         case WM_LBUTTONDOWN: return 1;
+        case WM_MBUTTONDBLCLK:
         case WM_MBUTTONDOWN: return 2;
+        case WM_RBUTTONDBLCLK:
         case WM_RBUTTONDOWN: return 3;
+        case WM_XBUTTONDBLCLK:
         case WM_XBUTTONDOWN:
             if (wParamHi == XBUTTON1)
                 return 4;


### PR DESCRIPTION
## Description

Windows has dedicated message for double click. Old behavior with this handler 
```
class IntersectionHandler : public vsg::Inherit<vsg::Visitor, IntersectionHandler>
{
public:

    void apply(vsg::ButtonReleaseEvent& evt) override {
        std::cout << "Release button = " << evt.button << " mask = " << evt.mask << std::endl;
    }

    void apply(vsg::ButtonPressEvent& evt) override
    {
        std::cout << "Press button = " << evt.button << " mask = " << evt.mask << std::endl;
    }

};
```
is 
```
Press button = 1 mask = 256
Release button = 1 mask = 0
Press button = 0 mask = 256
Release button = 1 mask = 0
```

Where button 0 doesn't look correct value for left button double click. With this changes:
```
Press button = 1 mask = 256
Release button = 1 mask = 0
Press button = 1 mask = 256
Release button = 1 mask = 0
```
And this depicts correctly the action.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It was tested with handler above.

**Test Configuration**:
Windows 11

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
