### PR TITLE
Reset State for top-level Views only

### DIFF
--- a/include/vsg/app/RecordTraversal.h
+++ b/include/vsg/app/RecordTraversal.h
@@ -183,6 +183,9 @@ namespace vsg
         int32_t _minimumBinNumber = 0;
         std::vector<ref_ptr<Bin>> _bins;
         ref_ptr<ViewDependentState> _viewDependentState;
+
+        // Increment and decrement the view counter so we know if we are traversing a top-level view.
+        int32_t _viewCounter = 0;
     };
 
 } // namespace vsg

--- a/src/vsg/app/RecordTraversal.cpp
+++ b/src/vsg/app/RecordTraversal.cpp
@@ -556,8 +556,9 @@ void RecordTraversal::apply(const View& view)
 {
     GPU_INSTRUMENTATION_L1_NCO(instrumentation, *getCommandBuffer(), "View", COLOR_RECORD_L1, &view);
 
-    // Reset the state at the start of a new view traversal.
-    _state->reset();
+    // Reset the state at the start of a new top-level view traversal.
+    if(_viewCounter == 0) _state->reset();
+    ++_viewCounter;
 
     // note, View::accept() updates the RecordTraversal's traversalMask
     auto cached_traversalMask = _state->_commandBuffer->traversalMask;
@@ -659,6 +660,8 @@ void RecordTraversal::apply(const View& view)
     cached_regionsOfInterest.swap(regionsOfInterest);
     _state->_commandBuffer->traversalMask = cached_traversalMask;
     _viewDependentState = cached_viewDependentState;
+
+    --_viewCounter;
 }
 
 void RecordTraversal::apply(const CommandGraph& commandGraph)


### PR DESCRIPTION
Reset state every time the RecordTraversal encounters a top-level View. 

State needs to be reset between sibling top-level Views, otherwise it is left in an undefined status, which can lead to state not being recorded when using lazy state updating. However, some implementations using nested Views require state to persist from parent View to child View.

This PR modifies https://github.com/vsg-dev/VulkanSceneGraph/pull/1502 so that only top-level State is reset instead of resetting it for all Views. This addresses https://github.com/vsg-dev/VulkanSceneGraph/issues/1538


