### PR TITLE
Do not set RELEASE_RESOURCES flag when resetting command pools by default

### DIFF
--- a/include/vsg/vk/CommandPool.h
+++ b/include/vsg/vk/CommandPool.h
@@ -32,7 +32,7 @@ namespace vsg
         const uint32_t queueFamilyIndex;
         const VkCommandPoolCreateFlags flags;
 
-        void reset(VkCommandPoolResetFlags reset_flags = VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT) const { vkResetCommandPool(*_device, _commandPool, reset_flags); }
+        void reset(VkCommandPoolResetFlags reset_flags = {}) const { vkResetCommandPool(*_device, _commandPool, reset_flags); }
 
         /// allocate CommandBuffer from CommandPool
         ref_ptr<CommandBuffer> allocate(VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY);


### PR DESCRIPTION
This gives an up to 10x performance improvement with AMD's proprietary Windows drivers, although it doesn't seem to make any difference with radv. I'd imagine that other drivers will see an impact somewhere between the two.

The flag signals to the driver that it should deallocate the memory backing all command buffers from the pool, potentially both in system RAM and VRAM, and potentially means that if command buffers are reused, they must be reallocated from scratch. This may mean additional CPU-GPU synchronisation, and so it's a heavyweight operation only intended to be used occasionally, e.g. after a large scene is unloaded, not after every frame when it's likely similarly-sized command buffers are about to be used again.

If anyone needs the old behaviour, e.g. to free up resources, they can still manually pass the flag explicitly. This way, the behaviour matches what the Vulkan spec suggests happens when resetting a command pool by default, and the expensive variant is opt-in.