### PR TITLE
Vague layout compatibility checks

### DIFF
--- a/include/vsg/state/DescriptorSetLayout.h
+++ b/include/vsg/state/DescriptorSetLayout.h
@@ -37,6 +37,8 @@ namespace vsg
         /// VkDescriptorSetLayoutCreateInfo settings
         DescriptorSetLayoutBindings bindings;
 
+        virtual bool empty() const { return bindings.empty(); }
+
         /// map the descriptor bindings to the descriptor pool sizes that will be required to represent them.
         void getDescriptorPoolSizes(DescriptorPoolSizes& descriptorPoolSizes);
 

--- a/include/vsg/state/PipelineLayout.h
+++ b/include/vsg/state/PipelineLayout.h
@@ -34,6 +34,7 @@ namespace vsg
         VkPipelineLayoutCreateFlags flags = 0;
         DescriptorSetLayouts setLayouts;
         PushConstantRanges pushConstantRanges;
+        std::vector<bool> descriptorSetSlots;
 
         /// Vulkan VkPipelineLayout handle
         VkPipelineLayout vk(uint32_t deviceID) const { return _implementation[deviceID]->_pipelineLayout; }

--- a/include/vsg/state/ViewDependentState.h
+++ b/include/vsg/state/ViewDependentState.h
@@ -33,6 +33,8 @@ namespace vsg
     public:
         ViewDescriptorSetLayout();
 
+        bool empty() const override { return false; }
+
         VkDescriptorSetLayout vk(uint32_t deviceID) const override { return _viewDescriptorSetLayout ? _viewDescriptorSetLayout->vk(deviceID) : 0; }
 
         int compare(const Object& rhs_object) const override;

--- a/include/vsg/utils/ShaderSet.h
+++ b/include/vsg/utils/ShaderSet.h
@@ -177,8 +177,11 @@ namespace vsg
         /// create the descriptor set layout.
         virtual ref_ptr<DescriptorSetLayout> createDescriptorSetLayout(const std::set<std::string>& defines, uint32_t set) const;
 
-        /// return true of specified pipeline layout is compatible with what is required for this ShaderSet
+        /// return true if specified pipeline layout is compatible with what is required for this ShaderSet
         virtual bool compatiblePipelineLayout(const PipelineLayout& layout, const std::set<std::string>& defines) const;
+
+        /// return true if specified pipeline layout is partially compatible with what is required for this ShaderSet
+        virtual bool partiallyCompatiblePipelineLayout(const PipelineLayout& layout, const std::set<std::string>& defines, bool onlyPushConstants, uint32_t descriptorSet) const;
 
         /// create the pipeline layout for all descriptor sets enabled by specified defines or required by default.
         inline ref_ptr<PipelineLayout> createPipelineLayout(const std::set<std::string>& defines) { return createPipelineLayout(defines, descriptorSetRange()); }

--- a/include/vsg/vk/CommandBuffer.h
+++ b/include/vsg/vk/CommandBuffer.h
@@ -56,6 +56,7 @@ namespace vsg
         void setCurrentPipelineLayout(const PipelineLayout* pipelineLayout);
 
         VkPipelineLayout getCurrentPipelineLayout() const { return _currentPipelineLayout; }
+        const std::vector<bool>& getCurrentDescriptorSetSlots() const { return _currentDescriptorSetSlots; }
         VkShaderStageFlags getCurrentPushConstantStageFlags() const { return _currentPushConstantStageFlags; }
 
         ref_ptr<ScratchMemory> scratchMemory;
@@ -73,6 +74,7 @@ namespace vsg
         ref_ptr<Device> _device;
         ref_ptr<CommandPool> _commandPool;
         VkPipelineLayout _currentPipelineLayout;
+        std::vector<bool> _currentDescriptorSetSlots;
         VkShaderStageFlags _currentPushConstantStageFlags;
     };
     VSG_type_name(vsg::CommandBuffer);

