### PR TITLE
Implemented release of static data after transfer to the GPU

### DIFF
--- a/src/vsg/app/TransferTask.cpp
+++ b/src/vsg/app/TransferTask.cpp
@@ -151,14 +151,14 @@ void TransferTask::_transferBufferInfos(VkCommandBuffer vk_commandBuffer, Frame&
                     offset = (/*alignment == 1 ||*/ (endOfEntry % alignment) == 0) ? endOfEntry : ((endOfEntry / alignment) + 1) * alignment;
                 }
 
-                if (bufferInfo->data->properties.dataVariance == STATIC_DATA)
+                if (bufferInfo->data->dynamic())
                 {
-                    log(level, "       removing copied static data: ", bufferInfo, ", ", bufferInfo->data);
-                    bufferInfo_itr = bufferInfos.erase(bufferInfo_itr);
+                    ++bufferInfo_itr;
                 }
                 else
                 {
-                    ++bufferInfo_itr;
+                    log(level, "       removing copied static data: ", bufferInfo, ", ", bufferInfo->data);
+                    bufferInfo_itr = bufferInfos.erase(bufferInfo_itr);
                 }
             }
         }
@@ -240,14 +240,14 @@ void TransferTask::_transferImageInfos(VkCommandBuffer vk_commandBuffer, Frame& 
                 _transferImageInfo(vk_commandBuffer, frame, offset, *imageInfo);
             }
 
-            if (imageInfo->imageView->image->data->properties.dataVariance == STATIC_DATA)
+            if (imageInfo->imageView->image->data->dynamic())
             {
-                log(level, "       removing copied static image data: ", imageInfo, ", ", imageInfo->imageView->image->data);
-                imageInfo_itr = _dynamicImageInfoSet.erase(imageInfo_itr);
+                ++imageInfo_itr;
             }
             else
             {
-                ++imageInfo_itr;
+                log(level, "       removing copied static image data: ", imageInfo, ", ", imageInfo->imageView->image->data);
+                imageInfo_itr = _dynamicImageInfoSet.erase(imageInfo_itr);
             }
         }
     }

--- a/src/vsg/state/BufferInfo.cpp
+++ b/src/vsg/state/BufferInfo.cpp
@@ -62,7 +62,7 @@ int BufferInfo::compare(const Object& rhs_object) const
 
     if (data != rhs.data && data && rhs.data)
     {
-        if (data->properties.dataVariance != STATIC_DATA || rhs.data->properties.dataVariance != STATIC_DATA)
+        if (data->dynamic() || rhs.data->dynamic())
         {
             if (data < rhs.data) return -1;
             return 1; // from checks above it must be that data > rhs.data
@@ -300,6 +300,10 @@ bool vsg::createBufferAndTransferData(Context& context, const BufferInfoList& bu
         if (data)
         {
             std::memcpy(ptr + bufferInfo->offset - deviceBufferInfo->offset, data->dataPointer(), data->dataSize());
+            if (data->properties.dataVariance == STATIC_DATA_UNREF_AFTER_TRANSFER)
+            {
+                bufferInfo->data.reset();
+            }
         }
         bufferInfo->parent = deviceBufferInfo;
     }

--- a/src/vsg/utils/FindDynamicObjects.cpp
+++ b/src/vsg/utils/FindDynamicObjects.cpp
@@ -39,7 +39,7 @@ void FindDynamicObjects::apply(const Object& object)
 
 void FindDynamicObjects::apply(const Data& data)
 {
-    if (data.properties.dataVariance != STATIC_DATA) tag(&data);
+    if (data.dynamic()) tag(&data);
 }
 
 void FindDynamicObjects::apply(const AnimationGroup& ag)


### PR DESCRIPTION
# Pull Request Template

## Description

VSG is not obeying the Property.dataVariance setting, STATIC_DATA_UNREF_AFTER_TRANSFER. This pull request releases static data marked accordingly after transferring it to the GPU.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
We tested this in our client code.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes