### PR TITLE
resolve undefined symbol OH_NativeWindow_NativeWindowHandleOpt on OpenHarmony

### DIFF
--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -321,6 +321,7 @@ if (VSG_SUPPORTS_Windowing)
     elseif (OHOS_ARCH)  # OpenHarmony
         set(HEADERS ${HEADERS} ${VSG_SOURCE_DIR}/include/vsg/platform/harmony/Harmony_Window.h)
         set(SOURCES ${SOURCES} platform/harmony/Harmony_Window.cpp)
+        set(LIBRARIES ${LIBRARIES} PRIVATE ace_ndk.z native_window)
     elseif (WIN32)
         set(SOURCES ${SOURCES} platform/win32/Win32_Window.cpp)
     elseif (IOS)


### PR DESCRIPTION
## Description
I am attempting to cross-compile VulkanSceneGraph (vsg v1.1.15) under Windows 11 using the HarmonyOS SDK provided by DevEco Studio 6.1.1. The objective is to run my downstream project vsgPotree(https://github.com/geocapp/vsgPotree.git) on HarmonyOS to support point cloud visualization.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
* **Source Setup:** Open vsg v1.1.15 source code using the integrated CMake-GUI inside DevEco Studio.
* **CMake Configuration:** Select **Ninja** as the generator and point to the HarmonyOS SDK toolchain file for cross-compilation.
* **Build Flags:** Enable the `BUILD_SHARED_LIBS` option.
* **Generation:** Click "Generate" (the `build.ninja` compiles successfully).
* **Compilation:** Open a terminal in the build directory and execute: `cmake --build .`

**Test Configuration**:
* **Host OS:**  Windows 11
* **IDE & SDK:**  DevEco Studio 6.1.1 (incorporating HarmonyOS SDK)
* **Library Version:**  VulkanSceneGraph (vsg) v1.1.15
* **Build System & Toolchain** : Integrated CMake-GUI in DevEco Studio
* **Generator** : Ninja
* **Key Configurations** : BUILD_SHARED_LIBS enabled (checked)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