--- a/src/vsg/state/BindDescriptorSet.cpp
+++ b/src/vsg/state/BindDescriptorSet.cpp
@@ -113,6 +113,13 @@ void BindDescriptorSets::compile(Context& context)
 void BindDescriptorSets::record(CommandBuffer& commandBuffer) const
 {
     //info("BindDescriptorSets::record() ", dynamicOffsets.size(), ", ", dynamicOffsets.data());
+    if (commandBuffer.getCurrentDescriptorSetSlots().size() < firstSet + descriptorSets.size())
+        return;
+    for (size_t slot = firstSet; slot < firstSet + descriptorSets.size(); ++slot)
+    {
+        if (!commandBuffer.getCurrentDescriptorSetSlots()[slot])
+            return;
+    }
     auto& vkd = _vulkanData[commandBuffer.deviceID];
     vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, vkd._vkPipelineLayout, firstSet,
                             static_cast<uint32_t>(vkd._vkDescriptorSets.size()), vkd._vkDescriptorSets.data(),
@@ -209,8 +216,11 @@ void BindDescriptorSet::compile(Context& context)
 void BindDescriptorSet::record(CommandBuffer& commandBuffer) const
 {
     //info("BindDescriptorSet::record() ", dynamicOffsets.size(), ", ", dynamicOffsets.data());
-    auto& vkd = _vulkanData[commandBuffer.deviceID];
-    vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, vkd._vkPipelineLayout, firstSet,
-                            1, &(vkd._vkDescriptorSet),
-                            static_cast<uint32_t>(dynamicOffsets.size()), dynamicOffsets.data());
+    if (commandBuffer.getCurrentDescriptorSetSlots().size() > firstSet && commandBuffer.getCurrentDescriptorSetSlots()[firstSet])
+    {
+        auto& vkd = _vulkanData[commandBuffer.deviceID];
+        vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, vkd._vkPipelineLayout, firstSet,
+                                1, &(vkd._vkDescriptorSet),
+                                static_cast<uint32_t>(dynamicOffsets.size()), dynamicOffsets.data());
+    }
 }

--- a/src/vsg/state/PipelineLayout.cpp
+++ b/src/vsg/state/PipelineLayout.cpp
@@ -130,7 +130,7 @@ void PipelineLayout::compile(Context& context)
         for (auto dsl : setLayouts)
         {
             if (dsl) dsl->compile(context);
-            descriptorSetSlots.push_back(dsl != nullptr);
+            descriptorSetSlots.push_back(dsl != nullptr && !dsl->empty());
         }
         _implementation[context.deviceID] = PipelineLayout::Implementation::create(context.device, setLayouts, pushConstantRanges, flags);
     }

--- a/src/vsg/state/PipelineLayout.cpp
+++ b/src/vsg/state/PipelineLayout.cpp
@@ -30,7 +30,8 @@ PipelineLayout::PipelineLayout(const PipelineLayout& rhs, const CopyOp& copyop) 
     Inherit(rhs, copyop),
     flags(rhs.flags),
     setLayouts(rhs.setLayouts),
-    pushConstantRanges(rhs.pushConstantRanges)
+    pushConstantRanges(rhs.pushConstantRanges),
+    descriptorSetSlots(rhs.descriptorSetSlots)
 {
 }
 
