### PR TITLE
Reset State at the beginning of each View record traversal

### DIFF
--- a/src/vsg/app/RecordTraversal.cpp
+++ b/src/vsg/app/RecordTraversal.cpp
@@ -556,6 +556,9 @@ void RecordTraversal::apply(const View& view)
 {
     GPU_INSTRUMENTATION_L1_NCO(instrumentation, *getCommandBuffer(), "View", COLOR_RECORD_L1, &view);
 
+    // Reset the state at the start of a new view traversal.
+    _state->reset();
+    
     // note, View::accept() updates the RecordTraversal's traversalMask
     auto cached_traversalMask = _state->_commandBuffer->traversalMask;
     _state->_commandBuffer->traversalMask = traversalMask;


### PR DESCRIPTION
This PR fixes issue https://github.com/vsg-dev/VulkanSceneGraph/issues/1501 by resetting state, and therefore the StateStack, at the beginning of each View record traversal. Without resetting, the StateStack is carried over from View to View in an undefined configuration instead of stack[0] being nullptr. This can lead to State not being recorded.

Tested using custom application.

Tested the vsganaglyphicstereo example, which uses multiple Views in a RenderGraph and it works the same pre and post PR. 
