### PR TITLE
vsg::Object cast<T>() sometimes returns nullptr on macOS Sonoma arm64 Release builds

### DIFF
--- a/include/vsg/io/Input.h
+++ b/include/vsg/io/Input.h
@@ -219,7 +219,8 @@ namespace vsg
         {
             if (!matchPropertyName(propertyName)) return;
 
-            arg = read().cast<T>();
+            ref_ptr<Object> object = read();
+            arg = ref_ptr<T>(dynamic_cast<T*>(object.get()));
         }
 
         /// read a value of particular type


### PR DESCRIPTION
## Description

- Addressed an issue where vsg::Object::cast<T>() would sometimes return nullptr on macOS Sonoma (Apple Silicon, arm64) in Release builds.
- Updated the casting logic to use dynamic_cast<T*>(), matching the approach already used  in the previous function " template<class T>
      ref_ptr<T> readObject(const char* propertyName)"

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

