### PR TITLE
Gamma correctness phase one

### DIFF
--- a/include/vsg/io/Options.h
+++ b/include/vsg/io/Options.h
@@ -87,6 +87,22 @@ namespace vsg
         /// Coordinate convention to assume for specified lower case file formats extensions
         std::map<Path, CoordinateConvention> formatCoordinateConventions;
 
+        enum ColorSpace
+        {
+            sRGB,
+            linearRGB
+        };
+
+        /// Color space to use for vertex colors for scene graph
+        ColorSpace sceneVertexColorColorSpace = ColorSpace::linearRGB;
+        /// Color space to use for materials for scene graph
+        ColorSpace sceneMaterialColorSpace = ColorSpace::linearRGB;
+
+        /// Color space to assume for vertex colors for specified lower case file formats extensions
+        std::map<Path, ColorSpace> formatVertexColorColorSpaces;
+        /// Color space to assume for materials for specified lower case file formats extensions
+        std::map<Path, ColorSpace> formatMaterialColorSpaces;
+
         /// User defined ShaderSet map, loaders should check the available ShaderSet using the name of the type of ShaderSet.
         /// Standard names are :
         ///     "pbr" will substitute for vsg::createPhysicsBasedRenderingShaderSet()

--- a/include/vsg/maths/color.h
+++ b/include/vsg/maths/color.h
@@ -99,28 +99,28 @@ namespace vsg
     template<typename T>
     constexpr t_vec4<T> linear_to_sRGB(const t_vec4<T>& src)
     {
-        const T exponent = static_cast<T>(2.2);
+        const T exponent = static_cast<T>(1.0 / 2.2);
         return t_vec4<T>(std::pow(src.r, exponent), std::pow(src.g, exponent), std::pow(src.b, exponent), src.a);
     }
 
     template<typename T>
     constexpr t_vec4<T> linear_to_sRGB(T r, T g, T b, T a)
     {
-        const T exponent = static_cast<T>(2.2);
+        const T exponent = static_cast<T>(1.0 / 2.2);
         return t_vec4<T>(std::pow(r, exponent), std::pow(g, exponent), std::pow(b, exponent), a);
     }
 
     template<typename T>
     constexpr t_vec4<T> sRGB_to_linear(const t_vec4<T>& src)
     {
-        const T exponent = static_cast<T>(1.0 / 2.2);
+        const T exponent = static_cast<T>(2.2);
         return t_vec4<T>(std::pow(src.r, exponent), std::pow(src.g, exponent), std::pow(src.b, exponent), src.a);
     }
 
     template<typename T>
     constexpr t_vec4<T> sRGB_to_linear(T r, T g, T b, T a)
     {
-        const T exponent = static_cast<T>(1.0 / 2.2);
+        const T exponent = static_cast<T>(2.2);
         return t_vec4<T>(std::pow(r, exponent), std::pow(g, exponent), std::pow(b, exponent), a);
     }
 

--- a/include/vsg/vk/Swapchain.h
+++ b/include/vsg/vk/Swapchain.h
@@ -27,7 +27,7 @@ namespace vsg
     };
 
     extern VSG_DECLSPEC SwapChainSupportDetails querySwapChainSupport(VkPhysicalDevice device, VkSurfaceKHR surface);
-    extern VSG_DECLSPEC VkSurfaceFormatKHR selectSwapSurfaceFormat(const SwapChainSupportDetails& details, VkSurfaceFormatKHR preferredSurfaceFormat = {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR});
+    extern VSG_DECLSPEC VkSurfaceFormatKHR selectSwapSurfaceFormat(const SwapChainSupportDetails& details, VkSurfaceFormatKHR preferredSurfaceFormat = {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR});
     extern VSG_DECLSPEC VkExtent2D selectSwapExtent(const SwapChainSupportDetails& details, uint32_t width, uint32_t height);
     extern VSG_DECLSPEC VkPresentModeKHR selectSwapPresentMode(const SwapChainSupportDetails& details, VkPresentModeKHR preferredPresentMode = VK_PRESENT_MODE_MAILBOX_KHR);
 
@@ -35,7 +35,7 @@ namespace vsg
     struct SwapchainPreferences
     {
         uint32_t imageCount = 3; // default to triple buffering
-        VkSurfaceFormatKHR surfaceFormat = {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR};
+        VkSurfaceFormatKHR surfaceFormat = {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR};
         VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
         VkImageUsageFlags imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     };

