### PR TITLE
observer_ptr comparison improvements

### DIFF
--- a/include/vsg/core/observer_ptr.h
+++ b/include/vsg/core/observer_ptr.h
@@ -114,6 +114,15 @@ namespace vsg
         template<class R>
         bool operator!=(const R* rhs) const { return (rhs != _ptr); }
 
+        template<class R>
+        bool operator<(const vsg::ref_ptr<R> rhs) const { return (rhs.get() < _ptr); }
+
+        template<class R>
+        bool operator==(const vsg::ref_ptr<R> rhs) const { return (rhs.get() == _ptr); }
+
+        template<class R>
+        bool operator!=(const vsg::ref_ptr<R> rhs) const { return (rhs.get() != _ptr); }
+
         bool valid() const noexcept { return _auxiliary.valid() && _auxiliary->getConnectedObject() != nullptr; }
 
         explicit operator bool() const noexcept { return valid(); }

--- a/include/vsg/core/observer_ptr.h
+++ b/include/vsg/core/observer_ptr.h
@@ -97,31 +97,73 @@ namespace vsg
         }
 
         template<class R>
-        bool operator<(const observer_ptr<R>& rhs) const { return (rhs._ptr < _ptr); }
+        bool operator<(const observer_ptr<R>& rhs) const { return (rhs._ptr < _ptr) || (rhs._ptr == _ptr && rhs._auxiliary < _auxiliary); }
 
         template<class R>
-        bool operator==(const observer_ptr<R>& rhs) const { return (rhs._ptr == _ptr); }
+        bool operator==(const observer_ptr<R>& rhs) const { return (rhs._ptr == _ptr) && (rhs._auxiliary == _auxiliary); }
 
         template<class R>
-        bool operator!=(const observer_ptr<R>& rhs) const { return (rhs._ptr != _ptr); }
+        bool operator!=(const observer_ptr<R>& rhs) const { return (rhs._ptr != _ptr) || (rhs._auxiliary != _auxiliary); }
 
         template<class R>
-        bool operator<(const R* rhs) const { return (rhs < _ptr); }
+        bool operator<(const R* rhs) const
+        {
+            if (rhs < _ptr)
+                return true;
+            if (_ptr == nullptr)
+                return false;
+            return rhs->getAuxiliary() < _auxiliary;
+        }
 
         template<class R>
-        bool operator==(const R* rhs) const { return (rhs == _ptr); }
+        bool operator==(const R* rhs) const
+        {
+            if (rhs != _ptr)
+                return false;
+            if (rhs == nullptr)
+                return true;
+            return rhs->getAuxiliary() == _auxiliary;
+        }
 
         template<class R>
-        bool operator!=(const R* rhs) const { return (rhs != _ptr); }
+        bool operator!=(const R* rhs) const
+        {
+            if (rhs != _ptr)
+                return true;
+            if (rhs == nullptr)
+                return false;
+            return rhs->getAuxiliary() != _auxiliary;
+        }
 
         template<class R>
-        bool operator<(const vsg::ref_ptr<R> rhs) const { return (rhs.get() < _ptr); }
+        bool operator<(const vsg::ref_ptr<R> rhs) const
+        {
+            if (rhs.get() < _ptr)
+                return true;
+            if (_ptr == nullptr)
+                return false;
+            return rhs->getAuxiliary() < _auxiliary;
+        }
 
         template<class R>
-        bool operator==(const vsg::ref_ptr<R> rhs) const { return (rhs.get() == _ptr); }
+        bool operator==(const vsg::ref_ptr<R> rhs) const
+        {
+            if (rhs.get() != _ptr)
+                return false;
+            if (rhs == nullptr)
+                return true;
+            return rhs->getAuxiliary() == _auxiliary;
+        }
 
         template<class R>
-        bool operator!=(const vsg::ref_ptr<R> rhs) const { return (rhs.get() != _ptr); }
+        bool operator!=(const vsg::ref_ptr<R> rhs) const
+        {
+            if (rhs.get() != _ptr)
+                return true;
+            if (rhs == nullptr)
+                return false;
+            return rhs->getAuxiliary() != _auxiliary;
+        }
 
         bool valid() const noexcept { return _auxiliary.valid() && _auxiliary->getConnectedObject() != nullptr; }
 


### PR DESCRIPTION
This PR's a little opinionated, so it's worth some consideration whether the change from each commit is a good idea.

First, this adds explicit `ref_ptr` comparison operators to `observer_ptr` as I noticed that due to the existing naked pointer comparison operator being templated, implicit conversions were disabled and you'd have to do explicit conversions to make it work. In a client app, someone had chosen an approach that required promoting a lot of `observer_ptr`s to `ref_ptr`s, and it was adding fifteen seconds to the launch time due to the lock. Having a sensible implementation chosen automatically avoids this footgun and makes it easier to write fast apps.

The other change it makes is to include `_auxiliary` in comparisons between `observer_ptr` and other pointers. This means that if an object is created and tracked by an `observer_ptr`, but then gets destroyed, the `observer_ptr` will compare as distinct from any other object that gets made later that reuses the same address. This could already be done by converting the `observer_ptr` to `ref_ptr` and comparing against that, but that involves taking a lock, whereas the implementation here is lock-free and therefore much faster.

For comparison to `std::shared_ptr` and `std::weak_ptr`, things are a little different. `std::weak_ptr` doesn't participate in any comparisons at all, so it has to be explicitly locked to create a `shared_ptr`. That's a much faster operation as it's designed to be implemented with atomics, so is lock-free, so the footgun we have with `observer_ptr` doesn't exist. If you do explicitly lock it, you get the behaviour where reuse of the same memory address doesn't give equal pointers as the pointer to a destroyed object becomes null when it's locked.