### PR TITLE
Remove CONFIG mode specification from find_package(glslang)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,10 @@ set(VSG_MAX_INSTRUMENTATION_LEVEL 1 CACHE STRING "Set the instrumentation level 
 set(VSG_SUPPORTS_ShaderCompiler  1 CACHE STRING "Optional shader compiler support, 0 for off, 1 for enabled." )
 if (VSG_SUPPORTS_ShaderCompiler)
     set(GLSLANG_MIN_VERSION "14" CACHE STRING "glslang 14 is the earliest version that we think installs itself properly on all platforms. Other platforms may be able to use an earlier version")
-    find_package(glslang ${GLSLANG_MIN_VERSION} CONFIG)
+    find_package(glslang ${GLSLANG_MIN_VERSION})
 
     if (glslang_FOUND)
-        set(FIND_DEPENDENCY_glslang "find_package(glslang ${GLSLANG_MIN_VERSION} CONFIG REQUIRED)")
+        set(FIND_DEPENDENCY_glslang "find_package(glslang ${GLSLANG_MIN_VERSION} REQUIRED)")
     else()
         message(WARNING "glslang not found. ShaderCompile support disabled.")
         set(VSG_SUPPORTS_ShaderCompiler 0)


### PR DESCRIPTION
## Description
Removes the hard-coded CONFIG mode from https://github.com/vsg-dev/VulkanSceneGraph/blob/b64dbb2cb70236071eae8687e0b0ec9e134acd2f/CMakeLists.txt#L47

---
### Why

This allows projects to more easily use vsg as a code dependency (MODULE mode). Projects can still use it as an installed dependency (CONFIG mode) since CMake gracefully falls-back to CONFIG mode in the event MODULE mode fails. (see https://cmake.org/cmake/help/latest/command/find_package.html#id7)

This allows developers to easily use both modes.

Note that **by default** CMake starts in MODULE mode (which can easily be overridden if users set `CMAKE_FIND_PACKAGE_PREFER_CONFIG ON`).

Fixes # https://github.com/vsg-dev/VulkanSceneGraph/issues/1271

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have a private project where I tested this as working.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
