### PR TITLE
Allow descriptor sets to be inherited even if the pipeline layout isn't exactly identical

### DIFF
--- a/include/vsg/utils/ShaderSet.h
+++ b/include/vsg/utils/ShaderSet.h
@@ -177,8 +177,11 @@ namespace vsg
         /// create the descriptor set layout.
         virtual ref_ptr<DescriptorSetLayout> createDescriptorSetLayout(const std::set<std::string>& defines, uint32_t set) const;
 
-        /// return true of specified pipeline layout is compatible with what is required for this ShaderSet
+        /// return true if specified pipeline layout is compatible with what is required for this ShaderSet
         virtual bool compatiblePipelineLayout(const PipelineLayout& layout, const std::set<std::string>& defines) const;
+
+        /// return true if specified pipeline layout is partially compatible with what is required for this ShaderSet
+        virtual bool partiallyCompatiblePipelineLayout(const PipelineLayout& layout, const std::set<std::string>& defines, bool onlyPushConstants, uint32_t descriptorSet) const;
 
         /// create the pipeline layout for all descriptor sets enabled by specified defines or required by default.
         inline ref_ptr<PipelineLayout> createPipelineLayout(const std::set<std::string>& defines) { return createPipelineLayout(defines, descriptorSetRange()); }

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -552,7 +552,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
 
         void apply(const BindDescriptorSet& bds) override
         {
-            if (!bds.descriptorSet || !bds.descriptorSet->setLayout || !gpc.descriptorConfigurator) return;
+            if (!bds.layout || !gpc.descriptorConfigurator) return;
 
             if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, false, bds.firstSet))
             {
@@ -562,7 +562,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
 
         void apply(const BindDescriptorSets& bds) override
         {
-            if (!gpc.descriptorConfigurator) return;
+            if (!bds.layout || !gpc.descriptorConfigurator) return;
 
             if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, false, bds.firstSet + static_cast<uint32_t>(bds.descriptorSets.size()) - 1))
             {

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -554,7 +554,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
         {
             if (!bds.descriptorSet || !bds.descriptorSet->setLayout || !gpc.descriptorConfigurator) return;
 
-            if (gpc.shaderSet->compatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines))
+            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, true, bds.firstSet))
             {
                 gpc.inheritedSets.insert(bds.firstSet);
             }
@@ -564,7 +564,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
         {
             if (!gpc.descriptorConfigurator) return;
 
-            if (gpc.shaderSet->compatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines))
+            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, true, bds.firstSet + bds.descriptorSets.size() - 1))
             {
                 for (size_t i = 0; i < bds.descriptorSets.size(); ++i)
                 {
@@ -575,7 +575,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
 
         void apply(const BindViewDescriptorSets& bvds) override
         {
-            if (!gpc.shaderSet->compatiblePipelineLayout(*bvds.layout, gpc.shaderHints->defines))
+            if (!gpc.shaderSet->partiallyCompatiblePipelineLayout(*bvds.layout, gpc.shaderHints->defines, true, bvds.firstSet))
             {
                 return;
             }

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -554,7 +554,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
         {
             if (!bds.descriptorSet || !bds.descriptorSet->setLayout || !gpc.descriptorConfigurator) return;
 
-            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, true, bds.firstSet))
+            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, false, bds.firstSet))
             {
                 gpc.inheritedSets.insert(bds.firstSet);
             }
@@ -564,7 +564,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
         {
             if (!gpc.descriptorConfigurator) return;
 
-            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, true, bds.firstSet + bds.descriptorSets.size() - 1))
+            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, false, bds.firstSet + static_cast<uint32_t>(bds.descriptorSets.size()) - 1))
             {
                 for (size_t i = 0; i < bds.descriptorSets.size(); ++i)
                 {
@@ -575,7 +575,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
 
         void apply(const BindViewDescriptorSets& bvds) override
         {
-            if (!gpc.shaderSet->partiallyCompatiblePipelineLayout(*bvds.layout, gpc.shaderHints->defines, true, bvds.firstSet))
+            if (!gpc.shaderSet->partiallyCompatiblePipelineLayout(*bvds.layout, gpc.shaderHints->defines, false, bvds.firstSet))
             {
                 return;
             }


### PR DESCRIPTION
# Pull Request Template

## Description

Vulkan only requires the pipeline layout used to bind descriptor sets to be compatible for the push constants and descriptor sets up to the one that's being bound. Descriptor sets after the one being bound don't make a difference. That means you can have nice things like shared descriptor sets in early slots that work with multiple pipelines with distinct layouts and don't need to rebind them.

Previously, the GraphicsPipelineConfigurator would only allow inherited state with an equivalent pipeline layout rather than just requiring it to match the subset that mattered. This makes it so descriptor sets can be inherited if their layout is compatible for that descriptor set.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

It's a quasi-fix-feature-optimisation combo change. Someone might consider the previous overly strict requirements to be a bug, but it's not like there was documentation saying they did something else. It doesn't necessarily make anything faster unless applications are set up so that it can. Some might be, as the VSG's built-in PBR and Phong shadersets have compatible view descriptor sets, so something using both together and inheriting one will see it start working for the other, too.

## How Has This Been Tested?

Mostly it's been tried with the not-yet-merged vsgincompatiblepipelinelayouts example as this work is a precursor to one of the potential fixes which we probably want to merge even if we don't go for that fix in the end.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
