### PR TITLE
Update PolytopeIntersector.cpp

### DIFF
--- a/src/vsg/utils/PolytopeIntersector.cpp
+++ b/src/vsg/utils/PolytopeIntersector.cpp
@@ -229,6 +229,8 @@ PolytopeIntersector::PolytopeIntersector(const Camera& camera, double xMin, doub
         eyespace.push_back(pl * projectionMatrix);
     }
 
+    _polytopeStack.push_back(eyespace);
+
     vsg::Polytope worldspace;
     for (auto& pl : eyespace)
     {


### PR DESCRIPTION
In the PolytopeIntersector constructor with screen coordinates, the eyespace polytope should also be placed in the polytope stack before the worldspace polytope (In the same way as in the LineSegmentIntersector constructor). 

# Pull Request Template

## Description

Change is to to also add the eyespace polytope to the polytope stack before the worldspace polytope

Fixes # 
The omission meant that intersections were not calculated properly for nodes under MatrixTransforms.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

Can be tested by modifying the vsgintersection example default box creation to be under a MatrixTransform as follows: 
(wont work without the change)
```
    if (scene->children.empty())
    {
        vsg::GeometryInfo info;
        info.cullNode = true;
        info.dx.set(100.0f, 0.0f, 0.0f);
        info.dy.set(0.0f, 100.0f, 0.0f);
        info.dz.set(0.0f, 0.0f, 100.0f);
        auto box = builder->createBox(info, stateInfo);
        auto transform = vsg::MatrixTransform::create();
        transform->matrix = vsg::translate(vsg::dvec3(1000.0, 1000.0, 1000.0));
        transform->addChild(box);
        scene->addChild(transform);
    }

```


Tested on windows