### PR TITLE
Fix macOS window embedding

### DIFF
--- a/include/vsg/platform/macos/MacOS_Window.h
+++ b/include/vsg/platform/macos/MacOS_Window.h
@@ -57,7 +57,7 @@ namespace vsgMacOS
 
         const char* instanceExtensionSurfaceName() const override { return "VK_MVK_macos_surface"; }
 
-        bool valid() const override { return _window; }
+        bool valid() const override { return _window || _view; }
 
         bool pollEvents(vsg::UIEvents& events) override;
 

--- a/src/vsg/platform/macos/MacOS_Window.mm
+++ b/src/vsg/platform/macos/MacOS_Window.mm
@@ -708,10 +708,58 @@ bool KeyboardMap::getKeySymbol(NSEvent* anEvent, vsg::KeySymbol& keySymbol, vsg:
 }
 
 MacOS_Window::MacOS_Window(vsg::ref_ptr<vsg::WindowTraits> traits) :
-    Inherit(traits)
+    Inherit(traits),
+    _window(nil),
+    _view(nil),
+    _metalLayer(nil)
 {
     _keyboard = new KeyboardMap;
 
+    // When nativeWindow is set, embed into the provided NSView rather than
+    // creating a standalone NSWindow.  This mirrors Win32_Window's handling
+    // of an external HWND.
+    if (traits->nativeWindow.has_value())
+    {
+        auto nativeHandle = std::any_cast<unsigned long long>(traits->nativeWindow);
+        if (nativeHandle)
+        {
+            NSView* externalView = reinterpret_cast<NSView*>(nativeHandle);
+            _view = (vsg_MacOS_NSView*)externalView;
+            [_view setWantsLayer:YES];
+
+            _metalLayer = (CAMetalLayer*)[_view layer];
+            if (!_metalLayer || ![_metalLayer isKindOfClass:[CAMetalLayer class]])
+            {
+                _metalLayer = [[CAMetalLayer alloc] init];
+                if (!_metalLayer)
+                {
+                    throw Exception{"Error: vsg::MacOS_Window::MacOS_Window(...) failed to create CAMetalLayer for embedded view.", VK_ERROR_INVALID_EXTERNAL_HANDLE};
+                }
+                [_view setLayer:_metalLayer];
+            }
+
+            auto devicePixelScale = _traits->hdpi ? [[_view window] backingScaleFactor] : 1.0f;
+            [_metalLayer setContentsScale:devicePixelScale];
+
+            uint32_t finalwidth = traits->width * devicePixelScale;
+            uint32_t finalheight = traits->height * devicePixelScale;
+
+            if (traits->device) share(traits->device);
+
+            _extent2D.width = finalwidth;
+            _extent2D.height = finalheight;
+
+            _first_macos_timestamp = [[NSProcessInfo processInfo] systemUptime];
+            _first_macos_time_point = vsg::clock::now();
+
+            vsg::clock::time_point event_time = vsg::clock::now();
+            bufferedEvents.emplace_back(vsg::ConfigureWindowEvent::create(this, event_time, _traits->x, _traits->y, finalwidth, finalheight));
+
+            return;
+        }
+    }
+
+    // Standalone window path
     NSRect contentRect = NSMakeRect(0, 0, traits->width, traits->height);
 
     NSWindowStyleMask styleMask = 0;
@@ -822,16 +870,20 @@ void MacOS_Window::_initSurface()
 
 bool MacOS_Window::pollEvents(vsg::UIEvents& events)
 {
-    for (;;)
+    // Skip NSApp event polling when embedded — the host owns the event loop.
+    if (_window)
     {
-        NSEvent* event = [NSApp nextEventMatchingMask:NSEventMaskAny
-                                            untilDate:[NSDate distantPast]
-                                               inMode:NSDefaultRunLoopMode
-                                              dequeue:YES];
-        if (event == nil)
-            break;
+        for (;;)
+        {
+            NSEvent* event = [NSApp nextEventMatchingMask:NSEventMaskAny
+                                                untilDate:[NSDate distantPast]
+                                                   inMode:NSDefaultRunLoopMode
+                                                  dequeue:YES];
+            if (event == nil)
+                break;
 
-        [NSApp sendEvent:event];
+            [NSApp sendEvent:event];
+        }
     }
 
     return Window::pollEvents(events);
@@ -841,7 +893,8 @@ void MacOS_Window::resize()
 {
     const NSRect contentRect = [_view frame];
 
-    auto devicePixelScale = _traits->hdpi ? [_window backingScaleFactor] : 1.0f;
+    NSWindow* hostWindow = _window ? _window : [_view window];
+    auto devicePixelScale = _traits->hdpi ? [hostWindow backingScaleFactor] : 1.0f;
     //[_metalLayer setContentsScale:devicePixelScale];
 
     _extent2D.width = contentRect.size.width * devicePixelScale;


### PR DESCRIPTION
# Pull Request Template

## Description

`MacOS_Window` ignores `WindowTraits::nativeWindow` and always creates a standalone `NSWindow`, making it impossible to embed a VSG Vulkan surface into an existing view hierarchy (e.g. a Qt `QWindow` via `QWidget::createWindowContainer`).

This change adds an embedded window path to `MacOS_Window` that mirrors what `Win32_Window` already does on Windows: when `traits->nativeWindow` contains a valid handle, the provided `NSView `is used directly instead of creating a new NSWindow/NSView. A `CAMetalLayer` is attached to the external view if one doesn't already exist, and the Vulkan surface is created from it.

Additionally, `pollEvents()` skips `NSApp` event draining in the embedded case (the host framework owns the event loop), and `resize()` falls back to `[_view window]` for `backingScaleFactor` when no standalone `_window` exists.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

 - Embedded VSG Vulkan rendering inside a Qt 6.9 `QWidget::createWindowContainer` on macOS — surface creation, swapchain, rendering, and resize all function correctly
 - Verified standalone (non-embedded) window path is unchanged
 
**Test Configuration:**

- Hardware: Apple M1 (arm64)
- Toolchain: AppleClang 17.0.0 (Xcode)
- SDK: macOS 15 (Sequoia), MoltenVK 1.4.0, Vulkan 1.4.323
- Qt: 6.9.3

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
