### PR TITLE
Detect the throw feature of the trackball within milliseconds

### DIFF
--- a/src/vsg/app/Trackball.cpp
+++ b/src/vsg/app/Trackball.cpp
@@ -192,7 +192,9 @@ void Trackball::apply(ButtonReleaseEvent& buttonRelease)
 
     if (!windowOffsets.empty() && windowOffsets.count(buttonRelease.window) == 0) return;
 
-    if (supportsThrow) _thrown = _previousPointerEvent && (buttonRelease.time == _previousPointerEvent->time);
+    if (supportsThrow) _thrown = _previousPointerEvent && 
+        (std::chrono::duration_cast<std::chrono::milliseconds>(
+            buttonRelease.time - _previousPointerEvent->time).count() == 0);
 
     _lastPointerEventWithinRenderArea = withinRenderArea(buttonRelease);
     _hasPointerFocus = false;


### PR DESCRIPTION
On the Windows platform, the move and release events of a mouse button are not tagged identically. To accommodate the throw feature, the detection threshold for the timestamps of these two events is set within a 1-millisecond range. This configuration also supports the handling of events with identical timestamps under Xcb/X11.

# Pull Request Template

## Description

To better support the throw feature on Windows, the detection method for simultaneous mouse move and release events has been revised.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

On my Windows system, releasing the left mouse button while in motion allows the scene to rotate effortlessly; however, if the left mouse button is released after the movement has ceased, the scene remains stationary at the position where the movement stopped.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
