### PR TITLE
Use renderArea instead of full window when compiling RenderGraph

### DIFF
--- a/src/vsg/app/CompileTraversal.cpp
+++ b/src/vsg/app/CompileTraversal.cpp
@@ -387,14 +387,9 @@ void CompileTraversal::apply(RenderGraph& renderGraph)
         auto previousOverridePipelineStates = context->overridePipelineStates;
 
         context->renderPass = renderGraph.getRenderPass();
-        if (renderGraph.window)
-        {
-            mergeGraphicsPipelineStates(context->mask, context->defaultPipelineStates, ViewportState::create(renderGraph.window->extent2D()));
-        }
-        else if (renderGraph.framebuffer)
-        {
-            mergeGraphicsPipelineStates(context->mask, context->defaultPipelineStates, ViewportState::create(renderGraph.framebuffer->extent2D()));
-        }
+        auto const& ra = renderGraph.renderArea;
+        mergeGraphicsPipelineStates(context->mask, context->defaultPipelineStates,
+                                    ViewportState::create(ra.offset.x, ra.offset.y, ra.extent.width, ra.extent.height));
 
         if (context->renderPass)
         {


### PR DESCRIPTION
Use renderArea of RenderGraph instead of the full window/framebuffer extent when creating the compile-context default viewportstate

Nominally, Views are above RenderGraphs in VSG scene graphs, however when a View that takes up a subset of the window/framebuffer extent contains individual RenderGraphs, the recorded default renderArea (viewportstate) was incorrect and resulted in the scene being drawn to the entire window area, but scissored to the render graphs renderArea. This change ensures that the default viewportstate is consistent with the rendergraph being compiled.

## Type of change

This is a breaking change, but I believe it resolves a long-standing bug in the Compilation of the scene.

## How Has This Been Tested?

I have a View with non-zero offset and a smaller extent than the whole window. This View contains multiple RenderGraphs which is required because I need to issue a PipelineBarrier between them.

## Checklist:

Note: before I go ahead and work up a VSG example to validate this change, I'd like some feedback from @robertosfield .

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
