### PR TITLE
Reorder API dump and validation layers

### DIFF
--- a/src/vsg/app/WindowTraits.cpp
+++ b/src/vsg/app/WindowTraits.cpp
@@ -110,8 +110,8 @@ void WindowTraits::validate()
     {
         instanceExtensionNames.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     }
-    if (debugLayer) requestedLayers.push_back("VK_LAYER_KHRONOS_validation");
     if (apiDumpLayer) requestedLayers.push_back("VK_LAYER_LUNARG_api_dump");
+    if (debugLayer) requestedLayers.push_back("VK_LAYER_KHRONOS_validation");
     if (synchronizationLayer) requestedLayers.push_back("VK_LAYER_KHRONOS_synchronization2");
 
     requestedLayers = vsg::validateInstancelayerNames(requestedLayers);


### PR DESCRIPTION
The validation layers eat and alter some Vulkan calls, so a combined log with both layers will have mismatched information.

In particular, vkSetDebugUtilsObjectNameEXT calls do not make it through the validation layers, so the API dump layer won't be able to see any object names or be able dump the calls that set them, and the validation layer internally remaps object IDs, so the IDs in any validation errors won't match those in the dumped API calls.

Ensuring the calls go through the dump layer before the validation layers ensures all calls are seen and can be dumped, and that the public object IDs that the validation layers expose to the application are the same as end up in the API dump.

I'm currently investigating some problems with an app that go away when it's run through RenderDoc, so I need to rely on the API dump layer to see what's going on, and this change gets rid of a lot of manual steps and guesswork.