### PR TITLE
Bump ci vulkan sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        vulkan-version: [1.3.224.1]
+        vulkan-version: [1.3.250.1]
         build-shared: [OFF]
         include:
           - build-shared: ON
             os: windows-latest
-            vulkan-version: 1.3.224.1
+            vulkan-version: 1.3.250.1
     continue-on-error: ${{ matrix.vulkan-version == 'latest' }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         cmake-version: ${{ env.CMakeVersion }}
     - name: Install Vulkan SDK
-      uses: humbletim/install-vulkan-sdk@v1.1.1
+      uses: humbletim/install-vulkan-sdk@c2aa128094d42ba02959a660f03e0a4e012192f9
       with:
         version: ${{ matrix.vulkan-version }}
         cache: true


### PR DESCRIPTION
Fixes CI for forks by:
* Switching to a version of the Vulkan SDK that's still available.
* Switching to a version (which hasn't made it to a release yet) of `install-vulkan-sdk` that can handle slightly newer Vulkan SDK packages.

It doesn't switch to the latest release as no version of `install-vulkan-sdk` can deal with it yet.