### PR TITLE
use rendergraph renderArea as scissor instead of viewport

### DIFF
--- a/src/vsg/app/RenderGraph.cpp
+++ b/src/vsg/app/RenderGraph.cpp
@@ -49,7 +49,8 @@ RenderGraph::RenderGraph(ref_ptr<Window> in_window, ref_ptr<View> in_view) :
         renderArea.extent = window->extent2D();
     }
 
-    viewportState->set(renderArea.offset.x, renderArea.offset.y, renderArea.extent.width, renderArea.extent.height);
+    viewportState->scissors.resize(1);
+    viewportState->scissors[0] = renderArea;
 
     // set up the clearValues based on the RenderPass's attachments.
     setClearValues(window->clearColor(), VkClearDepthStencilValue{0.0f, 0});
@@ -150,7 +151,8 @@ void RenderGraph::accept(RecordTraversal& recordTraversal) const
     vkCmdBeginRenderPass(vk_commandBuffer, &renderPassInfo, contents);
 
     // sync the viewportState and push
-    viewportState->set(renderArea.offset.x, renderArea.offset.y, renderArea.extent.width, renderArea.extent.height);
+    viewportState->scissors.resize(1);
+    viewportState->scissors[0] = renderArea;
 
     if ((viewportStateHint & DYNAMIC_VIEWPORTSTATE))
     {


### PR DESCRIPTION
In our application we frequently have views which are partially outside of the window's render area. In this case, the viewport is used to determine aspect ratio and should be allowed to go outside of the rendering area. The scissor is used to clip the rendered scene to the smaller visible region and should not change any rendering with respect to the camera. 

The original code sets the viewport and scissor to the render graph's renderArea during record which ignores any potential difference. This PR fixes that to only set the scissor.

While this change fixes our immediate issue, I suspect there is a better solution that will be more general or more complete. I'm just not sure what's best.

This is rework of the effort to accomplish the same thing with older VSG structure around viewport state
See these PRs: 

* #1431
* #1399
* #1390
* #1331

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work ~as expected~ as it did before)

## How Has This Been Tested?

In our application we have viewport states where the viewport is partially outside the window area. The scissor is then brought to be within the window area. The render graph's renderArea should then be the scissor and not the viewport when recording the render commands.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
