### PR TITLE
Ensure animation ends on final key frame

### DIFF
--- a/src/vsg/animation/Animation.cpp
+++ b/src/vsg/animation/Animation.cpp
@@ -132,6 +132,8 @@ bool Animation::update(double simulationTime)
 {
     if (!_active) return false;
 
+    bool finished = false;
+
     auto time_within_period = [](double x, double y) -> double {
         return x < 0.0 ? y + std::fmod(x, y) : std::fmod(x, y);
     };
@@ -153,14 +155,20 @@ bool Animation::update(double simulationTime)
     {
         if (time > _maxTime)
         {
-            stop(simulationTime);
-            return false;
+            finished = true;
+            samplerTime = time = _maxTime;
         }
     }
 
     for (auto sampler : samplers)
     {
         sampler->update(samplerTime);
+    }
+
+    if(finished)
+    {
+        stop(simulationTime);
+        return false;
     }
 
     return true;


### PR DESCRIPTION
When you set up an animation you expect that it will end on the final key frame (if not repeating). At present, the animation ceases updating on the last frame before the animation time exceeds the time of the final key frame. If key frames are spaced apart by greater than the frame rate then the final key frame is never reached.

This PR delays stopping the animation until after the final key frame is processed.

All repeat modes have been tested.
