### PR TITLE
Cache the block which most recently successfully allocated something

### DIFF
--- a/src/vsg/core/IntrusiveAllocator.cpp
+++ b/src/vsg/core/IntrusiveAllocator.cpp
@@ -745,7 +745,11 @@ void* IntrusiveAllocator::MemoryBlocks::allocate(std::size_t size)
         if (block != memoryBlockWithSpace)
         {
             auto ptr = block->allocate(size);
-            if (ptr) return ptr;
+            if (ptr)
+            {
+                memoryBlockWithSpace = block;
+                return ptr;
+            }
         }
     }
 


### PR DESCRIPTION
Otherwise, once the most recently allocated block was full, all allocations would need to scan the whole collection of blocks to find free space, which could take a while if lots of blocks had already been allocated but contained free space due to things being freed.

For the app I've tried this with, without this PR, loading a large scene takes 1:08 and reloading it takes 19:58, but with this PR, initial loading takes 1:04 (so about the same) and reloading it takes only 0:54, just 4.5% as long as without. I'm going to run some of the allocation benchmarks from the vsgExamples AllocatorRefactor branch, and probably tweak them so they also measure how much slower or faster reusing blocks is as it's possible I've ended up making something worse.