### PR TITLE
Cherry picked fixes

### DIFF
--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -268,7 +268,7 @@ set(LIBRARIES PUBLIC
 )
 
 if (${VSG_SUPPORTS_ShaderCompiler})
-    list(APPEND LIBRARIES PRIVATE glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV)
+    list(INSERT LIBRARIES 0 PRIVATE glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV)
 endif()
 
 # Check for std::atomic

--- a/src/vsg/io/VSG.cpp
+++ b/src/vsg/io/VSG.cpp
@@ -184,7 +184,7 @@ bool VSG::write(const vsg::Object* object, const vsg::Path& filename, ref_ptr<co
     }
     else if (ext == ".vsga" || ext == ".vsgt")
     {
-        std::ofstream fout(filename);
+        std::ofstream fout(filename, std::ios::out | std::ios::binary);
         writeHeader(fout, FormatInfo{ASCII, version});
 
         vsg::AsciiOutput output(fout, options);

--- a/src/vsg/utils/ShaderCompiler.cpp
+++ b/src/vsg/utils/ShaderCompiler.cpp
@@ -282,6 +282,7 @@ bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::strin
                 }
             }
 
+            vsg_shader->module->code.clear();
             glslang::GlslangToSpv(*(program->getIntermediate((EShLanguage)eshl_stage)), vsg_shader->module->code, &logger, &spvOptions);
         }
     }


### PR DESCRIPTION
Cherry-picked fixes from my colour correctness branch.

Prepend glslang onto the list of linked libraries so that we prefer the include paths from the version we're linking over the include paths for the Vulkan SDK, which may provide headers for an ABI-incompatible version of glslang, potentially leading to memory corruption etc.

Use binary IO mode when writing `.vsgt` files, like we already do when loading them, so that on Windows, we don't leave CRLF as-is on load but convert the CR and the LF both to a CRLF sequence on save. Fixing this avoids doubling all line breaks when loading and resaving a `.vsgt` file.

Clear the SPIR-V vector when recompiling shaders so that the new shader binary doesn't get appended onto the old one, which causes invalid opcode errors.