### PR TITLE
Win32 interactive resizing proof-of-concept

### DIFF
--- a/include/vsg/app/Viewer.h
+++ b/include/vsg/app/Viewer.h
@@ -101,6 +101,9 @@ namespace vsg
         /// If still active, poll for pending events and place them in the Events list and advance to the next frame, generate updated FrameStamp to signify the advancement to a new frame and return true.
         virtual bool advanceToNextFrame(double simulationTime = UseTimeSinceStartPoint);
 
+        virtual bool advanceToNextFramePhaseOne();
+        virtual bool advanceToNextFramePhaseTwo(double simulationTime = UseTimeSinceStartPoint);
+
         /// pass the Events into any registered EventHandlers
         virtual void handleEvents();
 

--- a/include/vsg/app/Window.h
+++ b/include/vsg/app/Window.h
@@ -58,6 +58,8 @@ namespace vsg
 
         virtual void resize() {}
 
+        std::function<void()> resizeCallback = {};
+
         ref_ptr<WindowTraits> traits() { return _traits; }
         const ref_ptr<WindowTraits> traits() const { return _traits; }
 

--- a/src/vsg/platform/win32/Win32_Window.cpp
+++ b/src/vsg/platform/win32/Win32_Window.cpp
@@ -610,6 +610,8 @@ bool Win32_Window::handleWin32Messages(UINT msg, WPARAM wParam, LPARAM lParam)
         _windowMapped = false;
         return true;
     case WM_PAINT:
+        if (resizeCallback)
+            resizeCallback();
         ValidateRect(_window, NULL);
         return true;
     case WM_MOUSEMOVE: {


### PR DESCRIPTION
Basically works by setting up a callback to draw a new frame which we do when the WM_PAINT event arrives, which is how Windows tries to tell us it's time to redraw the window due to a resize etc.

Unlike the WM_SIZE event, it only happens when we've consumed the whole message queue, so it should be pretty similar to the regular situation where a frame happens after `pollEvents` is called.

This approach is necessary in the first place because Win32 window messages can be reentrant, so the handler for one event, like a click on the corner of a window, can in turn fire a series of extra messages for the drag and resizes and release, without first returning.

This PR seems to work fine on Windows and shouldn't have changed anything on other platforms, but I've not tested it on other platforms, and it lacks some polish as I wasn't sure how best to accomplish the `advanceToNextFrame` splitting, so thought I'd wait for your opinion before doing more than the minimum.