### PR TITLE
Feature: Cache compiled SPIR-V to avoid recompiling identical shaders

### DIFF
--- a/src/vsg/utils/ShaderCompiler.cpp
+++ b/src/vsg/utils/ShaderCompiler.cpp
@@ -31,6 +31,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <algorithm>
 #include <iomanip>
+#include <map>
+#include <mutex>
+#include <sstream>
 
 #ifndef VK_API_VERSION_MAJOR
 #    define VK_API_VERSION_MAJOR(version) (((uint32_t)(version) >> 22) & 0x7FU)
@@ -129,6 +132,10 @@ bool ShaderCompiler::supported() const
 }
 
 #if VSG_SUPPORTS_ShaderCompiler
+// SPIR-V compile cache: avoids repeated glslang invocations for identical shaders.
+static std::mutex s_spirvCacheMutex;
+static std::map<std::string, vsg::ShaderModule::SPIRV> s_spirvCache;
+
 bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::string>& defines, ref_ptr<const Options> options)
 {
     // need to balance the inits.
@@ -137,6 +144,61 @@ bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::strin
         s_initializeProcess();
         _initialized = true;
     }
+
+    // Build cache keys from shader stage, settings, and final source (with includes/defines).
+    auto computeCacheKey = [&](const ref_ptr<ShaderStage>& vsg_shader) -> std::string {
+        auto settings = vsg_shader->module->hints ? vsg_shader->module->hints : defaults;
+        std::string source = vsg::insertIncludes(vsg_shader->module->source, options);
+        std::vector<std::string> allDefines(defines);
+        if (settings)
+        {
+            for (const auto& define : settings->defines) allDefines.push_back(define);
+        }
+        if (!allDefines.empty()) source = combineSourceAndDefines(source, allDefines);
+
+        std::ostringstream k;
+        k << static_cast<uint32_t>(vsg_shader->stage) << ';';
+        if (settings)
+        {
+            k << static_cast<int>(settings->language)
+              << ';' << settings->vulkanVersion
+              << ';' << settings->clientInputVersion
+              << ';' << static_cast<int>(settings->target)
+              << ';' << settings->defaultVersion
+              << ';' << settings->forwardCompatible
+              << ';' << settings->generateDebugInfo
+              << ';' << settings->optimize << ';';
+        }
+        k << source;
+        return k.str();
+    };
+
+    std::vector<std::string> cacheKeys;
+    cacheKeys.reserve(shaders.size());
+    for (auto& vsg_shader : shaders)
+    {
+        if (vsg_shader && vsg_shader->module)
+            cacheKeys.push_back(computeCacheKey(vsg_shader));
+        else
+            cacheKeys.emplace_back();
+    }
+
+	// Check if all shaders are already cached.
+    {
+        std::scoped_lock<std::mutex> lock(s_spirvCacheMutex);
+        bool allCached = !shaders.empty();
+        for (size_t i = 0; i < shaders.size() && allCached; ++i)
+        {
+            if (!shaders[i] || !shaders[i]->module || s_spirvCache.find(cacheKeys[i]) == s_spirvCache.end())
+                allCached = false;
+        }
+        if (allCached)
+        {
+            for (size_t i = 0; i < shaders.size(); ++i) shaders[i]->module->code = s_spirvCache[cacheKeys[i]];
+            return true;
+        }
+    }
+    // ---- end SPIR-V compile cache pre-check (results stored after a successful compile below) ---
 
     auto getFriendlyNameForShader = [](const ref_ptr<ShaderStage>& vsg_shader) {
         switch (vsg_shader->stage)
@@ -278,15 +340,15 @@ bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::strin
         shader->setEnvClient(glslang::EShClientVulkan, targetClientVersion);
         shader->setEnvTarget(glslang::EShTargetSpv, targetLanguageVersion);
 
-        std::string finalShaderSource = vsg::insertIncludes(vsg_shader->module->source, options);
+        std::string source = vsg::insertIncludes(vsg_shader->module->source, options);
 
-        std::vector<std::string> combinedDefines(defines);
-        for (const auto& define : settings->defines) combinedDefines.push_back(define);
-        if (!combinedDefines.empty()) finalShaderSource = combineSourceAndDefines(finalShaderSource, combinedDefines);
+        std::vector<std::string> allDefines(defines);
+        for (const auto& define : settings->defines) allDefines.push_back(define);
+        if (!allDefines.empty()) source = combineSourceAndDefines(source, allDefines);
 
-        vsg::debug("ShaderCompiler::compile() combinedDefines = ", combinedDefines);
+        vsg::debug("ShaderCompiler::compile() allDefines = ", allDefines);
 
-        const char* str = finalShaderSource.c_str();
+        const char* str = source.c_str();
         shader->setStrings(&str, 1);
 
         EShMessages messages = EShMsgDefault;
@@ -298,7 +360,7 @@ bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::strin
 
         if (parseResult)
         {
-            debug("Successful compile\n", debugFormatShaderSource(finalShaderSource), "\n");
+            debug("Successful compile\n", debugFormatShaderSource(source), "\n");
 
             program->addShader(shader);
             stageShaderMap[envStage] = vsg_shader;
@@ -307,7 +369,7 @@ bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::strin
         {
             // print error information
             warn("\n----  ", getFriendlyNameForShader(vsg_shader), "  ---- \n");
-            warn(debugFormatShaderSource(finalShaderSource));
+            warn(debugFormatShaderSource(source));
             warn("GLSL source failed to parse.");
             warn("glslang info log:\n", shader->getInfoLog());
             info("glslang debug info log: \n", shader->getInfoDebugLog());
@@ -377,6 +439,16 @@ bool ShaderCompiler::compile(ShaderStages& shaders, const std::vector<std::strin
                 }
             }
 #    endif
+        }
+    }
+
+    // Cache new compiled SPIR-V.
+    {
+        std::scoped_lock<std::mutex> lock(s_spirvCacheMutex);
+        for (size_t i = 0; i < shaders.size(); ++i)
+        {
+            if (shaders[i] && shaders[i]->module && !shaders[i]->module->code.empty())
+                s_spirvCache[cacheKeys[i]] = shaders[i]->module->code;
         }
     }
 