@@ -123,9 +124,13 @@ void PipelineLayout::compile(Context& context)
 {
     if (!_implementation[context.deviceID])
     {
+        descriptorSetSlots.clear();
+        descriptorSetSlots.reserve(setLayouts.size());
+
         for (auto dsl : setLayouts)
         {
             if (dsl) dsl->compile(context);
+            descriptorSetSlots.push_back(dsl != nullptr);
         }
         _implementation[context.deviceID] = PipelineLayout::Implementation::create(context.device, setLayouts, pushConstantRanges, flags);
     }

--- a/src/vsg/state/ViewDependentState.cpp
+++ b/src/vsg/state/ViewDependentState.cpp
@@ -151,7 +151,7 @@ void BindViewDescriptorSets::compile(Context& context)
 
 void BindViewDescriptorSets::record(CommandBuffer& commandBuffer) const
 {
-    if (commandBuffer.viewDependentState)
+    if (commandBuffer.viewDependentState && commandBuffer.getCurrentDescriptorSetSlots().size() > firstSet && commandBuffer.getCurrentDescriptorSetSlots()[firstSet])
     {
         commandBuffer.viewDependentState->bindDescriptorSets(commandBuffer, pipelineBindPoint, layout->vk(commandBuffer.deviceID), firstSet);
     }

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -552,7 +552,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
 
         void apply(const BindDescriptorSet& bds) override
         {
-            if (!bds.descriptorSet || !bds.descriptorSet->setLayout || !gpc.descriptorConfigurator) return;
+            if (!bds.layout || !gpc.descriptorConfigurator) return;
 
             if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, false, bds.firstSet))
             {
@@ -562,7 +562,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
 
         void apply(const BindDescriptorSets& bds) override
         {
-            if (!gpc.descriptorConfigurator) return;
+            if (!bds.layout || !gpc.descriptorConfigurator) return;
 
             if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, false, bds.firstSet + static_cast<uint32_t>(bds.descriptorSets.size()) - 1))
             {

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -554,7 +554,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
         {
             if (!bds.descriptorSet || !bds.descriptorSet->setLayout || !gpc.descriptorConfigurator) return;
 
-            if (gpc.shaderSet->compatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines))
+            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, true, bds.firstSet))
             {
                 gpc.inheritedSets.insert(bds.firstSet);
             }
@@ -564,7 +564,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
         {
             if (!gpc.descriptorConfigurator) return;
 
-            if (gpc.shaderSet->compatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines))
+            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, true, bds.firstSet + bds.descriptorSets.size() - 1))
             {
                 for (size_t i = 0; i < bds.descriptorSets.size(); ++i)
                 {
@@ -575,7 +575,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
 
         void apply(const BindViewDescriptorSets& bvds) override
         {
-            if (!gpc.shaderSet->compatiblePipelineLayout(*bvds.layout, gpc.shaderHints->defines))
+            if (!gpc.shaderSet->partiallyCompatiblePipelineLayout(*bvds.layout, gpc.shaderHints->defines, true, bvds.firstSet))
             {
                 return;
             }

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -554,7 +554,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
         {
             if (!bds.descriptorSet || !bds.descriptorSet->setLayout || !gpc.descriptorConfigurator) return;
 
-            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, true, bds.firstSet))
+            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, false, bds.firstSet))
             {
                 gpc.inheritedSets.insert(bds.firstSet);
             }
