### PR TITLE
app: WindowTraits: Support command line arguments to alter first devi…

### DIFF
--- a/src/vsg/app/WindowTraits.cpp
+++ b/src/vsg/app/WindowTraits.cpp
@@ -54,6 +54,17 @@ WindowTraits::WindowTraits(CommandLine& arguments)
     arguments.read("--screen", screenNum);
     arguments.read("--display", display);
     arguments.read("--samples", samples);
+
+    auto setDevicePref = [&](const VkPhysicalDeviceType typeIn)
+    {
+      auto it = std::find(deviceTypePreferences.begin(), deviceTypePreferences.end(), typeIn);
+      if (it != deviceTypePreferences.end()) deviceTypePreferences.erase(it);
+      deviceTypePreferences.insert(deviceTypePreferences.begin(), typeIn);
+    };
+    if (arguments.read("--prefer-integrated")) setDevicePref(VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU);
+    if (arguments.read("--prefer-discrete")) setDevicePref(VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU);
+    if (arguments.read("--prefer-virtual")) setDevicePref(VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU);
+    if (arguments.read("--prefer-cpu")) setDevicePref(VK_PHYSICAL_DEVICE_TYPE_CPU);
 }
 
 WindowTraits::WindowTraits(const WindowTraits& traits, const CopyOp& copyop) :


### PR DESCRIPTION
I wanted to experiment with mesh shaders, so I tried running the vsgmeshshader example. It failed as my laptop integrated card doesn't support that feature. I noticed my cpu device supported the feature, but I didn't see anyway to force it's use for the vsgmeshshader example. This commits adds that support.