### PR TITLE
Increase extensibility of DescriptorSetLayout

### DIFF
--- a/include/vsg/state/DescriptorSetLayout.h
+++ b/include/vsg/state/DescriptorSetLayout.h
@@ -21,6 +21,7 @@ namespace vsg
     class Context;
 
     using DescriptorSetLayoutBindings = std::vector<VkDescriptorSetLayoutBinding>;
+    using DescriptorSetLayoutBindingFlags = std::vector<VkDescriptorBindingFlags>;
     using DescriptorPoolSizes = std::vector<VkDescriptorPoolSize>;
 
     /// DescriptorSetLayout encapsulates VkDescriptorSetLayout and VkDescriptorSetLayoutCreateInfo settings used to set it up.
@@ -34,8 +35,16 @@ namespace vsg
         /// Vulkan VkDescriptorSetLayout handle
         virtual VkDescriptorSetLayout vk(uint32_t deviceID) const { return _implementation[deviceID]->_descriptorSetLayout; }
 
+        /// VkDescriptorSetLayoutCreateFlags flags
+        VkDescriptorSetLayoutCreateFlags createFlags;
+
+        void addBinding(uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, VkDescriptorBindingFlags flags = 0);
+
         /// VkDescriptorSetLayoutCreateInfo settings
         DescriptorSetLayoutBindings bindings;
+
+        /// VkDescriptorSetLayoutBindingFlagsCreateInfo settings
+        DescriptorSetLayoutBindingFlags bindingFlags;
 
         /// map the descriptor bindings to the descriptor pool sizes that will be required to represent them.
         void getDescriptorPoolSizes(DescriptorPoolSizes& descriptorPoolSizes);
@@ -59,7 +68,7 @@ namespace vsg
 
         struct Implementation : public Inherit<Object, Implementation>
         {
-            Implementation(Device* device, const DescriptorSetLayoutBindings& descriptorSetLayoutBindings);
+            Implementation(Device* device, VkDescriptorSetLayoutCreateFlags createFlags, const DescriptorSetLayoutBindings& descriptorSetLayoutBindings, const DescriptorSetLayoutBindingFlags& descriptorSetLayoutBindingFlags);
 
             virtual ~Implementation();
 


### PR DESCRIPTION
# Pull Request Template

## Description

Change to increase the extensibility of `DescriptorSetLayout` support in vsg.

Adds `VkDescriptorSetLayoutCreateFlags` to enable customization of layout creation.

Adds `DescriptorSetLayoutBindingFlags` to enable customization of binding layout creation.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
