### PR TITLE
Fix typo in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ Command line instructions for default build of static library (.a) in source:
 
     git clone https://github.com/vsg-dev/VulkanSceneGraph.git
     cd VulkanSceneGraph
-    cmake .c
+    cmake .
     cmake --build . -j 16 -t install
 
 Command line instructions for building shared library (.so) out of source:


### PR DESCRIPTION
In the process of reviewing the VulkanSceneGraph library, I discovered this typo. 
Why didn't anyone notice right away?