### PR TITLE
Intersect text with PolytopeIntersector or LineSegmentIntersector

### DIFF
--- a/include/vsg/maths/transform.h
+++ b/include/vsg/maths/transform.h
@@ -176,6 +176,25 @@ namespace vsg
                vsg::translate(-eye.x, -eye.y, -eye.z);
     }
 
+    template<typename T>
+    constexpr t_mat4<T> computeBillboardMatrix(const t_vec3<T>& centerEye, T autoscaleDistance)
+    {
+        auto distance = -centerEye.z;
+
+        auto scale = (distance < autoscaleDistance) ? distance / autoscaleDistance : 1.0;
+        t_mat4<T> mS(scale, 0.0, 0.0, 0.0,
+                     0.0, scale, 0.0, 0.0,
+                     0.0, 0.0, scale, 0.0,
+                     0.0, 0.0, 0.0, 1.0);
+
+        t_mat4<T> mT(1.0, 0.0, 0.0, 0.0,
+                     0.0, 1.0, 0.0, 0.0,
+                     0.0, 0.0, 1.0, 0.0,
+                     centerEye.x, centerEye.y, centerEye.z, 1.0);
+
+        return mT * mS;
+    }
+
     /// Hint on axis, using Collada conventions, all Right Hand
     enum class CoordinateConvention
     {

--- a/include/vsg/utils/Intersector.h
+++ b/include/vsg/utils/Intersector.h
@@ -53,6 +53,8 @@ namespace vsg
         void apply(const ushortArray& array) override;
         void apply(const uintArray& array) override;
 
+        void apply(const TextTechnique& technique) override;
+
         //
         // provide virtual functions for concrete Intersector implementations to provide handling of intersection with mesh geometries
         //

--- a/src/vsg/state/ArrayState.cpp
+++ b/src/vsg/state/ArrayState.cpp
@@ -491,7 +491,6 @@ ref_ptr<const vec3Array> BillboardArrayState::vertexArray(uint32_t instanceIndex
     dvec3 position(gv.value.xyz);
     double autoDistanceScale = gv.value.w;
 
-
     dmat4 billboard_to_local;
     if (!localToWorldStack.empty() && !worldToLocalStack.empty())
     {

--- a/src/vsg/state/ArrayState.cpp
+++ b/src/vsg/state/ArrayState.cpp
@@ -491,27 +491,14 @@ ref_ptr<const vec3Array> BillboardArrayState::vertexArray(uint32_t instanceIndex
     dvec3 position(gv.value.xyz);
     double autoDistanceScale = gv.value.w;
 
+
     dmat4 billboard_to_local;
     if (!localToWorldStack.empty() && !worldToLocalStack.empty())
     {
         const auto& mv = localToWorldStack.back();
         const auto& inverse_mv = worldToLocalStack.back();
-
         auto center_eye = mv * position;
-        double distance = -center_eye.z;
-
-        double scale = (distance < autoDistanceScale) ? distance / autoDistanceScale : 1.0;
-        dmat4 S(scale, 0.0, 0.0, 0.0,
-                0.0, scale, 0.0, 0.0,
-                0.0, 0.0, scale, 0.0,
-                0.0, 0.0, 0.0, 1.0);
-
-        dmat4 T(1.0, 0.0, 0.0, 0.0,
-                0.0, 1.0, 0.0, 0.0,
-                0.0, 0.0, 1.0, 0.0,
-                center_eye.x, center_eye.y, center_eye.z, 1.0);
-
-        dmat4 billboard_mv = T * S;
+        auto billboard_mv = computeBillboardMatrix(center_eye, autoDistanceScale);
         billboard_to_local = inverse_mv * billboard_mv;
     }
     else

--- a/src/vsg/text/CpuLayoutTechnique.cpp
+++ b/src/vsg/text/CpuLayoutTechnique.cpp
@@ -34,6 +34,73 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
+class VSG_DECLSPEC CpuLayoutTechniqueArrayState : public Inherit<ArrayState, CpuLayoutTechniqueArrayState>
+{
+public:
+    CpuLayoutTechniqueArrayState(const CpuLayoutTechnique& in_technique) :
+        technique(in_technique)
+    {
+    }
+
+    CpuLayoutTechniqueArrayState(const CpuLayoutTechniqueArrayState& rhs) :
+        Inherit(rhs),
+        technique(rhs.technique)
+    {
+    }
+
+    ref_ptr<ArrayState> cloneArrayState() override
+    {
+        return CpuLayoutTechniqueArrayState::create(*this);
+    }
+
+    ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override
+    {
+        auto clone = CpuLayoutTechniqueArrayState::create(*this);
+        clone->localToWorldStack = arrayState->localToWorldStack;
+        clone->worldToLocalStack = arrayState->worldToLocalStack;
+        return clone;
+    }
+
+    ref_ptr<const vec3Array> vertexArray(uint32_t instanceIndex) override
+    {
+        auto new_vertices = vsg::vec3Array::create(static_cast<uint32_t>(vertices->size()));
+        auto src_vertex_itr = vertices->begin();
+        size_t v_index = 0;
+        for (auto& v : *new_vertices)
+        {
+            const auto& sv = *(src_vertex_itr++);
+
+            dvec4 centerAndAutoScaleDistance;
+            if (technique.centerAndAutoScaleDistances->size() == 1)
+                centerAndAutoScaleDistance = technique.centerAndAutoScaleDistances->at(0);
+            else
+                centerAndAutoScaleDistance = technique.centerAndAutoScaleDistances->at(v_index++);
+
+            dmat4 billboard_to_local;
+            if (!localToWorldStack.empty() && !worldToLocalStack.empty())
+            {
+                const auto& mv = localToWorldStack.back();
+                const auto& inverse_mv = worldToLocalStack.back();
+                dvec3 center_eye = mv * centerAndAutoScaleDistance.xyz;
+                dmat4 billboard_mv = computeBillboardMatrix(center_eye, centerAndAutoScaleDistance.w);
+                billboard_to_local = inverse_mv * billboard_mv;
+            }
+            else
+            {
+                billboard_to_local = vsg::translate(centerAndAutoScaleDistance.xyz);
+            }
+
+            v = vec3(billboard_to_local * dvec3(sv));
+        }
+
+        return new_vertices;
+    }
+
+    using ArrayState::apply;
+
+    const CpuLayoutTechnique& technique;
+};
+
 void CpuLayoutTechnique::setup(Text* text, uint32_t minimumAllocation, ref_ptr<const Options> options)
 {
     if (!text || !(text->text) || !text->font || !text->layout) return;
@@ -290,6 +357,10 @@ ref_ptr<Node> CpuLayoutTechnique::createRenderingSubgraph(ref_ptr<ShaderSet> sha
         drawCommands->addChild(bindVertexBuffers);
         drawCommands->addChild(bindIndexBuffer);
         drawCommands->addChild(drawIndexed);
+
+        // Assign ArrayState for CPU mapping of billboarding
+        if (billboard)
+            stategroup->prototypeArrayState = CpuLayoutTechniqueArrayState::create(*this);
 
         stategroup->addChild(drawCommands);
     }

--- a/src/vsg/text/GpuLayoutTechnique.cpp
+++ b/src/vsg/text/GpuLayoutTechnique.cpp
@@ -34,6 +34,104 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 using namespace vsg;
 
+class VSG_DECLSPEC GpuLayoutTechniqueArrayState : public Inherit<ArrayState, GpuLayoutTechniqueArrayState>
+{
+public:
+    GpuLayoutTechniqueArrayState(const GpuLayoutTechnique* in_technique, const Text* in_text, bool in_billboard) :
+        technique(in_technique),
+        text(in_text),
+        billboard(in_billboard)
+    {
+    }
+
+    GpuLayoutTechniqueArrayState(const GpuLayoutTechniqueArrayState& rhs) :
+        Inherit(rhs),
+        technique(rhs.technique),
+        text(rhs.text),
+        billboard(rhs.billboard)
+    {
+    }
+
+    explicit GpuLayoutTechniqueArrayState(const ArrayState& rhs) :
+        Inherit(rhs)
+    {
+    }
+
+    ref_ptr<ArrayState> cloneArrayState() override
+    {
+        return GpuLayoutTechniqueArrayState::create(*this);
+    }
+
+    ref_ptr<ArrayState> cloneArrayState(ref_ptr<ArrayState> arrayState) override
+    {
+        auto clone = GpuLayoutTechniqueArrayState::create(*arrayState);
+        clone->technique = technique;
+        clone->text = text;
+        clone->billboard = billboard;
+        return clone;
+    }
+
+    ref_ptr<const vec3Array> vertexArray(uint32_t instanceIndex) override
+    {
+        // compute the position of the glyph
+        float horiAdvance = 0.0;
+        float vertAdvance = 0.0;
+        for (uint32_t i = 0; i < instanceIndex; ++i)
+        {
+            uint32_t glyph_index = technique->textArray->at(i);
+            if (glyph_index == 0)
+            {
+                // treat as a newlline
+                vertAdvance -= 1.0;
+                horiAdvance = 0.0;
+            }
+            else
+            {
+                const GlyphMetrics& glyph_metrics = text->font->glyphMetrics->at(glyph_index);
+                horiAdvance += glyph_metrics.horiAdvance;
+            }
+        }
+
+        uint32_t glyph_index = technique->textArray->at(instanceIndex);
+        const GlyphMetrics& glyph_metrics = text->font->glyphMetrics->at(glyph_index);
+
+        // billboard effect
+        auto textLayout = technique->layoutValue->value();
+        dmat4 transform_to_local;
+        if (billboard && !localToWorldStack.empty() && !worldToLocalStack.empty())
+        {
+            const dmat4& mv = localToWorldStack.back();
+            const dmat4& inverse_mv = worldToLocalStack.back();
+            dvec3 center_eye = mv * dvec3(textLayout.position);
+            dmat4 billboard_mv = computeBillboardMatrix(center_eye, (double)textLayout.billboardAutoScaleDistance);
+            transform_to_local = inverse_mv * billboard_mv;
+        }
+        else
+        {
+            transform_to_local = vsg::translate(textLayout.position);
+        }
+
+        auto new_vertices = vsg::vec3Array::create(6);
+        auto src_vertex_itr = vertices->begin();
+        for (auto& v : *new_vertices)
+        {
+            const auto& sv = *(src_vertex_itr++);
+
+            // compute the position of vertex
+            vec3 pos = textLayout.horizontal * (horiAdvance + textLayout.horizontalAlignment + glyph_metrics.horiBearingX + sv.x * glyph_metrics.width) +
+                       textLayout.vertical * (vertAdvance + textLayout.verticalAlignment + glyph_metrics.horiBearingY + (sv.y - 1.f) * glyph_metrics.height);
+
+            v = vec3(transform_to_local * dvec3(pos));
+        }
+
+        return new_vertices;
+    }
+
+    const GpuLayoutTechnique* technique = nullptr;
+    const Text* text = nullptr;
+    bool billboard = false;
+};
+
 template<typename T>
 void assignValue(T& dest, const T& src, bool& updated)
 {
@@ -176,18 +274,21 @@ void GpuLayoutTechnique::setup(Text* text, uint32_t minimumAllocation, ref_ptr<c
 
     if (!vertices)
     {
-        vertices = vec3Array::create(4);
+        vertices = vec3Array::create(6);
 
         float leadingEdgeGradient = 0.1f;
 
         vertices->set(0, vec3(0.0f, 1.0f, 2.0f * leadingEdgeGradient));
         vertices->set(1, vec3(0.0f, 0.0f, leadingEdgeGradient));
         vertices->set(2, vec3(1.0f, 1.0f, leadingEdgeGradient));
-        vertices->set(3, vec3(1.0f, 0.0f, 0.0f));
+
+        vertices->set(3, vec3(0.0f, 0.0f, leadingEdgeGradient));
+        vertices->set(4, vec3(1.0f, 0.0f, 0.0f));
+        vertices->set(5, vec3(1.0f, 1.0f, leadingEdgeGradient));
     }
 
     if (!draw)
-        draw = Draw::create(4, num_quads, 0, 0);
+        draw = Draw::create(6, num_quads, 0, 0);
     else
         draw->instanceCount = num_quads;
 
@@ -223,14 +324,6 @@ void GpuLayoutTechnique::setup(Text* text, uint32_t minimumAllocation, ref_ptr<c
         config->assignDescriptor("textLayout", layoutValue);
         config->assignDescriptor("text", textArray);
 
-        // Set the InputAssemblyState.topology
-        struct SetPipelineStates : public Visitor
-        {
-            void apply(Object& object) override { object.traverse(*this); }
-            void apply(InputAssemblyState& ias) override { ias.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP; }
-        };
-        vsg::visit<SetPipelineStates>(config);
-
         if (sharedObjects)
             sharedObjects->share(config, [](auto gpc) { gpc->init(); });
         else
@@ -245,6 +338,9 @@ void GpuLayoutTechnique::setup(Text* text, uint32_t minimumAllocation, ref_ptr<c
         drawCommands->addChild(bindVertexBuffers);
         drawCommands->addChild(draw);
         stateGroup->addChild(drawCommands);
+
+        // Assign ArrayState for CPU mapping of vertices
+        stateGroup->prototypeArrayState = GpuLayoutTechniqueArrayState::create(this, text, billboard);
     }
     else
     {

--- a/src/vsg/utils/Intersector.cpp
+++ b/src/vsg/utils/Intersector.cpp
@@ -208,8 +208,6 @@ void Intersector::apply(const uintArray& array)
 
 void Intersector::apply(const TextTechnique& technique)
 {
-    // TODO: Implement TextLayout support
-
     if (auto cpuTechnique = technique.cast<CpuLayoutTechnique>())
         cpuTechnique->scenegraph->accept(*this);
     if (auto gpuTechnique = technique.cast<GpuLayoutTechnique>())

--- a/src/vsg/utils/Intersector.cpp
+++ b/src/vsg/utils/Intersector.cpp
@@ -28,6 +28,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/nodes/VertexIndexDraw.h>
 #include <vsg/state/GraphicsPipeline.h>
 #include <vsg/utils/Intersector.h>
+#include <vsg/text/CpuLayoutTechnique.h>
+#include <vsg/text/GpuLayoutTechnique.h>
 
 using namespace vsg;
 
@@ -202,6 +204,16 @@ void Intersector::apply(const uintArray& array)
 {
     ushort_indices = nullptr;
     uint_indices = &array;
+}
+
+void Intersector::apply(const TextTechnique& technique)
+{
+    // TODO: Implement TextLayout support
+
+    if (auto cpuTechnique = technique.cast<CpuLayoutTechnique>())
+        cpuTechnique->scenegraph->accept(*this);
+    if (auto gpuTechnique = technique.cast<GpuLayoutTechnique>())
+        gpuTechnique->scenegraph->accept(*this);
 }
 
 void Intersector::apply(const Draw& draw)

--- a/src/vsg/utils/PolytopeIntersector.cpp
+++ b/src/vsg/utils/PolytopeIntersector.cpp
@@ -309,7 +309,7 @@ bool PolytopeIntersector::intersectDraw(uint32_t firstVertex, uint32_t vertexCou
     auto& arrayState = *arrayStateStack.back();
 
     vsg::PrimitiveFunctor<vsg::PolytopePrimitiveIntersection> printPrimitives(*this, arrayState, _polytopeStack.back());
-    if (ushort_indices) printPrimitives.draw(arrayState.topology, firstVertex, vertexCount, firstInstance, instanceCount);
+    printPrimitives.draw(arrayState.topology, firstVertex, vertexCount, firstInstance, instanceCount);
 
     return intersections.size() != previous_size;
 }

--- a/src/vsg/utils/PolytopeIntersector.cpp
+++ b/src/vsg/utils/PolytopeIntersector.cpp
@@ -236,6 +236,10 @@ PolytopeIntersector::PolytopeIntersector(const Camera& camera, double xMin, doub
     }
 
     _polytopeStack.push_back(worldspace);
+
+    dmat4 eyeToWorld = inverse(viewMatrix);
+    localToWorldStack().push_back(viewMatrix);
+    worldToLocalStack().push_back(eyeToWorld);
 }
 
 PolytopeIntersector::Intersection::Intersection(const dvec3& in_localIntersection, const dvec3& in_worldIntersection, const dmat4& in_localToWorld, const NodePath& in_nodePath, const DataList& in_arrays, const std::vector<uint32_t>& in_indices, uint32_t in_instanceIndex) :


### PR DESCRIPTION
# Pull Request Template

## Description

Adds support for intersecting text using `PolytopeIntersector` or `LineSegmentIntersector`.

Adds `computeBillboardMatrix` method.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested in vsgtext using the following eventHandler:


```
    class IntersectionHandler : public vsg::Inherit<vsg::Visitor, IntersectionHandler>
    {
    public:
        vsg::ref_ptr<vsg::Camera> camera;
        vsg::ref_ptr<vsg::Group> scenegraph;
        IntersectionHandler(
            vsg::ref_ptr<vsg::Camera> in_camera,
            vsg::ref_ptr<vsg::Group> in_scenegraph) :
            camera(in_camera),
            scenegraph(in_scenegraph)
        {
        }

        void apply(vsg::ButtonPressEvent& pointerEvent) override
        {
#if 1
            double size = 5.0;
            double xMin = static_cast<double>(pointerEvent.x) - size;
            double xMax = static_cast<double>(pointerEvent.x) + size;
            double yMin = static_cast<double>(pointerEvent.y) - size;
            double yMax = static_cast<double>(pointerEvent.y) + size;

            auto intersector = vsg::PolytopeIntersector::create(*camera, xMin, yMin, xMax, yMax);
#else
            auto intersector = vsg::LineSegmentIntersector::create(*camera, pointerEvent.x, pointerEvent.y);
#endif
            scenegraph->accept(*intersector);

            std::cout << "Hits: " << intersector->intersections.size() << std::endl;
        }

    };
    viewer->addEventHandler(IntersectionHandler::create(camera, scenegraph));
```
It prints 0 when clicking outside of text, and non-zero when clicking text (billboarded, CPU/GPU, different layouts).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