--- a/src/vsg/app/Window.cpp
+++ b/src/vsg/app/Window.cpp
@@ -41,7 +41,7 @@ Window::Window(ref_ptr<WindowTraits> traits) :
 {
     if (_traits && (_traits->swapchainPreferences.surfaceFormat.format == VK_FORMAT_B8G8R8A8_SRGB || _traits->swapchainPreferences.surfaceFormat.format == VK_FORMAT_B8G8R8_SRGB))
     {
-        _clearColor = linear_to_sRGB(_clearColor);
+        _clearColor = sRGB_to_linear(_clearColor);
         info("Selected sRGB window ", _clearColor);
     }
 }

--- a/src/vsg/io/Options.cpp
+++ b/src/vsg/io/Options.cpp
@@ -49,6 +49,10 @@ Options::Options(const Options& options) :
     mapRGBtoRGBAHint(options.mapRGBtoRGBAHint),
     sceneCoordinateConvention(options.sceneCoordinateConvention),
     formatCoordinateConventions(options.formatCoordinateConventions),
+    sceneVertexColorColorSpace(options.sceneVertexColorColorSpace),
+    sceneMaterialColorSpace(options.sceneMaterialColorSpace),
+    formatVertexColorColorSpaces(options.formatVertexColorColorSpaces),
+    formatMaterialColorSpaces(options.formatMaterialColorSpaces),
     shaderSets(options.shaderSets),
     inheritedState(options.inheritedState),
     instrumentation(options.instrumentation),
@@ -79,6 +83,10 @@ int Options::compare(const Object& rhs_object) const
     if ((result = compare_value(mapRGBtoRGBAHint, rhs.mapRGBtoRGBAHint))) return result;
     if ((result = compare_value(sceneCoordinateConvention, rhs.sceneCoordinateConvention))) return result;
     if ((result = compare_value(formatCoordinateConventions, rhs.formatCoordinateConventions))) return result;
+    if ((result = compare_value(sceneVertexColorColorSpace, rhs.sceneVertexColorColorSpace))) return result;
+    if ((result = compare_value(sceneMaterialColorSpace, rhs.sceneMaterialColorSpace))) return result;
+    if ((result = compare_value(formatVertexColorColorSpaces, rhs.formatVertexColorColorSpaces))) return result;
+    if ((result = compare_value(formatMaterialColorSpaces, rhs.formatMaterialColorSpaces))) return result;
     return compare_value(shaderSets, rhs.shaderSets);
 }
 

--- a/src/vsg/vk/Swapchain.cpp
+++ b/src/vsg/vk/Swapchain.cpp
@@ -54,7 +54,7 @@ VkSurfaceFormatKHR vsg::selectSwapSurfaceFormat(const SwapChainSupportDetails& d
     if (details.formats.empty() || (details.formats.size() == 1 && details.formats[0].format == VK_FORMAT_UNDEFINED))
     {
         warn("selectSwapSurfaceFormat() VK_FORMAT_UNDEFINED, so using fallback ");
-        return {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR};
+        return {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR};
     }
 
     // check if requested format is available
@@ -66,10 +66,10 @@ VkSurfaceFormatKHR vsg::selectSwapSurfaceFormat(const SwapChainSupportDetails& d
         }
     }
 
-    // fallback to checking for {VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}
+    // fallback to checking for {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR}
     for (const auto& availableFormat : details.formats)
     {
-        if (availableFormat.format == VK_FORMAT_B8G8R8A8_UNORM && availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+        if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB && availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
         {
             return availableFormat;
         }


### PR DESCRIPTION
As discussed here https://github.com/vsg-dev/VulkanSceneGraph/discussions/1291, there are quite a few gamma-correctness issues and annoying-to-work-around obstacles in the VSG. Between this, and related PRs https://github.com/vsg-dev/vsgXchange/pull/204 and https://github.com/vsg-dev/vsgExamples/pull/323, things should be more manageable.

This PR:
* Changes the default surface image format from a `UNORM` one to an `SRGB` one, enabling automatic linear-to-sRGB conversions when data is written to the framebuffer. We're already telling the driver that we're writing sRGB data to the surface as we're giving it an sRGB colour space. This should avoid things like alpha blending issues caused by doing the sRGB conversion first. The vsgExamples PR includes an update to the PBR shader to remove the now-redundant conversion it was doing at the end.
* Fixes the conversion functions in `color.h` as they did the opposite of what they said. The call site I found seemed to be calling the one with the right implementation but wrong name, so I switched it over.
* Adds extra fields to `vsg::Options` to control when vsgXchange converts colour spaces in loaded data.

Things with a potential to break existing applications can be opted out of - you can still explicitly ask for a `UNORM` surface format and set the source and destination colour spaces via `vsg::Options`.