### PR TITLE
Adressed implicit conversion issues in quat.h

### DIFF
--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -155,7 +155,7 @@ namespace vsg
 
         explicit operator bool() const noexcept
         {
-            static constexpr value_type zero = static_cast<value_type>(1.0);
+            static constexpr value_type zero = static_cast<value_type>(0.0);
             return value[0] != zero || value[1] != zero || value[2] != zero || value[3] != zero;
         }
     };

--- a/include/vsg/maths/quat.h
+++ b/include/vsg/maths/quat.h
@@ -93,7 +93,13 @@ namespace vsg
 
         void set(value_type angle_radians, const t_vec3<value_type>& axis)
         {
-            const value_type epsilon = 1e-7;
+            //@todo epsilon might have to be made value_type dependent
+            static constexpr value_type epsilon = static_cast<value_type>(1e-7);
+            // avoid implicit conversions. 
+            // a performance optimization for the sin / cos calls below which otherwise operate in double precision.
+            static constexpr value_type one = static_cast<value_type>(1.0);
+            static constexpr value_type half = static_cast<value_type>(0.5);
+
             value_type len = length(axis);
             if (len < epsilon)
             {
@@ -102,9 +108,9 @@ namespace vsg
                 return;
             }
 
-            value_type inversenorm = 1.0 / len;
-            value_type coshalfangle = cos(0.5 * angle_radians);
-            value_type sinhalfangle = sin(0.5 * angle_radians);
+            value_type inversenorm =  one / len;
+            value_type coshalfangle = cos(half * angle_radians);
+            value_type sinhalfangle = sin(half * angle_radians);
 
             x = axis.x * sinhalfangle * inversenorm;
             y = axis.y * sinhalfangle * inversenorm;
@@ -114,7 +120,12 @@ namespace vsg
 
         void set(const t_vec3<value_type>& from, const t_vec3<value_type>& to)
         {
-            const value_type epsilon = 1e-7;
+            //@todo epsilon might have to be made value_type dependent
+            static constexpr value_type epsilon = static_cast<value_type>(1e-7);
+            // avoid implicit conversions.
+            // a performance optimization for the sin / cos calls below which otherwise operate in double precision.
+            static constexpr value_type one = static_cast<value_type>(1.0);
+            static constexpr value_type half = static_cast<value_type>(0.5);
 
             value_type dot_pd = vsg::dot(from, to);
             value_type div = std::sqrt(length2(from) * length2(to));
@@ -132,9 +143,9 @@ namespace vsg
 
             double angle_radians = acos(dot_pd / div);
 
-            value_type inversenorm = 1.0 / len;
-            value_type coshalfangle = cos(0.5 * angle_radians);
-            value_type sinhalfangle = sin(0.5 * angle_radians);
+            value_type inversenorm = one / len;
+            value_type coshalfangle = cos(half * angle_radians);
+            value_type sinhalfangle = sin(half * angle_radians);
 
             x = axis.x * sinhalfangle * inversenorm;
             y = axis.y * sinhalfangle * inversenorm;
@@ -142,7 +153,11 @@ namespace vsg
             w = coshalfangle;
         }
 
-        explicit operator bool() const noexcept { return value[0] != 0.0 || value[1] != 0.0 || value[2] != 0.0 || value[3] != 0.0; }
+        explicit operator bool() const noexcept
+        {
+            static constexpr value_type zero = static_cast<value_type>(1.0);
+            return value[0] != zero || value[1] != zero || value[2] != zero || value[3] != zero;
+        }
     };
 
     using quat = t_quat<float>;         /// float quaternion
@@ -275,7 +290,7 @@ namespace vsg
         T one(1.0);
 
         T cosomega = dot(from, to);
-        if (cosomega < 0.0)
+        if (cosomega < static_cast<T>(0.0))
         {
             cosomega = -cosomega;
             to.x = -to.x;


### PR DESCRIPTION
Implicit conversions in quat.h from constants (e.g. 1.0 which is a double) into value_type break compilation in VisualStudio with compiler settings "/W3 /WX".

These changes also improve performance by allowing the compiler to use the value_type variants of sin and cos.

# Pull Request Template

## Description

Motivation: see above.

We have strict compiler settings to catch conversion issues in our application code on windows (/W3 /WX). The include of vsg/maths/quat.h and subsequent use of vsg::quat (aka t_quat<float>) result in compiler warnings and subsequent errors due to the /WX setting.

The proposed fix not only adresses the compiler warnings but also enables the compiler to choose the appropriate value_type specific version of sin() and cos() which in turn might improve performance.

The applied solution is the most straight-forward one i could think of. Another solution could be the specialization of the template class for at least double- and float-types. That would then increase maintenance costs.

No dependencies.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The problem occured in the compilation of the CsWorldview app (from the csgCs project) with our compiler settings.

A repeat case is:
`           
#include <vsg/all.h>
int main()
{
            vsg::quat hourRot;
            hourRot.set(-1.0f, vsg::vec3(0.0f, 0.0f, 1.0f));
            return 0;
}
`
- [ ] Test A
- [ ] Test B

**Test Configuration**:
VisualStudio with compiler flags "/W3 /WX".

## Checklist:

- [? ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