### PR DESCRIPTION
Cache compiled shaders by source and settings so repeated glslang invocations for identical shaders are skipped.

## Description

This adds a cache of compiled SPIR-V inside ShaderCompiler::compile so that an
identical shader is sent through glslang at most once per run.

We ran into this in a proprietary application that changes scene graph nodes very
often. Every time the user changes the layout we rebuild part of the scene and
call Viewer::compile again. We first noticed it after updating VSG from 1.1.10 to
1.1.15: on 1.1.15 each change spent almost all of its time recompiling shaders,
around 220 ms per change, while on 1.1.10 the same application did not.

The cause is that ShaderCompiler::compile runs glslang whenever a ShaderModule has
no code yet. When the scene is rebuilt with fresh modules that have the same source
and settings as before, the same shaders are compiled from scratch every time.

The cache is keyed by the shader stage, the compile settings, and the final source
after includes and defines are applied. On a hit it assigns the cached SPIR-V to
module->code and skips glslang. On a miss it stores the result after a successful
compile. Access is guarded by a mutex, so each unique shader is compiled once and
reused after that.

The cache is a static map with no eviction. The set of unique shaders is small in
practice, so it settles at a few entries, but I am happy to make it optional or add
a size limit if you prefer.

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We profiled a RelWithDebInfo build with the Windows Performance Toolkit and added
timing around the phases of our redraw.

- [x] Before the change, almost all of the per change time was glslang (yyparse, TGlslangToSpvTraverser, ShaderCompiler::compile) inside Viewer::compile.
- [x] Measured the per change compile time in the application before and after: about 220 ms down to about 22 ms.
- [x] Compared against 1.1.10, which does not show the problem, to confirm where it started.
- [x] Checked that the rendered scene is unchanged after the patch.

To reproduce: build an application that rebuilds its scene and calls Viewer::compile
repeatedly (so ShaderModules are recreated with the same source and settings), and
time Viewer::compile with and without the patch.

**Test Configuration**:
* OS: Windows 11
* Hardware: NVIDIA GPU (laptop also has an Intel integrated GPU)
* Toolchain: MSVC (Visual Studio), C++17
* VSG: tested on 1.1.15; the patch also applies cleanly to current master

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules