### PR TITLE
Robust view resize via modification counting

### DIFF
--- a/include/vsg/app/View.h
+++ b/include/vsg/app/View.h
@@ -35,6 +35,8 @@ namespace vsg
     class VSG_DECLSPEC View : public Inherit<Group, View>
     {
     public:
+        static ModifiedCount modifiedCount(uint32_t viewID);
+
         View(ViewFeatures in_features = RECORD_ALL);
 
         // share the specified view's children, viewID, mask and camera ViewportState
@@ -62,6 +64,10 @@ namespace vsg
 
         /// share the specified view's viewID, mask, camera ViewportState, with this View
         void share(const View& view);
+
+        /// incremented when the pipeline state for the viewID is invalidated
+        ModifiedCount modifiedCount();
+        void modified();
 
         /// camera controls the viewport state and projection and view matrices
         ref_ptr<Camera> camera;

--- a/include/vsg/state/GraphicsPipeline.h
+++ b/include/vsg/state/GraphicsPipeline.h
@@ -95,6 +95,8 @@ namespace vsg
 
             virtual ~Implementation();
 
+            ModifiedCount viewModifiedCount;
+
             VkPipeline _pipeline;
 
             ref_ptr<Device> _device;

--- a/src/vsg/app/WindowResizeHandler.cpp
+++ b/src/vsg/app/WindowResizeHandler.cpp
@@ -144,11 +144,13 @@ void WindowResizeHandler::apply(vsg::View& view)
 {
     if (!visit(&view)) return;
 
+    auto previous_viewID = context->viewID;
     context->viewID = view.viewID;
 
     if (!view.camera)
     {
         view.traverse(*this);
+        context->viewID = previous_viewID;
         return;
     }
 
@@ -183,4 +185,5 @@ void WindowResizeHandler::apply(vsg::View& view)
     view.traverse(*this);
 
     context->defaultPipelineStates.pop_back();
+    context->viewID = previous_viewID;
 }

--- a/src/vsg/app/WindowResizeHandler.cpp
+++ b/src/vsg/app/WindowResizeHandler.cpp
@@ -45,7 +45,6 @@ void UpdateGraphicsPipelines::apply(vsg::BindGraphicsPipeline& bindPipeline)
     auto pipeline = bindPipeline.pipeline;
     if (pipeline)
     {
-        pipeline->release(context->viewID);
         pipeline->compile(*context);
     }
 }
@@ -118,7 +117,6 @@ void WindowResizeHandler::apply(vsg::BindGraphicsPipeline& bindPipeline)
         bool needToRegenerateGraphicsPipeline = !containsViewport(*graphicsPipeline);
         if (needToRegenerateGraphicsPipeline)
         {
-            graphicsPipeline->release(context->viewID);
             graphicsPipeline->compile(*context);
         }
     }
@@ -179,6 +177,8 @@ void WindowResizeHandler::apply(vsg::View& view)
             renderArea = scissor;
         }
     }
+
+    view.modified();
 
     context->defaultPipelineStates.emplace_back(viewportState);
 

--- a/src/vsg/state/GraphicsPipeline.cpp
+++ b/src/vsg/state/GraphicsPipeline.cpp
@@ -10,6 +10,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <vsg/app/View.h>
 #include <vsg/core/Exception.h>
 #include <vsg/core/compare.h>
 #include <vsg/io/Logger.h>
@@ -138,7 +139,7 @@ void GraphicsPipeline::compile(Context& context)
         _implementation.resize(viewID + 1);
     }
 
-    if (!_implementation[viewID])
+    if (!_implementation[viewID] || _implementation[viewID]->viewModifiedCount != View::modifiedCount(context.viewID))
     {
         // compile shaders if required
         bool requiresShaderCompiler = false;
@@ -189,6 +190,7 @@ void GraphicsPipeline::compile(Context& context)
 // GraphicsPipeline::Implementation
 //
 GraphicsPipeline::Implementation::Implementation(Context& context, Device* device, const RenderPass* renderPass, const PipelineLayout* pipelineLayout, const ShaderStages& shaderStages, const GraphicsPipelineStates& pipelineStates, uint32_t subpass) :
+    viewModifiedCount(View::modifiedCount(context.viewID)),
     _device(device)
 {
     VkGraphicsPipelineCreateInfo pipelineInfo = {};


### PR DESCRIPTION
This should solve the problem where, if a subgraph is temporarily removed from the scenegraph, and a resize happens while it's detached, nothing would clear the outdated pipeline(s), and future attempts to recompile the pipeline would be skipped due to one already existing.

As noted elsewhere, I think it would be more sensible for viewport state to be dynamic so the pipeline doesn't need to be recompiled in the first place, but this is a simpler and less invasive change that also fixes the problem.