### PR TITLE
Fix forward and back animation issue

### DIFF
--- a/src/vsg/animation/Animation.cpp
+++ b/src/vsg/animation/Animation.cpp
@@ -136,17 +136,18 @@ bool Animation::update(double simulationTime)
         return x < 0.0 ? y + std::fmod(x, y) : std::fmod(x, y);
     };
 
-    time = time + (simulationTime - _previousSimulationTime) * speed;
+    auto samplerTime = time = time + (simulationTime - _previousSimulationTime) * speed;
+
     _previousSimulationTime = simulationTime;
 
     if (mode == REPEAT)
     {
-        time = time_within_period(time, _maxTime);
+        samplerTime = time = time_within_period(time, _maxTime);
     }
     else if (mode == FORWARD_AND_BACK)
     {
-        time = time_within_period(time, 2.0 * _maxTime);
-        if (time > _maxTime) time = 2.0 * _maxTime - time;
+        samplerTime = time = time_within_period(time, 2.0 * _maxTime);
+        if (time > _maxTime) samplerTime = 2.0 * _maxTime - time;
     }
     else
     {
@@ -159,7 +160,7 @@ bool Animation::update(double simulationTime)
 
     for (auto sampler : samplers)
     {
-        sampler->update(time);
+        sampler->update(samplerTime);
     }
 
     return true;


### PR DESCRIPTION
## Description

There is an issue with this code
```
time = time_within_period(time, 2.0 * _maxTime);
if (time > _maxTime) time = 2.0 * _maxTime - time;
```
```time``` value should run though the range of [0, 2 * maxTime] but as soon as it reaches maxTime it will stop grow and never reach 2.0 * _maxTime thus backward part won't work. I've added additional variable samplerTime which stores time for sampler while ```time``` variable will be able to move forward in the range [0, 2 * maxTime].

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Create simple forward and backward animation, start it and check incoming values to the sampler

```
auto animation = vsg::Animation::create();
animation->mode = vsg::Animation::FORWARD_AND_BACK;
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
