### PR TITLE
Fix cppcheck on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,10 @@ vsg_add_target_cppcheck(
     SUPPRESSIONS_LIST
         "${VSG_SOURCE_DIR}/cmake/cppcheck-suppression-list.txt"
     FILES
-        ${CMAKE_SOURCE_DIR}/include/vsg/*/*.h
-        ${VSG_SOURCE_DIR}/src/vsg/*/*.cpp
+        ${CMAKE_SOURCE_DIR}/include/
+        --file-filter=${CMAKE_SOURCE_DIR}/include/vsg/*/*.h
+        ${VSG_SOURCE_DIR}/src/
+        --file-filter=${VSG_SOURCE_DIR}/src/vsg/*/*.cpp
         -I ${VSG_SOURCE_DIR}/include/
 )
 vsg_add_target_uninstall()


### PR DESCRIPTION
Fixes #1092 

The gist of the problem is that as-is, the `vsg_add_target_cppcheck` macro generates a command that looks something like this:
```
/usr/bin/cppcheck -j 24 --quiet --enable=style --language=c++ /path/to/vsg/cmake/cppcheck-suppression-list.txt /path/to/vsg/include/vsg/*/*.h /path/to/vsg/include/vsg/*/*.h
```
Unix-derived platforms will expand wildcards in commands before passing them to the process, so the process gets passed a bit list of filepaths. Windows is derived from CP/M, which just passed the literal command verbatim to the process, and let it split the arguments and expand wildcards however it wanted, so that's what Windows does, too.

cppcheck *is* able to deal with wildcards, but to do that, it needs to be passed a directory instead of a file and a `--file-filter` to say which files to use from the directory. Making that change works for me on both Windows and Ubuntu, so I think it's a safe bet that it's reliable everywhere.

This might not be the best way to set cppcheck up, though. It's got built-in support for analysing CMake projects (provided you're using a generator that supports `EXPORT_COMPILE_COMMANDS`, so Makefiles or Ninja) and VS solutions (so the most popular non-`EXPORT_COMPILE_COMMANDS` generator). In that mode, it can figure out the include paths and preprocessor defines from the project, which might give better results.

