### PR TITLE
fixed conversion of wchar_t to uint32_t

### DIFF
--- a/src/vsg/text/GpuLayoutTechnique.cpp
+++ b/src/vsg/text/GpuLayoutTechnique.cpp
@@ -199,9 +199,9 @@ void GpuLayoutTechnique::setup(Text* text, uint32_t minimumAllocation, ref_ptr<c
             allocate(static_cast<uint32_t>(text.value().size()));
 
             auto itr = textArray->begin();
-            for (auto& c : text.value())
+            for (auto c : text.value())
             {
-                assignValue(*(itr++), font.glyphIndexForCharcode(uint16_t(c)), updated);
+                assignValue(*(itr++), font.glyphIndexForCharcode(std::make_unsigned_t<decltype(c)>(c)), updated);
             }
         }
         void apply(const ubyteArray& text) override

--- a/src/vsg/text/StandardLayout.cpp
+++ b/src/vsg/text/StandardLayout.cpp
@@ -42,9 +42,9 @@ namespace
         }
         void apply(const wstringValue& text) override
         {
-            for (const auto& c : text.value())
+            for (const auto c : text.value())
             {
-                character(uint16_t(c));
+                character(std::make_unsigned_t<decltype(c)>(c));
             }
         }
         void apply(const ubyteArray& text) override
@@ -280,9 +280,9 @@ void StandardLayout::layout(const Data* text, const Font& font, TextQuads& quads
         void apply(const wstringValue& text) override
         {
             reserve(text.value().size());
-            for (auto& c : text.value())
+            for (auto c : text.value())
             {
-                character(uint16_t(c));
+                character(std::make_unsigned_t<decltype(c)>(c));
             }
         }
         void apply(const ubyteArray& text) override


### PR DESCRIPTION
The size of wchar_t in Linux and many other non-Windows systems is 4 bytes, and converting it to uint16_t may cause information loss.