### PR TITLE
Extend shader compiler define syntax to allow name=value instead of just valueless defines

### DIFF
--- a/src/vsg/utils/ShaderCompiler.cpp
+++ b/src/vsg/utils/ShaderCompiler.cpp
@@ -10,6 +10,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 </editor-fold> */
 
+#include <vsg/core/Exception.h>
 #include <vsg/core/Version.h>
 #include <vsg/io/Logger.h>
 #include <vsg/io/Options.h>
@@ -30,6 +31,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #endif
 
 #include <algorithm>
+#include <cassert>
 #include <iomanip>
 
 #ifndef VK_API_VERSION_MAJOR
@@ -444,7 +446,8 @@ std::string ShaderCompiler::combineSourceAndDefines(const std::string& source, c
         return str.substr(start + 1, (end - start) - 1);
     };
 
-    auto split = [](const std::string& str, const char& separator) {
+    // returns the string split into sanitized tokens
+    auto split = [&sanitise](const std::string& str, const char& separator) {
         std::vector<std::string> elements;
 
         std::string::size_type prev_pos = 0, pos = 0;
@@ -453,10 +456,12 @@ std::string ShaderCompiler::combineSourceAndDefines(const std::string& source, c
         {
             auto substring = str.substr(prev_pos, pos - prev_pos);
             elements.push_back(substring);
+            sanitise(elements.back());
             prev_pos = ++pos;
         }
 
         elements.push_back(str.substr(prev_pos, pos - prev_pos));
+        sanitise(elements.back());
 
         return elements;
     };
@@ -464,6 +469,31 @@ std::string ShaderCompiler::combineSourceAndDefines(const std::string& source, c
     auto addLine = [](std::ostringstream& ss, const std::string& line) {
         ss << line << "\n";
     };
+
+    /*
+     * Verify that all the shader compiler defines are of the form "name" or "name=value" and that
+     * the set doesn't contain entries with the same name and different values. This check is only
+     * a temporary stopgap until the shader compiler defines container is updated from a
+     * std::set<std::string>, to a std::map<std::string,std::string> to more properly manage defines
+     * with optional values.
+     */
+    std::set<std::string> uniqueDefines;
+    for (auto nameValueDef : defines)
+    {
+        auto nameValueDefElems = split(nameValueDef, '=');
+        // simple check for formatting issues
+        if (nameValueDefElems.size() != 1 && nameValueDefElems.size() != 2)
+        {
+            throw Exception{"Error: Incorrectly formatted shader compile define. Acceptable formats are either a name or name=value."};
+        }
+        // verify that a valueless define or a name=value define with the same name has not already been encountered
+        if (uniqueDefines.count(nameValueDefElems.front()) != 0)
+        {
+            throw Exception{"Error: Found two shader compiler defines with the same name and different values."};
+        }
+        // keep track that we have seen this define name
+        uniqueDefines.insert(nameValueDefElems.front());
+    }
 
     std::istringstream iss(source);
     std::ostringstream headerstream;
@@ -493,16 +523,20 @@ std::string ShaderCompiler::combineSourceAndDefines(const std::string& source, c
 
             addLine(headerstream, line);
 
-            // loop the imported defines and see if it's also requested in defines, if so insert a define line
-            for (auto importedDef : importedDefines)
+            // loop over the requested defines and see if it's also in the imported defines, if so insert a define line
+            for (auto nameValueDef : defines)
             {
-                auto sanitiesedImportDef = importedDef;
-                sanitise(sanitiesedImportDef);
+                // separate the define name from its optional value
+                auto nameValueDefElems = split(nameValueDef, '=');
+                assert(nameValueDefElems.size() == 1 || nameValueDefElems.size() == 2);
 
-                auto finditr = std::find(defines.begin(), defines.end(), sanitiesedImportDef);
+                auto finditr = std::find(importedDefines.begin(), importedDefines.end(), nameValueDefElems.front());
                 if (finditr != defines.end())
                 {
-                    addLine(headerstream, "#define " + sanitiesedImportDef);
+                    // output the pre-processor define directive with its name and optional value
+                    addLine(headerstream, "#define " + nameValueDefElems.front() +
+                                (nameValueDefElems.size() == 2
+                                     ? " "+nameValueDefElems.back() : std::string()));
                 }
             }
         }


### PR DESCRIPTION
## Description

Using shader specialization constants to size global arrays doesn't work on the Mac.

We have a need in our vertex shader to size both a vertex attribute array and an array of gl_clipDistance by a defined value at shader compile time. We were using shader specialization constants to achieve this and on Linux and Windows with NVidia and AMD we seemed to have success even though the "Arrays inside a block" discussion in section "4.4.x Specialization-Constant Qualifier" of [ARB_gl_spirv.txt](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_gl_spirv.txt) made it sound like using specialization constants to size these array members in the shader is not supported. When we tried out the same code on the Mac we had very unreliable results and were not able to get clipping to work correctly if the vertex array or the gl_ClipDistance array was sized by a specialization constant.

Currently, valueless shader compiler defines are added to a `std::set<std::string>` container via the shader module's hints. This PR extents the syntax to allow `name=value` without changing the client API thereby providing an option for defines with simple values for use the in the shader code.

Fixes # (issue)
#1534 

## Type of change
Core VSG change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I extended the vsgclip example in the vsgExamples repository. See pull request 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
