### PR TITLE
Add missing &

### DIFF
--- a/include/vsg/core/observer_ptr.h
+++ b/include/vsg/core/observer_ptr.h
@@ -136,7 +136,7 @@ namespace vsg
         }
 
         template<class R>
-        bool operator<(const vsg::ref_ptr<R> rhs) const
+        bool operator<(const vsg::ref_ptr<R>& rhs) const
         {
             if (rhs.get() < _ptr)
                 return true;
@@ -146,7 +146,7 @@ namespace vsg
         }
 
         template<class R>
-        bool operator==(const vsg::ref_ptr<R> rhs) const
+        bool operator==(const vsg::ref_ptr<R>& rhs) const
         {
             if (rhs.get() != _ptr)
                 return false;
@@ -156,7 +156,7 @@ namespace vsg
         }
 
         template<class R>
-        bool operator!=(const vsg::ref_ptr<R> rhs) const
+        bool operator!=(const vsg::ref_ptr<R>& rhs) const
         {
             if (rhs.get() != _ptr)
                 return true;


### PR DESCRIPTION
I'm not entirely sure how these were missed, but there were still ref and unref calls I wasn't expecting on a hot path. This takes a further five seconds off the startup time of the app I'm working on, so between this and the previous PR, that's nearly half the launch time gone.