@@ -564,7 +564,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
         {
             if (!gpc.descriptorConfigurator) return;
 
-            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, true, bds.firstSet + bds.descriptorSets.size() - 1))
+            if (gpc.shaderSet->partiallyCompatiblePipelineLayout(*bds.layout, gpc.shaderHints->defines, false, bds.firstSet + static_cast<uint32_t>(bds.descriptorSets.size()) - 1))
             {
                 for (size_t i = 0; i < bds.descriptorSets.size(); ++i)
                 {
@@ -575,7 +575,7 @@ void GraphicsPipelineConfigurator::_assignInheritedSets()
 
         void apply(const BindViewDescriptorSets& bvds) override
         {
-            if (!gpc.shaderSet->partiallyCompatiblePipelineLayout(*bvds.layout, gpc.shaderHints->defines, true, bvds.firstSet))
+            if (!gpc.shaderSet->partiallyCompatiblePipelineLayout(*bvds.layout, gpc.shaderHints->defines, false, bvds.firstSet))
             {
                 return;
             }

--- a/src/vsg/vk/CommandBuffer.cpp
+++ b/src/vsg/vk/CommandBuffer.cpp
@@ -30,6 +30,7 @@ CommandBuffer::CommandBuffer(CommandPool* commandPool, VkCommandBuffer commandBu
     _device(commandPool->getDevice()),
     _commandPool(commandPool),
     _currentPipelineLayout(VK_NULL_HANDLE),
+    _currentDescriptorSetSlots(),
     _currentPushConstantStageFlags(0)
 {
 }
@@ -45,6 +46,7 @@ CommandBuffer::~CommandBuffer()
 void CommandBuffer::reset()
 {
     _currentPipelineLayout = VK_NULL_HANDLE;
+    _currentDescriptorSetSlots.clear();
     _currentPushConstantStageFlags = 0;
 
     _commandPool->reset();
@@ -59,6 +61,7 @@ void CommandBuffer::setCurrentPipelineLayout(const PipelineLayout* pipelineLayou
         state->dirtyStateStacks();
 
         _currentPipelineLayout = newLayout;
+        _currentDescriptorSetSlots = pipelineLayout->descriptorSetSlots;
         if (pipelineLayout->pushConstantRanges.empty())
             _currentPushConstantStageFlags = 0;
         else


### PR DESCRIPTION
# Pull Request Template

## Description

Avoids disturbing necessary descriptor sets while still avoiding the need for full layout compatibility checks.

This is achieved with a basic `vector<bool>` saying which sets a pipeline layout has and doesn't have, so layouts it doesn't have won't be bound. This could mean different sets are bound than if a full compatibility check was done, but that should only happen when the scenegraph requested invalid API usage - there should only be one `BindDescriptorSet` for each slot at the top of the state stacks, and if it's for a slot the current pipeline statically uses, it must be compatible. Therefore, we only need to worry about compatibility checks for slots the current pipeline layout doesn't use, which the change here now does.

*There's a slight caveat here - if a pipeline doesn't statically use any bindings in a descriptor set, it's legal to bind nothing to it, so someone might make a scenegraph that leaves its `BindDescriptorSet` out of a stategroup and inherets something incompatible. If a descriptor set is empty, it can't be statically used, so that's treated as if there's no descriptor set. Any handling beyond that would have a larger performance overhead, so I think use cases other than this aren't worth supporting directly. If someone wants to avoid binding useless descriptor sets, there are other means, e.g. adding a dummy statecommand or not having a pointless descriptor set in the first place.*

This is based on https://github.com/vsg-dev/VulkanSceneGraph/pull/1438, even though technically it could be separated and used on its own. This is because my earlier attempts to fix the problem relied on that PR, and using the same baseline made comparing them more straightforward.

This fix is by far the fastest that helps every failure case I identified (before yesterday), with the performance impact of a worst-case scenario ranging from below the noise floor of my measurements to just 0.25% overhead depending on whether I cherry-pick a good run or my worst run. For a scenegraph that isn't designed specifically to make this have as large an impact as possible, it should be free - it does a few instructions extra work for each pipeline layout change and descriptor set binding, both of which take much longer than that already.

Fixes #1394

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The main interesting test is the incompatible layout example here: https://github.com/vsg-dev/vsgExamples/compare/master...AnyOldName3:vsgExamples:incompatible-layouts. As discussed in #1394, it replicates the problem I initially discovered in a client app and several related situations that I discovered and thought were likely to have problems. There's lots of detail in this post https://github.com/vsg-dev/VulkanSceneGraph/issues/1394#issuecomment-2762170208. With the master branch, lots of validation errors are emitted in most test cases, but with this branch, it causes no errors at all.

Obviously, I've confirmed that this fixes the problem in the original client app.

As well as this, I've done performance testing. On my machine, the overhead is much smaller than the variation in framerate or execution time from run to run, so simply timing things didn't provide meaningful results. Instead, I found that running for a couple of minutes with a sampling-based profiler (I used the one built into Visual Studio) and comparing the percentage of samples in the modified functions was much more consistent. To get a worst-case scenario and maximise the observable overhead, I generated a scenegraph where the same basic cube is drawn thousands of times cycling between 32 different materials, with the number of draw commands chosen to give around a hundred frames per second. Trying fewer draws and more frames just made the noise from slow functions (particularly `vkCmdBeginRenderPass` and `vkBeginCommandBuffer`) overwhelm the overhead I was trying to measure, but trying a smaller number of slower frames meant they were called less and countered this out. Other variations on this style of scenegraph produced equivalent results. As mentioned above, if I cherry-pick the fastest baseline result and slowest result from this branch, and compare the number of samples in modified functions, that only accounts for 0.25% of all samples. If I don't artificially try and make things look as bad as possible, then the difference is too small to measure.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works. *They're on a vsgExamples branch - now the problem's fixed, it's not necessarily worth keeping the test app around.*
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
