### PR TITLE
Move numReadThreads to be a class member so that it can be set extern…

### DIFF
--- a/include/vsg/io/DatabasePager.h
+++ b/include/vsg/io/DatabasePager.h
@@ -99,6 +99,8 @@ namespace vsg
         std::atomic_uint numActiveRequests{0};
         std::atomic_uint64_t frameCount;
 
+        int numReadThreads{4};
+
         ref_ptr<CulledPagedLODs> culledPagedLODs;
 
         /// for systems with smaller GPU memory limits you may need to reduce the targetMaxNumPagedLODWithHighResSubgraphs to keep memory usage within available limits.

--- a/src/vsg/io/DatabasePager.cpp
+++ b/src/vsg/io/DatabasePager.cpp
@@ -133,8 +133,6 @@ void DatabasePager::assignInstrumentation(ref_ptr<Instrumentation> in_instrument
 
 void DatabasePager::start()
 {
-    int numReadThreads = 4;
-
     //
     // set up read thread(s)
     //


### PR DESCRIPTION
Make numReadThreads a member of DatabasePager so that it can be set externally if desired. It used to be hardwired in the start() method. The default value is kept the same so there should be no effect on existing code.