### PR TITLE
only install cmake on non-window runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
 env:
   BuildDocEnabled: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+  CMakeVersion: 3.10.x
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -22,6 +23,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v1.12
+      if: ${{ !startsWith(matrix.os, 'windows')}}
       with:
         cmake-version: ${{ env.CMakeVersion }}
     - name: Install Vulkan SDK


### PR DESCRIPTION
…  and added control back for cmake version - windows will default to cmake provided by the runner

# Pull Request Template

## Description

I prefer this fix over with removing the variable that controls cmake completely. Completely removing it will default all runners to latest and greatest which may not be desirable for linux package managers.

