### PR TITLE
Fixed incorrect keyboard events process in win32 subsystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,5 @@ DerivedData/
 include/glslang
 src/vsg/CHANGES.md
 src/vsg/vsgTargets.cmake
-
+*.txt.user
+*.txt.user.*

--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -53,7 +53,7 @@ namespace vsgWin32
             // Get virtual key code
             uint32_t virtualKey = static_cast<uint32_t>(wParam);
 
-            // Left and right modofier detection
+            // Left and right modifier detection
             if (virtualKey == VK_SHIFT)
             {
                 virtualKey = (scanCode == 0x2A) ? VK_RSHIFT : VK_LSHIFT;
@@ -101,22 +101,7 @@ namespace vsgWin32
             {
                 wchar_t ch = unicodeChar[0];
 
-                if (ch >= L'A' && ch <= L'Z')
-                {
-                    modifiedKeySymbol = static_cast<vsg::KeySymbol>(L'a' + (ch - L'A'));
-                }
-                else if (ch >= L'a' && ch <= L'z')
-                {
-                    modifiedKeySymbol = static_cast<vsg::KeySymbol>(ch);
-                }
-                else if (ch >= L'0' && ch <= L'9')
-                {
-                    modifiedKeySymbol = static_cast<vsg::KeySymbol>(ch);
-                }
-                else
-                {
-                    modifiedKeySymbol = mapUnicodeToKeySymbol(ch);
-                }
+                modifiedKeySymbol = mapCharToKeySymbol(ch);
             }
             else
             {
@@ -127,6 +112,70 @@ namespace vsgWin32
         }
 
     protected:
+
+        vsg::KeySymbol mapCharToKeySymbol(wchar_t ch)
+        {
+            // Letters
+            if (ch >= L'A' && ch <= L'Z')
+            {
+                return static_cast<vsg::KeySymbol>(ch);  // Capital
+            }
+            if (ch >= L'a' && ch <= L'z')
+            {
+                return static_cast<vsg::KeySymbol>(ch);
+            }
+
+            // Digits
+            if (ch >= L'0' && ch <= L'9')
+            {
+                return static_cast<vsg::KeySymbol>(ch);
+            }
+
+            // Special characters (with and without Shift)
+            switch (ch)
+            {
+            case L'!': return vsg::KEY_Exclaim;
+            case L'\"': return vsg::KEY_Quotedbl;
+            case L'#': return vsg::KEY_Hash;
+            case L'$': return vsg::KEY_Dollar;
+            case L'%': return vsg::KEY_Percent;
+            case L'&': return vsg::KEY_Ampersand;
+            case L'\'': return vsg::KEY_Quote;
+            case L'(': return vsg::KEY_Leftparen;
+            case L')': return vsg::KEY_Rightparen;
+            case L'*': return vsg::KEY_Asterisk;
+            case L'+': return vsg::KEY_Plus;
+            case L',': return vsg::KEY_Comma;
+            case L'-': return vsg::KEY_Minus;
+            case L'.': return vsg::KEY_Period;
+            case L'/': return vsg::KEY_Slash;
+            case L':': return vsg::KEY_Colon;
+            case L';': return vsg::KEY_Semicolon;
+            case L'<': return vsg::KEY_Less;
+            case L'=': return vsg::KEY_Equals;
+            case L'>': return vsg::KEY_Greater;
+            case L'?': return vsg::KEY_Question;
+            case L'@': return vsg::KEY_At;
+            case L'[': return vsg::KEY_Leftbracket;
+            case L'\\': return vsg::KEY_Backslash;
+            case L']': return vsg::KEY_Rightbracket;
+            case L'^': return vsg::KEY_Caret;
+            case L'_': return vsg::KEY_Underscore;
+            case L'`': return vsg::KEY_Backquote;
+            case L'{': return vsg::KEY_Leftcurlybracket;
+            case L'|': return vsg::KEY_Verticalslash;
+            case L'}': return vsg::KEY_Rightcurlybracket;
+            case L'~': return vsg::KEY_Tilde;
+
+            // Whitespace and control characters
+            case L' ': return vsg::KEY_Space;
+            case L'\t': return vsg::KEY_Tab;
+            case L'\r': return vsg::KEY_Return;
+            }
+
+            // Return for other non-ASCII
+            return mapUnicodeToKeySymbol(ch);
+        }
 
         // Helper function for Unicode cahracters
         vsg::KeySymbol mapUnicodeToKeySymbol(wchar_t ch)

--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -115,89 +115,14 @@ namespace vsgWin32
 
         vsg::KeySymbol mapCharToKeySymbol(wchar_t ch)
         {
-            // Letters
-            if (ch >= L'A' && ch <= L'Z')
-            {
-                return static_cast<vsg::KeySymbol>(ch);  // Capital
-            }
-            if (ch >= L'a' && ch <= L'z')
-            {
-                return static_cast<vsg::KeySymbol>(ch);
-            }
-
-            // Digits
-            if (ch >= L'0' && ch <= L'9')
-            {
-                return static_cast<vsg::KeySymbol>(ch);
-            }
-
             // Special characters (with and without Shift)
             switch (ch)
             {
-            case L'!': return vsg::KEY_Exclaim;
-            case L'\"': return vsg::KEY_Quotedbl;
-            case L'#': return vsg::KEY_Hash;
-            case L'$': return vsg::KEY_Dollar;
-            case L'%': return vsg::KEY_Percent;
-            case L'&': return vsg::KEY_Ampersand;
-            case L'\'': return vsg::KEY_Quote;
-            case L'(': return vsg::KEY_Leftparen;
-            case L')': return vsg::KEY_Rightparen;
-            case L'*': return vsg::KEY_Asterisk;
-            case L'+': return vsg::KEY_Plus;
-            case L',': return vsg::KEY_Comma;
-            case L'-': return vsg::KEY_Minus;
-            case L'.': return vsg::KEY_Period;
-            case L'/': return vsg::KEY_Slash;
-            case L':': return vsg::KEY_Colon;
-            case L';': return vsg::KEY_Semicolon;
-            case L'<': return vsg::KEY_Less;
-            case L'=': return vsg::KEY_Equals;
-            case L'>': return vsg::KEY_Greater;
-            case L'?': return vsg::KEY_Question;
-            case L'@': return vsg::KEY_At;
-            case L'[': return vsg::KEY_Leftbracket;
-            case L'\\': return vsg::KEY_Backslash;
-            case L']': return vsg::KEY_Rightbracket;
-            case L'^': return vsg::KEY_Caret;
-            case L'_': return vsg::KEY_Underscore;
-            case L'`': return vsg::KEY_Backquote;
-            case L'{': return vsg::KEY_Leftcurlybracket;
-            case L'|': return vsg::KEY_Verticalslash;
-            case L'}': return vsg::KEY_Rightcurlybracket;
-            case L'~': return vsg::KEY_Tilde;
-
-            // Whitespace and control characters
-            case L' ': return vsg::KEY_Space;
             case L'\t': return vsg::KEY_Tab;
             case L'\r': return vsg::KEY_Return;
             }
 
-            // Return for other non-ASCII
-            return mapUnicodeToKeySymbol(ch);
-        }
-
-        // Helper function for Unicode cahracters
-        vsg::KeySymbol mapUnicodeToKeySymbol(wchar_t ch)
-        {
-            switch (ch)
-            {
-            case L' ': return vsg::KEY_Space;
-            case L'\t': return vsg::KEY_Tab;
-            case L'\r': return vsg::KEY_Return;
-            case L',': return vsg::KEY_Comma;
-            case L'.': return vsg::KEY_Period;
-            case L'/': return vsg::KEY_Slash;
-            case L';': return vsg::KEY_Semicolon;
-            case L'=': return vsg::KEY_Equals;
-            case L'-': return vsg::KEY_Minus;
-            case L'[': return vsg::KEY_Leftbracket;
-            case L']': return vsg::KEY_Rightbracket;
-            case L'\\': return vsg::KEY_Backslash;
-            case L'`': return vsg::KEY_Tilde;
-            case L'\'': return vsg::KEY_Quote;
-            default: return static_cast<vsg::KeySymbol>(ch);
-            }
+            return static_cast<vsg::KeySymbol>(ch);
         }
 
         VirtualKeyToKeySymbolMap _vk2vsg;

--- a/include/vsg/platform/win32/Win32_Window.h
+++ b/include/vsg/platform/win32/Win32_Window.h
@@ -40,86 +40,86 @@ namespace vsgWin32
         {
             uint16_t modifierMask = 0;
 
-            // see https://learn.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#keystroke-message-flags
-            WORD keyFlags = HIWORD(lParam);
-            WORD scanCode = LOBYTE(keyFlags);                             // scan code
-            BOOL isExtendedKey = (keyFlags & KF_EXTENDED) == KF_EXTENDED; // extended-key flag, 1 if scancode has 0xE0 prefix
+            // Get scancode
+            uint16_t keyFlags = HIWORD(lParam);
+            uint16_t scanCode = LOBYTE(lParam);
+            bool isExtendedKey = (keyFlags & KF_EXTENDED) == KF_EXTENDED;
 
             if (isExtendedKey)
+            {
                 scanCode = MAKEWORD(scanCode, 0xE0);
+            }
 
-            uint32_t virtualKey = ::MapVirtualKeyEx(scanCode, MAPVK_VSC_TO_VK_EX, ::GetKeyboardLayout(0));
+            // Get virtual key code
+            uint32_t virtualKey = static_cast<uint32_t>(wParam);
+
+            // Left and right modofier detection
+            if (virtualKey == VK_SHIFT)
+            {
+                virtualKey = (scanCode == 0x2A) ? VK_RSHIFT : VK_LSHIFT;
+            }
+            else if (virtualKey == VK_CONTROL)
+            {
+                virtualKey = isExtendedKey ? VK_RCONTROL : VK_LCONTROL;
+            }
+            else if (virtualKey == VK_MENU)
+            {
+                virtualKey = isExtendedKey ? VK_RMENU : VK_LMENU;
+            }
+
             auto itr = _vk2vsg.find(virtualKey);
 
             if (itr == _vk2vsg.end())
             {
-                // What ever the code was in lParam should translate to a Virtual Key that we know of in _vk2vsg
-                // If we cannot find it, we simply return.
                 return false;
             }
 
-            // This is the base-key that was pressed. (i.e., the VSG enum of the physical key pressed).
             keySymbol = itr->second;
 
-            // Look for any modifiers that may be active.
+            // Get keys state
             BYTE keyState[256];
-            if (virtualKey == 0 || !::GetKeyboardState(keyState))
+
+            if (!::GetKeyboardState(keyState))
             {
-                // if virtualKey was undefined or we could not get the keyboard state, simply return.
                 return false;
             }
 
-            // If any of the specific left/right modifier keys are active
-            // add the side-independent vsg modifier to the modifier Mask
-            switch (virtualKey)
-            {
-            case VK_LSHIFT:
-            case VK_RSHIFT:
-                modifierMask |= vsg::KeyModifier::MODKEY_Shift;
-                break;
-
-            case VK_LCONTROL:
-            case VK_RCONTROL:
-                modifierMask |= vsg::KeyModifier::MODKEY_Control;
-                break;
-
-            case VK_LMENU:
-            case VK_RMENU:
-                modifierMask |= vsg::KeyModifier::MODKEY_Alt;
-                break;
-
-            default:
-                virtualKey = static_cast<uint32_t>(wParam);
-                break;
-            }
-
-            // Check if caps lock or numlock is toggled.
+            // Modifier's flags setting
+            if (keyState[VK_SHIFT] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Shift;
+            if (keyState[VK_CONTROL] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Control;
+            if (keyState[VK_MENU] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Alt;
             if (keyState[VK_CAPITAL] & 0x01) modifierMask |= vsg::KeyModifier::MODKEY_CapsLock;
             if (keyState[VK_NUMLOCK] & 0x01) modifierMask |= vsg::KeyModifier::MODKEY_NumLock;
 
-            // Check if the modifier keys are down (these are non-toggle keys, so the high-order bit is relevant!)
-            // again, vsg only has a side-independent modifier
-            if (keyState[VK_LSHIFT] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Shift;
-            if (keyState[VK_RSHIFT] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Shift;
-            if (keyState[VK_LCONTROL] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Control;
-            if (keyState[VK_RCONTROL] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Control;
-            if (keyState[VK_LMENU] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Alt;
-            if (keyState[VK_RMENU] & 0x80) modifierMask |= vsg::KeyModifier::MODKEY_Alt;
-
-            // This is the final keyModifier
             keyModifier = static_cast<vsg::KeyModifier>(modifierMask);
 
-            // The actual keystroke is what we get after the ::ToAscii call
-            char asciiKey[2];
-            int32_t numChars = ::ToAsciiEx(static_cast<UINT>(wParam), scanCode, keyState, reinterpret_cast<WORD*>(asciiKey), 0, ::GetKeyboardLayout(0));
+            // Get Unicode symbol
+            wchar_t unicodeChar[2] = {0};
+            int numChars = ::ToUnicodeEx(virtualKey, scanCode, keyState, unicodeChar, 2, 0, ::GetKeyboardLayout(0));
+
             if (numChars == 1)
             {
-                // it is indeed an ascii character. 0-127
-                modifiedKeySymbol = static_cast<vsg::KeySymbol>(asciiKey[0]);
+                wchar_t ch = unicodeChar[0];
+
+                if (ch >= L'A' && ch <= L'Z')
+                {
+                    modifiedKeySymbol = static_cast<vsg::KeySymbol>(L'a' + (ch - L'A'));
+                }
+                else if (ch >= L'a' && ch <= L'z')
+                {
+                    modifiedKeySymbol = static_cast<vsg::KeySymbol>(ch);
+                }
+                else if (ch >= L'0' && ch <= L'9')
+                {
+                    modifiedKeySymbol = static_cast<vsg::KeySymbol>(ch);
+                }
+                else
+                {
+                    modifiedKeySymbol = mapUnicodeToKeySymbol(ch);
+                }
             }
             else
             {
-                // otherwise treat the modifiedKeySymbol as the same as the keySymbol.
                 modifiedKeySymbol = keySymbol;
             }
 
@@ -127,6 +127,30 @@ namespace vsgWin32
         }
 
     protected:
+
+        // Helper function for Unicode cahracters
+        vsg::KeySymbol mapUnicodeToKeySymbol(wchar_t ch)
+        {
+            switch (ch)
+            {
+            case L' ': return vsg::KEY_Space;
+            case L'\t': return vsg::KEY_Tab;
+            case L'\r': return vsg::KEY_Return;
+            case L',': return vsg::KEY_Comma;
+            case L'.': return vsg::KEY_Period;
+            case L'/': return vsg::KEY_Slash;
+            case L';': return vsg::KEY_Semicolon;
+            case L'=': return vsg::KEY_Equals;
+            case L'-': return vsg::KEY_Minus;
+            case L'[': return vsg::KEY_Leftbracket;
+            case L']': return vsg::KEY_Rightbracket;
+            case L'\\': return vsg::KEY_Backslash;
+            case L'`': return vsg::KEY_Tilde;
+            case L'\'': return vsg::KEY_Quote;
+            default: return static_cast<vsg::KeySymbol>(ch);
+            }
+        }
+
         VirtualKeyToKeySymbolMap _vk2vsg;
     };
 


### PR DESCRIPTION
# Fixed incorrect keyboard events process in win32 subsystem

## Description

While work in our project based on a VSG, we noticed that sometimes has incorrect processing of some keys (such as `Pause`, numpad keys with enabled `NumLock`, etc). I look at code of this subsystem and saw problem.

Original code translate scancode from keyboard throw WinAPI function

```
uint32_t virtualKey = ::MapVirtualKeyEx(scanCode, MAPVK_VSC_TO_VK_EX, ::GetKeyboardLayout(0));
```

but it is unnecesarry, because OS already give virtual keycode from wParam. Besides, ::MapVirtualKeyEx() can return incorrect virtual key code for some keys. 

So, other problem is in this fucnction's call

```
int32_t numChars = ::ToAsciiEx(static_cast<UINT>(wParam), scanCode, keyState, reinterpret_cast<WORD*>(asciiKey), 0, ::GetKeyboardLayout(0));
```

because this function wroks incoreectly when we switch to natioal keyboard layout. I used convertion VK-code and scan code to Unicode character, and it's work good. ::ToUnicodeEx() translate key's codes to Unicode, and in ASCII symbol case it give same result with any keyboard layout.

We test this changes in vsginput from vsgExamples and in our project. All works good, and now we have correct work of NumPad keyboard and other keys which had incorrect detection. 

I didn't change anything except getKeySymbol() function. I propose these changes as a pull request.



