### PR TITLE
Avoid reusing semaphores that may still be in flight

### DIFF
--- a/include/vsg/app/Presentation.h
+++ b/include/vsg/app/Presentation.h
@@ -24,7 +24,6 @@ namespace vsg
         VkResult present();
 
         Windows windows;
-        Semaphores waitSemaphores; // taken from RecordAndSubmitTasks.signalSemaphores
 
         ref_ptr<Queue> queue; // assign in application for GraphicsQueue from device
     };

--- a/include/vsg/app/RecordAndSubmitTask.h
+++ b/include/vsg/app/RecordAndSubmitTask.h
@@ -39,7 +39,6 @@ namespace vsg
         Windows windows;
         Semaphores waitSemaphores;   // assign in application setup
         CommandGraphs commandGraphs; // assign in application setup
-        Semaphores signalSemaphores; // connect to Presentation.waitSemaphores
 
         ref_ptr<TransferTask> transferTask; // data is transferred for this frame
 

--- a/include/vsg/app/Window.h
+++ b/include/vsg/app/Window.h
@@ -122,6 +122,7 @@ namespace vsg
             ref_ptr<ImageView> imageView;
             ref_ptr<Framebuffer> framebuffer;
             ref_ptr<Semaphore> imageAvailableSemaphore;
+            ref_ptr<Semaphore> renderFinishedSemaphore;
         };
 
         using Frames = std::vector<Frame>;

--- a/src/vsg/app/Presentation.cpp
+++ b/src/vsg/app/Presentation.cpp
@@ -20,10 +20,6 @@ VkResult Presentation::present()
     //debug("Presentation::present()");
 
     std::vector<VkSemaphore> vk_semaphores;
-    for (auto& semaphore : waitSemaphores)
-    {
-        vk_semaphores.emplace_back(*(semaphore));
-    }
 
     std::vector<VkSwapchainKHR> vk_swapchains;
     std::vector<uint32_t> indices;
@@ -34,6 +30,9 @@ VkResult Presentation::present()
         {
             vk_swapchains.emplace_back(*(window->getOrCreateSwapchain()));
             indices.emplace_back(static_cast<uint32_t>(imageIndex));
+
+            auto& renderFinishedSemaphore = window->frame(imageIndex).renderFinishedSemaphore;
+            vk_semaphores.push_back(*renderFinishedSemaphore);
         }
     }
 

--- a/src/vsg/app/Viewer.cpp
+++ b/src/vsg/app/Viewer.cpp
@@ -524,13 +524,10 @@ void Viewer::assignRecordAndSubmitTaskAndPresentation(CommandGraphs in_commandGr
 
             Windows activeWindows(findWindows.windows.begin(), findWindows.windows.end());
 
-            auto renderFinishedSemaphore = vsg::Semaphore::create(device);
-
             // set up Submission with CommandBuffer and signals
             auto recordAndSubmitTask = vsg::RecordAndSubmitTask::create(device, numBuffers);
             recordAndSubmitTask->commandGraphs = commandGraphs;
             recordAndSubmitTask->databasePager = databasePager;
-            recordAndSubmitTask->signalSemaphores.emplace_back(renderFinishedSemaphore);
             recordAndSubmitTask->windows = activeWindows;
             recordAndSubmitTask->queue = mainQueue;
             recordAndSubmitTasks.emplace_back(recordAndSubmitTask);
@@ -541,7 +538,6 @@ void Viewer::assignRecordAndSubmitTaskAndPresentation(CommandGraphs in_commandGr
             if (instrumentation) recordAndSubmitTask->assignInstrumentation(instrumentation);
 
             auto presentation = vsg::Presentation::create();
-            presentation->waitSemaphores.emplace_back(renderFinishedSemaphore);
             presentation->windows = activeWindows;
             presentation->queue = device->getQueue(deviceQueueFamily.presentFamily);
             presentations.emplace_back(presentation);

--- a/src/vsg/app/Window.cpp
+++ b/src/vsg/app/Window.cpp
@@ -447,6 +447,9 @@ VkResult Window::acquireNextImage(uint64_t timeout)
         // the acquired image's semaphore must be available now so make it the new _availableSemaphore and set its entry to the one to use for the next frame by swapping ref_ptr<>'s
         _availableSemaphore.swap(_frames[nextImageIndex].imageAvailableSemaphore);
 
+        if (!_frames[nextImageIndex].renderFinishedSemaphore)
+            _frames[nextImageIndex].renderFinishedSemaphore = vsg::Semaphore::create(_device);
+
         // shift up previous frame indices
         for (size_t i = _indices.size() - 1; i > 0; --i)
         {


### PR DESCRIPTION
Fixes validation error `VUID-vkQueueSubmit-pSignalSemaphores-00067`

At the moment, this is a little bit too enthusiastic when multiple windows are affected by the same RecordAndSubmitTask. It would be sufficient to use any one of their `renderFinishedSemaphore`s, but one's used from every window. This shouldn't make a major difference to anything, as they'll all be signalled at the same time and waited on by the same presentation, but in principle, redundant semaphores might have some overhead.

If this change isn't satisfactory and some things warrant rearranging, then that might become moot anyway, so I've not done anything about it yet and will wait for feedback before doing so.