### PR TITLE
Add flags in swapchain preferences

### DIFF
--- a/include/vsg/vk/Swapchain.h
+++ b/include/vsg/vk/Swapchain.h
@@ -38,7 +38,7 @@ namespace vsg
         VkSurfaceFormatKHR surfaceFormat = {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR};
         VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
         VkImageUsageFlags imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-        VkSwapchainCreateFlagsKHR flags = 0; // e.g. VK_SWAPCHAIN_CREATE_PRESENT_ID_2_BIT_KHR / VK_SWAPCHAIN_CREATE_PRESENT_WAIT_2_BIT_KHR
+        VkSwapchainCreateFlagsKHR flags = 0;
     };
 
     /// Swapchain encapsulates vkSwapchainKHR

--- a/include/vsg/vk/Swapchain.h
+++ b/include/vsg/vk/Swapchain.h
@@ -38,6 +38,7 @@ namespace vsg
         VkSurfaceFormatKHR surfaceFormat = {VK_FORMAT_B8G8R8A8_SRGB, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR};
         VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
         VkImageUsageFlags imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        VkSwapchainCreateFlagsKHR flags = 0; // e.g. VK_SWAPCHAIN_CREATE_PRESENT_ID_2_BIT_KHR / VK_SWAPCHAIN_CREATE_PRESENT_WAIT_2_BIT_KHR
     };
 
     /// Swapchain encapsulates vkSwapchainKHR

--- a/src/vsg/vk/Swapchain.cpp
+++ b/src/vsg/vk/Swapchain.cpp
@@ -183,6 +183,7 @@ Swapchain::Swapchain(PhysicalDevice* physicalDevice, Device* device, Surface* su
     VkSwapchainCreateInfoKHR createInfo = {};
     createInfo.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
     createInfo.surface = *surface;
+    createInfo.flags = preferences.flags;
 
     createInfo.minImageCount = imageCount;
     createInfo.imageFormat = surfaceFormat.format;


### PR DESCRIPTION
Add a `flags` field to `SwapchainPreferences` and forward it to the `VkSwapchainCreateInfoKHR`. A minimal, backward-compatible addition (defaults to 0, current behaviour unchanged)

Motivation: https://github.com/vsg-dev/VulkanSceneGraph/discussions/1716

With this patch, I could successfully use `VkSurfaceCapabilitiesPresentId2KHR` / `VkSurfaceCapabilitiesPresentWait2KHR`