### PR TITLE
Update quat.h

### DIFF
--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -119,7 +119,7 @@ namespace vsg
             value_type dot_pd = vsg::dot(from, to);
             value_type div = std::sqrt(length2(from) * length2(to));
             vsg::dvec3 axis;
-            if (div - dot_pd < epsilon)
+            if (div - std::abs(dot_pd) < epsilon)
             {
                 axis = orthogonal(from);
             }


### PR DESCRIPTION

If from and to vectors are close to being opposite, it is not handled properly.  For example, if from is (0,0,1) and to is (0,0,-1) the dot product is -1 this will imply that the axis will be (0,0,0), the length = 0 and the inversenorm will be infinite.

For the proposed solution, note that div is always greater or equal than dot_pd


