### PR TITLE
Add a View resize notification function called from WindowResizeHandler

### DIFF
--- a/include/vsg/app/View.h
+++ b/include/vsg/app/View.h
@@ -86,6 +86,9 @@ namespace vsg
         /// override states for customization of graphics pipelines for this view
         GraphicsPipelineStates overridePipelineStates;
 
+        // abstract class to notify that the window is resized
+        virtual void resize() {};
+
     protected:
         virtual ~View();
     };

--- a/src/vsg/app/WindowResizeHandler.cpp
+++ b/src/vsg/app/WindowResizeHandler.cpp
@@ -183,4 +183,7 @@ void WindowResizeHandler::apply(vsg::View& view)
     view.traverse(*this);
 
     context->defaultPipelineStates.pop_back();
+
+    // Notify the view about the resize
+    view.resize();
 }


### PR DESCRIPTION
- This allows creating views that are redrawn on window resize

# Pull Request Template

## Description

Some `View`'s may need updating when the window is resized. E.g. if doing a pixel exact 2D overlay, we may want to resize the elements to be of a certain size in pixels. I could not find any callback that I could catch in my custom view that notifies of such resizing. This was the reason that I introduced the `resize()` abstract callback.

Another issue with pixel exact overlays, is that we may want to have the projection matrix fixed. Currently, the projection matrix is updated in `WindowResizeHandler::apply(vsg::View&)`.  An overloaded `resize()` method allows resetting the `projectionMatrix` to an expected transparent state.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

I created a test program available here: https://gist.github.com/dov/b4ca06a0b13558b75da05948eb955777

**Test Configuration**:

Tested on Linux .
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
