### PR TITLE
Default ~Builder() in cpp file

### DIFF
--- a/include/vsg/utils/Builder.h
+++ b/include/vsg/utils/Builder.h
@@ -136,6 +136,8 @@ namespace vsg
         ref_ptr<CompileTraversal> compileTraversal;
 
     protected:
+        ~Builder();
+
         void transform(const mat4& matrix, ref_ptr<vec3Array> vertices, ref_ptr<vec3Array> normals);
         ref_ptr<Data> instancePositions(const GeometryInfo& info, uint32_t& instanceCount);
         ref_ptr<Data> instanceColors(const GeometryInfo& info, uint32_t instanceCount);

--- a/include/vsg/utils/Builder.h
+++ b/include/vsg/utils/Builder.h
@@ -114,6 +114,8 @@ namespace vsg
         Builder(const Builder& rhs) = delete;
         Builder& operator = (const Builder& rhs) = delete;
 
+        ~Builder();
+
         bool verbose = false;
         ref_ptr<Options> options;
         ref_ptr<SharedObjects> sharedObjects;
@@ -136,8 +138,6 @@ namespace vsg
         ref_ptr<CompileTraversal> compileTraversal;
 
     protected:
-        ~Builder();
-
         void transform(const mat4& matrix, ref_ptr<vec3Array> vertices, ref_ptr<vec3Array> normals);
         ref_ptr<Data> instancePositions(const GeometryInfo& info, uint32_t& instanceCount);
         ref_ptr<Data> instanceColors(const GeometryInfo& info, uint32_t instanceCount);

--- a/src/vsg/utils/Builder.cpp
+++ b/src/vsg/utils/Builder.cpp
@@ -25,6 +25,8 @@ Builder::Builder()
 {
 }
 
+Builder::~Builder() = default;
+
 void Builder::assignCompileTraversal(ref_ptr<CompileTraversal> ct)
 {
     compileTraversal = ct;


### PR DESCRIPTION
This isn't enough to make `Builder.h` a self-sufficient header for shared library builds (as some of the things it includes aren't themselves self-sufficient), but is enough to mean projects subclassing `vsg::Builder` don't need to `#include <vsg/io/Options.h>` if they don't use it.