### PR TITLE
Ensure minimum maxSets is at least one

### DIFF
--- a/src/vsg/vk/Context.cpp
+++ b/src/vsg/vk/Context.cpp
@@ -10,6 +10,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <algorithm>
+#include <cassert>
+
 #include <vsg/commands/Commands.h>
 #include <vsg/commands/CopyAndReleaseBuffer.h>
 #include <vsg/commands/CopyAndReleaseImage.h>
@@ -96,7 +99,7 @@ Context::Context(Device* in_device, const ResourceRequirements& in_resourceRequi
     //semaphore = vsg::Semaphore::create(device);
     scratchMemory = ScratchMemory::create(4096);
 
-    minimum_maxSets = in_resourceRequirements.computeNumDescriptorSets();
+    minimum_maxSets = std::max(1u, in_resourceRequirements.computeNumDescriptorSets());
     minimum_descriptorPoolSizes = in_resourceRequirements.computeDescriptorPoolSizes();
 }
 
@@ -255,7 +258,8 @@ void Context::reserve(const ResourceRequirements& requirements)
     if (required_maxSets > 0 || !required_descriptorPoolSizes.empty())
     {
         getDescriptorPoolSizesToUse(required_maxSets, required_descriptorPoolSizes);
-        if (required_maxSets > 0 && !required_descriptorPoolSizes.empty())
+        assert(required_maxSets >= minimum_maxSets);
+        if (!required_descriptorPoolSizes.empty())
         {
             descriptorPools.push_back(vsg::DescriptorPool::create(device, required_maxSets, required_descriptorPoolSizes));
         }


### PR DESCRIPTION
Following the discussions in #960 and #961 this sets the minimum maxSets to 1 so that when switching out graphics pipelines that use different descriptor sets, the warning about Context::reserve() is avoided. See also 

See issues:

* #960 
* #961 

And in vsgExamples:

* https://github.com/vsg-dev/vsgExamples/issues/312
* https://github.com/vsg-dev/vsgExamples/pull/311

This PR is a possible fix for the warning, but it's unclear to this author if this is the correct and robust solution. I expect a discussion on the merits of this w.r.t. other possible changes to follow here or in the discussion board.