### PR TITLE
Device memory allocate flags

### DIFF
--- a/include/vsg/state/Buffer.h
+++ b/include/vsg/state/Buffer.h
@@ -80,6 +80,6 @@ namespace vsg
     };
     VSG_type_name(vsg::Buffer);
 
-    extern VSG_DECLSPEC ref_ptr<Buffer> createBufferAndMemory(Device* device, VkDeviceSize in_size, VkBufferUsageFlags in_usage, VkSharingMode in_sharingMode, VkMemoryPropertyFlags memoryProperties);
+    extern VSG_DECLSPEC ref_ptr<Buffer> createBufferAndMemory(Device* device, VkDeviceSize in_size, VkBufferUsageFlags in_usage, VkSharingMode in_sharingMode, VkMemoryPropertyFlags memoryProperties, void* pNextAllocInfo = nullptr);
 
 } // namespace vsg

--- a/src/vsg/raytracing/AccelerationGeometry.cpp
+++ b/src/vsg/raytracing/AccelerationGeometry.cpp
@@ -55,9 +55,17 @@ void AccelerationGeometry::compile(Context& context)
     auto vertexBufferInfo = vsg::createBufferAndTransferData(context, vertexDataList, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_SHARING_MODE_EXCLUSIVE);
     auto indexBufferInfo = vsg::createBufferAndTransferData(context, indexDataList, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_SHARING_MODE_EXCLUSIVE);
 #else
-    auto vertexBufferInfo = vsg::createHostVisibleBuffer(context.device, vertexDataList, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE);
+    auto vertexBufferInfo = vsg::createHostVisibleBuffer(context.device, vertexDataList,
+	VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
+	VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+	VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
+	VK_SHARING_MODE_EXCLUSIVE);
     vsg::copyDataListToBuffers(context.device, vertexBufferInfo);
-    auto indexBufferInfo = vsg::createHostVisibleBuffer(context.device, indexDataList, VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE);
+    auto indexBufferInfo = vsg::createHostVisibleBuffer(context.device, indexDataList,
+	VK_BUFFER_USAGE_INDEX_BUFFER_BIT |
+	VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+	VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
+	VK_SHARING_MODE_EXCLUSIVE);
     vsg::copyDataListToBuffers(context.device, indexBufferInfo);
 #endif
 

--- a/src/vsg/raytracing/AccelerationStructure.cpp
+++ b/src/vsg/raytracing/AccelerationStructure.cpp
@@ -62,8 +62,10 @@ void AccelerationStructure::compile(Context& context)
         _geometryPrimitiveCounts.data(),
         &accelerationStructureBuildSizesInfo);
 
-    _buffer = vsg::createBufferAndMemory(context.device, accelerationStructureBuildSizesInfo.accelerationStructureSize,
-                                         VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    VkMemoryAllocateFlagsInfo memFlags = {};
+    memFlags.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
+    memFlags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    _buffer = vsg::createBufferAndMemory(context.device, accelerationStructureBuildSizesInfo.accelerationStructureSize, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &memFlags);
 
     _accelerationStructureInfo.buffer = _buffer->vk(context.deviceID);
     _accelerationStructureInfo.size = accelerationStructureBuildSizesInfo.accelerationStructureSize;

--- a/src/vsg/raytracing/RayTracingPipeline.cpp
+++ b/src/vsg/raytracing/RayTracingPipeline.cpp
@@ -179,9 +179,12 @@ RayTracingPipeline::Implementation::Implementation(Context& context, RayTracingP
         //auto bindingTableBuffer = bindingTableBufferInfo.buffer;
         //auto bindingTableMemory = bindingTableBuffer->getDeviceMemory(context.deviceID);
         std::vector<ref_ptr<Buffer>> bindingTableBuffers(rayTracingShaderGroups.size());
+        VkMemoryAllocateFlagsInfo memFlags = {};
+        memFlags.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
+        memFlags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
         for (size_t i = 0; i < bindingTableBuffers.size(); ++i)
         {
-            bindingTableBuffers[i] = createBufferAndMemory(_device, handleSizeAligned, VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            bindingTableBuffers[i] = createBufferAndMemory(_device, handleSizeAligned, VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &memFlags);
         }
 
         std::vector<uint8_t> shaderHandleStorage(sbtSize);

--- a/src/vsg/state/Buffer.cpp
+++ b/src/vsg/state/Buffer.cpp
@@ -153,13 +153,13 @@ size_t Buffer::totalReservedSize() const
     return _memorySlots.totalReservedSize();
 }
 
-ref_ptr<Buffer> vsg::createBufferAndMemory(Device* device, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode, VkMemoryPropertyFlags memoryProperties)
+ref_ptr<Buffer> vsg::createBufferAndMemory(Device* device, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode, VkMemoryPropertyFlags memoryProperties, void* pNextAllocInfo)
 {
     auto buffer = vsg::Buffer::create(size, usage, sharingMode);
     buffer->compile(device);
 
     auto memRequirements = buffer->getMemoryRequirements(device->deviceID);
-    auto memory = vsg::DeviceMemory::create(device, memRequirements, memoryProperties);
+    auto memory = vsg::DeviceMemory::create(device, memRequirements, memoryProperties, pNextAllocInfo);
 
     buffer->bind(memory, 0);
     return buffer;

--- a/src/vsg/vk/Context.cpp
+++ b/src/vsg/vk/Context.cpp
@@ -286,7 +286,10 @@ bool Context::record()
         // create scratch buffer and issue build acceleration structure commands
         if (scratchBufferSize > 0)
         {
-            ref_ptr<Buffer> scratchBuffer = vsg::createBufferAndMemory(device, scratchBufferSize, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+            VkMemoryAllocateFlagsInfo memFlags = {};
+            memFlags.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
+            memFlags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+            ref_ptr<Buffer> scratchBuffer = vsg::createBufferAndMemory(device, scratchBufferSize, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_SHARING_MODE_EXCLUSIVE, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &memFlags);
 
             for (auto& command : buildAccelerationStructureCommands)
             {


### PR DESCRIPTION
added pNext allocInfo for createBufferAndMemory()
so that we can customize the memory allocation, specifically for raytracing.
This resolves vulkan validation errors when creating memory with the
device address usage bit but without the bit set in the pNext structure.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] no doc needed - this just follows from the memory allocation Vulkan API

## How Has This Been Tested?

This was tested on our own raytracing example code. Was shown to work on linux windows and mac (arm).

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works (raytracing example in the vsgExamples should suffice)
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules (Not relevant)
