### PR TITLE
Partial compatibility

### DIFF
--- a/include/vsg/state/PipelineLayout.h
+++ b/include/vsg/state/PipelineLayout.h
@@ -43,6 +43,9 @@ namespace vsg
         void release(uint32_t deviceID) { _implementation[deviceID] = {}; }
         void release() { _implementation.clear(); }
 
+        // returns whether the layouts are push-constant-compatible and the lowest N for which the layouts are not compatible for descriptor set N
+        std::pair<bool, uint32_t> computeCompatibility(const PipelineLayout& other);
+
     public:
         ref_ptr<Object> clone(const CopyOp& copyop = {}) const override { return PipelineLayout::create(*this, copyop); }
         int compare(const Object& rhs) const override;

--- a/src/vsg/state/PipelineLayout.cpp
+++ b/src/vsg/state/PipelineLayout.cpp
@@ -50,8 +50,10 @@ std::pair<bool, uint32_t> vsg::PipelineLayout::computeCompatibility(const Pipeli
     auto result = std::make_pair<bool, uint32_t>(compare_value_container(pushConstantRanges, other.pushConstantRanges) == 0, 0);
     if (!result.first)
         return result;
+#ifdef VK_EXT_graphics_pipeline_library
     if ((flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT) != (other.flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT))
         return result;
+#endif
     for (result.second = 0; result.second < std::min(setLayouts.size(), other.setLayouts.size()); ++result.second)
     {
         if (compare_value_container(setLayouts[result.second]->bindings, other.setLayouts[result.second]->bindings) != 0)

--- a/src/vsg/state/PipelineLayout.cpp
+++ b/src/vsg/state/PipelineLayout.cpp
@@ -45,6 +45,21 @@ PipelineLayout::~PipelineLayout()
 {
 }
 
+std::pair<bool, uint32_t> vsg::PipelineLayout::computeCompatibility(const PipelineLayout& other)
+{
+    auto result = std::make_pair<bool, uint32_t>(compare_value_container(pushConstantRanges, other.pushConstantRanges) == 0, 0);
+    if (!result.first)
+        return result;
+    if ((flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT) != (other.flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT))
+        return result;
+    for (result.second = 0; result.second < std::min(setLayouts.size(), other.setLayouts.size()); ++result.second)
+    {
+        if (compare_value_container(setLayouts[result.second]->bindings, other.setLayouts[result.second]->bindings) != 0)
+            break;
+    }
+    return result;
+}
+
 int PipelineLayout::compare(const Object& rhs_object) const
 {
     int result = Object::compare(rhs_object);

--- a/src/vsg/state/PipelineLayout.cpp
+++ b/src/vsg/state/PipelineLayout.cpp
@@ -56,6 +56,9 @@ std::pair<bool, uint32_t> vsg::PipelineLayout::computeCompatibility(const Pipeli
 #endif
     for (result.second = 0; result.second < std::min(setLayouts.size(), other.setLayouts.size()); ++result.second)
     {
+        // if this is a partial layout for a graphics pipeline library, it may be made compatible later
+        if (!setLayouts[result.second] || !other.setLayouts[result.second])
+            continue;
         if (compare_value_container(setLayouts[result.second]->bindings, other.setLayouts[result.second]->bindings) != 0)
             break;
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a function to compute the compatibility of partially compatible pipeline layouts. This is useful for things like knowing which descriptor sets need to be rebound when switching between layouts.

At the moment it returns a `std::pair` but could return a struct with named fields instead. It's just marginally less effort to use a pair then switch to a struct than to use a struct then switch to a pair, so a pair's better for prototyping.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I made a visitor that compared a pipeline layout to everything it found in a subgraph and fed it some data that I knew the correct results for. It gave those results. It was only a small handful of combinations, though, and I didn't try it with any partial layouts. I don't think it's particularly risky as it's pretty similar to the existing `compare` function and as a new feature, it's not got any existing call sites to cause regressions with.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
