### PR TITLE
Fix ViewMatrix serialisation

### DIFF
--- a/include/vsg/app/ViewMatrix.h
+++ b/include/vsg/app/ViewMatrix.h
@@ -33,7 +33,7 @@ namespace vsg
 
         /// origin value provides a means of translating the view matrix relative to the origin of any CoordinateFrame subgraphs
         /// to maximize the precision when moving around the CoordinateFrame subgraph.  This is helpful for astronmically large
-        /// scenes where standrd double precision is insufficient for avoiding visually significant numerical errors.
+        /// scenes where standard double precision is insufficient for avoiding visually significant numerical errors.
         dvec3 origin;
 
         virtual dmat4 transform(const dvec3& offset = {}) const = 0;

--- a/src/vsg/app/ViewMatrix.cpp
+++ b/src/vsg/app/ViewMatrix.cpp
@@ -20,14 +20,18 @@ void ViewMatrix::read(Input& input)
 {
     Object::read(input);
 
-    input.read("origin", origin);
+    if (input.version_greater_equal(1, 1, 8))
+        input.read("origin", origin);
+    else
+        origin = {};
 }
 
 void ViewMatrix::write(Output& output) const
 {
     Object::write(output);
 
-    output.write("origin", origin);
+    if (output.version_greater_equal(1, 1, 8))
+        output.write("origin", origin);
 }
 
 void LookAt::read(Input& input)


### PR DESCRIPTION
Older files don't have the new field, and loading them will make it yell at you.

I've got some old camera animation files for performance testing and can't load them without this. I still can't use them even with this (the camera doesn't move), but at least no errors are printed.
