### PR TITLE
Added copy and clone for view and projection matrix

### DIFF
--- a/include/vsg/app/ProjectionMatrix.h
+++ b/include/vsg/app/ProjectionMatrix.h
@@ -23,6 +23,15 @@ namespace vsg
     class VSG_DECLSPEC ProjectionMatrix : public Inherit<Object, ProjectionMatrix>
     {
     public:
+        ProjectionMatrix()
+        {
+        }
+
+        explicit ProjectionMatrix(const ProjectionMatrix& pm, const CopyOp& copyop = {}) :
+            Inherit(pm, copyop)
+        {
+        }
+
         virtual dmat4 transform() const = 0;
 
         virtual dmat4 inverse() const
@@ -48,6 +57,15 @@ namespace vsg
         {
         }
 
+        explicit Perspective(const Perspective& p, const CopyOp& copyop = {}) :
+            Inherit(p, copyop),
+            fieldOfViewY(p.fieldOfViewY),
+            aspectRatio(p.aspectRatio),
+            nearDistance(p.nearDistance),
+            farDistance(p.farDistance)
+        {
+        }
+
         Perspective(double fov, double ar, double nd, double fd) :
             fieldOfViewY(fov),
             aspectRatio(ar),
@@ -55,6 +73,8 @@ namespace vsg
             farDistance(fd)
         {
         }
+
+        ref_ptr<Object> clone(const CopyOp& copyop = {}) const override { return Perspective::create(*this, copyop); }
 
         dmat4 transform() const override { return perspective(radians(fieldOfViewY), aspectRatio, nearDistance, farDistance); }
 
@@ -91,6 +111,17 @@ namespace vsg
         {
         }
 
+        explicit Orthographic(const Orthographic& o, const CopyOp& copyop = {}) :
+            Inherit(o, copyop),
+            left(o.left),
+            right(o.right),
+            bottom(o.bottom),
+            top(o.top),
+            nearDistance(o.nearDistance),
+            farDistance(o.farDistance)
+        {
+        }
+
         Orthographic(double l, double r, double b, double t, double nd, double fd) :
             left(l),
             right(r),
@@ -100,6 +131,8 @@ namespace vsg
             farDistance(fd)
         {
         }
+
+        ref_ptr<Object> clone(const CopyOp& copyop = {}) const override { return Orthographic::create(*this, copyop); }
 
         dmat4 transform() const override { return orthographic(left, right, bottom, top, nearDistance, farDistance); }
 

--- a/include/vsg/app/ViewMatrix.h
+++ b/include/vsg/app/ViewMatrix.h
@@ -22,6 +22,15 @@ namespace vsg
     class VSG_DECLSPEC ViewMatrix : public Inherit<Object, ViewMatrix>
     {
     public:
+        ViewMatrix()
+        {
+        }
+
+        explicit ViewMatrix(const ViewMatrix& vm, const CopyOp& copyop = {}) :
+            Inherit(vm, copyop)
+        {
+        }
+
         virtual dmat4 transform() const = 0;
 
         virtual dmat4 inverse() const
@@ -42,8 +51,8 @@ namespace vsg
         {
         }
 
-        LookAt(const LookAt& lookAt) :
-            Inherit(lookAt),
+        LookAt(const LookAt& lookAt, const CopyOp& copyop = {}) :
+            Inherit(lookAt, copyop),
             eye(lookAt.eye),
             center(lookAt.center),
             up(lookAt.up)
@@ -67,6 +76,8 @@ namespace vsg
             up = lookAt.up;
             return *this;
         }
+
+        ref_ptr<Object> clone(const CopyOp& copyop = {}) const override { return LookAt::create(*this, copyop); }
 
         void transform(const dmat4& matrix)
         {


### PR DESCRIPTION
## Description

We were trying to clone the view and projection matrices.

## Type of change

Enhancement

Please delete options that are not relevant.

- [x] Filled out missing clone() method for several matrices.

## How Has This Been Tested?

Without these implementations the object's clone base class simply returns a copy of the pointer. Now it performs an actual copy of the objects. Similar implementation to many many classes in VSG. I don't see any tests for cloning of other objects.

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] My changes generate no new warnings
- [ x ] New and existing unit tests pass locally with my changes