### PR TITLE
Initial implementation of ReplacementVisitor

### DIFF
--- a/include/vsg/all.h
+++ b/include/vsg/all.h
@@ -30,6 +30,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/MipmapLayout.h>
 #include <vsg/core/Object.h>
 #include <vsg/core/Objects.h>
+#include <vsg/core/ReplacementVisitor.h>
 #include <vsg/core/ScratchMemory.h>
 #include <vsg/core/Value.h>
 #include <vsg/core/Version.h>

--- a/include/vsg/animation/Animation.h
+++ b/include/vsg/animation/Animation.h
@@ -94,6 +94,10 @@ namespace vsg
         }
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& sampler : samplers) visitor.tryReplacePointer(sampler);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/animation/AnimationGroup.h
+++ b/include/vsg/animation/AnimationGroup.h
@@ -45,6 +45,11 @@ namespace vsg
         {
             for (auto& child : children) child->accept(visitor);
         }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& animation : animations) visitor.tryReplacePointer(animation);
+            for (auto& child : children) visitor.tryReplacePointer(child);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/animation/Joint.h
+++ b/include/vsg/animation/Joint.h
@@ -49,6 +49,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& child : children) visitor.tryReplacePointer(child);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/commands/Commands.h
+++ b/include/vsg/commands/Commands.h
@@ -39,6 +39,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& child : children) visitor.tryReplacePointer(child);
+        }
 
         int compare(const Object& rhs) const override;
 

--- a/include/vsg/core/Array.h
+++ b/include/vsg/core/Array.h
@@ -150,6 +150,7 @@ namespace vsg
         // implementation provided by Visitor.h
         void accept(Visitor& visitor) override;
         void accept(ConstVisitor& visitor) const override;
+        std::optional<ref_ptr<Object>> accept(ReplacementVisitor& visitor) override;
 
         void read(Input& input) override
         {

--- a/include/vsg/core/Array2D.h
+++ b/include/vsg/core/Array2D.h
@@ -128,6 +128,7 @@ namespace vsg
         // implementation provided by Visitor.h
         void accept(Visitor& visitor) override;
         void accept(ConstVisitor& visitor) const override;
+        std::optional<ref_ptr<Object>> accept(ReplacementVisitor& visitor) override;
 
         void read(Input& input) override
         {

--- a/include/vsg/core/Array3D.h
+++ b/include/vsg/core/Array3D.h
@@ -134,6 +134,7 @@ namespace vsg
         // implementation provided by Visitor.h
         void accept(Visitor& visitor) override;
         void accept(ConstVisitor& visitor) const override;
+        std::optional<ref_ptr<Object>> accept(ReplacementVisitor& visitor) override;
 
         void read(Input& input) override
         {

--- a/include/vsg/core/External.h
+++ b/include/vsg/core/External.h
@@ -46,6 +46,13 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal&) const override {}
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& [path, object] : entries)
+            {
+                if (object) visitor.tryReplacePointer(object);
+            }
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/core/Inherit.h
+++ b/include/vsg/core/Inherit.h
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <vsg/app/RecordTraversal.h>
 #include <vsg/core/ConstVisitor.h>
+#include <vsg/core/ReplacementVisitor.h>
 #include <vsg/core/Visitor.h>
 #include <vsg/core/ref_ptr.h>
 #include <vsg/core/type_name.h>
@@ -69,6 +70,7 @@ namespace vsg
 
         void accept(Visitor& visitor) override { visitor.apply(static_cast<Subclass&>(*this)); }
         void accept(ConstVisitor& visitor) const override { visitor.apply(static_cast<const Subclass&>(*this)); }
+        std::optional<ref_ptr<Object>> accept(ReplacementVisitor& visitor) override { return visitor.apply(static_cast<Subclass&>(*this)); }
         void accept(RecordTraversal& visitor) const override { visitor.apply(static_cast<const Subclass&>(*this)); }
     };
 

--- a/include/vsg/core/Object.h
+++ b/include/vsg/core/Object.h
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <atomic>
 #include <map>
+#include <optional>
 #include <string>
 #include <typeindex>
 #include <vector>
@@ -29,6 +30,7 @@ namespace vsg
     class Auxiliary;
     class Visitor;
     class ConstVisitor;
+    class ReplacementVisitor;
     class RecordTraversal;
     class Input;
     class Output;
@@ -111,6 +113,9 @@ namespace vsg
 
         virtual void accept(ConstVisitor& visitor) const;
         virtual void traverse(ConstVisitor&) const {}
+
+        virtual std::optional<ref_ptr<Object>> accept(ReplacementVisitor& visitor);
+        virtual void traverse(ReplacementVisitor&) {};
 
         virtual void accept(RecordTraversal& visitor) const;
         virtual void traverse(RecordTraversal&) const {}

--- a/include/vsg/core/Objects.h
+++ b/include/vsg/core/Objects.h
@@ -35,6 +35,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& child : children) visitor.tryReplacePointer(child);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/core/ReplacementVisitor.h
+++ b/include/vsg/core/ReplacementVisitor.h
@@ -1,0 +1,529 @@
+#pragma once
+
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018-2026 Robert Osfield, Chris Djali
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/core/Array.h>
+#include <vsg/core/Array2D.h>
+#include <vsg/core/Array3D.h>
+#include <vsg/core/Mask.h>
+#include <vsg/core/Value.h>
+
+#include <optional>
+
+namespace vsg
+{
+    // forward declare core Objects
+    class Objects;
+    class External;
+    class MipmapLayout;
+
+    // forward declare node classes
+    class Node;
+    class Commands;
+    class Group;
+    class QuadGroup;
+    class LOD;
+    class PagedLOD;
+    class StateGroup;
+    class CullGroup;
+    class CullNode;
+    class Transform;
+    class MatrixTransform;
+    class CoordinateFrame;
+    class Geometry;
+    class VertexDraw;
+    class VertexIndexDraw;
+    class DepthSorted;
+    class Layer;
+    class Bin;
+    class Switch;
+    class Light;
+    class AmbientLight;
+    class DirectionalLight;
+    class PointLight;
+    class SpotLight;
+    class InstrumentationNode;
+    class RegionOfInterest;
+    class InstanceNode;
+    class InstanceDraw;
+    class InstanceDrawIndexed;
+
+    // forward declare text classes
+    class Text;
+    class TextGroup;
+    class TextTechnique;
+    class TextLayout;
+
+    // forward declare animation classes
+    class Animation;
+    class AnimationGroup;
+    class AnimationSampler;
+    class TransformSampler;
+    class CameraSampler;
+    class MorphSampler;
+    class JointSampler;
+    class Joint;
+
+    // forward declare vulkan classes
+    class BufferInfo;
+    class ImageInfo;
+    class ImageView;
+    class Image;
+    class Compilable;
+    class Command;
+    class StateCommand;
+    class StateSwitch;
+    class CommandBuffer;
+    class RenderPass;
+    class BindDescriptorSet;
+    class BindDescriptorSets;
+    class BindViewDescriptorSets;
+    class Descriptor;
+    class DescriptorBuffer;
+    class DescriptorImage;
+    class DescriptorSet;
+    class BindVertexBuffers;
+    class BindIndexBuffer;
+    class BindComputePipeline;
+    class BindGraphicsPipeline;
+    class BindRayTracingPipeline;
+    class GraphicsPipeline;
+    class ComputePipeline;
+    class RayTracingPipeline;
+    class Draw;
+    class DrawIndexed;
+    class ShaderStage;
+    class GraphicsPipelineState;
+    class VertexInputState;
+    class InputAssemblyState;
+    class TessellationState;
+    class ViewportState;
+    class RasterizationState;
+    class MultisampleState;
+    class DepthStencilState;
+    class ColorBlendState;
+    class DynamicState;
+    class ResourceHints;
+    class ClearAttachments;
+    class ClearColorImage;
+    class ClearDepthStencilImage;
+    class QueryPool;
+    class ResetQueryPool;
+    class BeginQuery;
+    class EndQuery;
+    class WriteTimestamp;
+    class CopyQueryPoolResults;
+
+    // forward declare rtx classes
+    class DrawMeshTasks;
+    class DrawMeshTasksIndirect;
+    class DrawMeshTasksIndirectCount;
+
+    // forward declare ui events classes
+    class UIEvent;
+    class WindowEvent;
+    class ExposeWindowEvent;
+    class ConfigureWindowEvent;
+    class CloseWindowEvent;
+    class FocusInEvent;
+    class FocusOutEvent;
+    class KeyEvent;
+    class KeyPressEvent;
+    class KeyReleaseEvent;
+    class PointerEvent;
+    class ButtonPressEvent;
+    class ButtonReleaseEvent;
+    class MoveEvent;
+    class TouchEvent;
+    class TouchDownEvent;
+    class TouchUpEvent;
+    class TouchMoveEvent;
+    class ScrollWheelEvent;
+    class TerminateEvent;
+    class FrameEvent;
+
+    // forward declare util classes
+    class ShaderCompileSettings;
+
+    // forward declare viewer classes
+    class Camera;
+    class CommandGraph;
+    class SecondaryCommandGraph;
+    class RenderGraph;
+    class View;
+    class Viewer;
+    class ViewMatrix;
+    class LookAt;
+    class LookDirection;
+    class RelativeViewMatrix;
+    class TrackingViewMatrix;
+    class ProjectionMatrix;
+    class Perspective;
+    class Orthographic;
+    class RelativeProjection;
+    class EllipsoidPerspective;
+
+    // forward declare general classes
+    class FrameStamp;
+    class Instrumentation;
+
+    class VSG_DECLSPEC ReplacementVisitor : public Object
+    {
+    public:
+        ReplacementVisitor();
+
+        ReplacementVisitor(const ReplacementVisitor& rhs, const CopyOp& copyop = {}) :
+            Object(rhs, copyop),
+            traversalMask(rhs.traversalMask),
+            overrideMask(rhs.overrideMask) {}
+
+        Mask traversalMask = MASK_ALL;
+        Mask overrideMask = MASK_OFF;
+
+        virtual Instrumentation* getInstrumentation() { return nullptr; }
+
+        template<class T>
+        std::optional<ref_ptr<T>> acceptChecked(T& object)
+        {
+            std::optional<ref_ptr<Object>> replacement = object.accept(*this);
+            if (!replacement.has_value())
+                return std::nullopt;
+            if (replacement.value() == nullptr)
+                return nullptr;
+            if (replacement.value()->is_compatible(typeid(T)))
+                return ref_ptr(static_cast<T*>(replacement.value().get()));
+            return std::nullopt;
+        }
+
+        template<class T>
+        bool tryReplacePointer(ref_ptr<T>& ptr)
+        {
+            std::optional<ref_ptr<T>> newPtr = acceptChecked(*ptr);
+            if (newPtr.has_value())
+            {
+                ptr = newPtr.value();
+                return true;
+            }
+            return false;
+        }
+
+        virtual std::optional<ref_ptr<Object>> apply(Object&);
+        virtual std::optional<ref_ptr<Object>> apply(Objects&);
+        virtual std::optional<ref_ptr<Object>> apply(External&);
+        virtual std::optional<ref_ptr<Object>> apply(Data&);
+        virtual std::optional<ref_ptr<Object>> apply(MipmapLayout&);
+
+        // Values
+        virtual std::optional<ref_ptr<Object>> apply(stringValue&);
+        virtual std::optional<ref_ptr<Object>> apply(wstringValue&);
+        virtual std::optional<ref_ptr<Object>> apply(boolValue&);
+        virtual std::optional<ref_ptr<Object>> apply(intValue&);
+        virtual std::optional<ref_ptr<Object>> apply(uintValue&);
+        virtual std::optional<ref_ptr<Object>> apply(floatValue&);
+        virtual std::optional<ref_ptr<Object>> apply(doubleValue&);
+        virtual std::optional<ref_ptr<Object>> apply(vec2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(vec3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(vec4Value&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec4Value&);
+        virtual std::optional<ref_ptr<Object>> apply(bvec2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(bvec3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(bvec4Value&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec4Value&);
+        virtual std::optional<ref_ptr<Object>> apply(svec2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(svec3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(svec4Value&);
+        virtual std::optional<ref_ptr<Object>> apply(usvec2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(usvec3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(usvec4Value&);
+        virtual std::optional<ref_ptr<Object>> apply(ivec2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(ivec3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(ivec4Value&);
+        virtual std::optional<ref_ptr<Object>> apply(uivec2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(uivec3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(uivec4Value&);
+        virtual std::optional<ref_ptr<Object>> apply(mat2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(dmat2Value&);
+        virtual std::optional<ref_ptr<Object>> apply(mat3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(dmat3Value&);
+        virtual std::optional<ref_ptr<Object>> apply(mat4Value&);
+        virtual std::optional<ref_ptr<Object>> apply(dmat4Value&);
+
+        // Arrays
+        virtual std::optional<ref_ptr<Object>> apply(stringArray&);
+        virtual std::optional<ref_ptr<Object>> apply(byteArray&);
+        virtual std::optional<ref_ptr<Object>> apply(ubyteArray&);
+        virtual std::optional<ref_ptr<Object>> apply(shortArray&);
+        virtual std::optional<ref_ptr<Object>> apply(ushortArray&);
+        virtual std::optional<ref_ptr<Object>> apply(intArray&);
+        virtual std::optional<ref_ptr<Object>> apply(uintArray&);
+        virtual std::optional<ref_ptr<Object>> apply(floatArray&);
+        virtual std::optional<ref_ptr<Object>> apply(doubleArray&);
+        virtual std::optional<ref_ptr<Object>> apply(vec2Array&);
+        virtual std::optional<ref_ptr<Object>> apply(vec3Array&);
+        virtual std::optional<ref_ptr<Object>> apply(vec4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec2Array&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec3Array&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(bvec2Array&);
+        virtual std::optional<ref_ptr<Object>> apply(bvec3Array&);
+        virtual std::optional<ref_ptr<Object>> apply(bvec4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(svec2Array&);
+        virtual std::optional<ref_ptr<Object>> apply(svec3Array&);
+        virtual std::optional<ref_ptr<Object>> apply(svec4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(ivec2Array&);
+        virtual std::optional<ref_ptr<Object>> apply(ivec3Array&);
+        virtual std::optional<ref_ptr<Object>> apply(ivec4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec2Array&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec3Array&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(usvec2Array&);
+        virtual std::optional<ref_ptr<Object>> apply(usvec3Array&);
+        virtual std::optional<ref_ptr<Object>> apply(usvec4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(uivec2Array&);
+        virtual std::optional<ref_ptr<Object>> apply(uivec3Array&);
+        virtual std::optional<ref_ptr<Object>> apply(uivec4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(mat4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(dmat4Array&);
+        virtual std::optional<ref_ptr<Object>> apply(block64Array&);
+        virtual std::optional<ref_ptr<Object>> apply(block128Array&);
+
+        // Array2Ds
+        virtual std::optional<ref_ptr<Object>> apply(byteArray2D&);
+        virtual std::optional<ref_ptr<Object>> apply(ubyteArray2D&);
+        virtual std::optional<ref_ptr<Object>> apply(shortArray2D&);
+        virtual std::optional<ref_ptr<Object>> apply(ushortArray2D&);
+        virtual std::optional<ref_ptr<Object>> apply(intArray2D&);
+        virtual std::optional<ref_ptr<Object>> apply(uintArray2D&);
+        virtual std::optional<ref_ptr<Object>> apply(floatArray2D&);
+        virtual std::optional<ref_ptr<Object>> apply(doubleArray2D&);
+        virtual std::optional<ref_ptr<Object>> apply(vec2Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(vec3Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(vec4Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec2Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec3Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec4Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(bvec2Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(bvec3Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(bvec4Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(svec2Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(svec3Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(svec4Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(ivec2Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(ivec3Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(ivec4Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec2Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec3Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec4Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(usvec2Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(usvec3Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(usvec4Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(uivec2Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(uivec3Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(uivec4Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(block64Array2D&);
+        virtual std::optional<ref_ptr<Object>> apply(block128Array2D&);
+
+        // Array3Ds
+        virtual std::optional<ref_ptr<Object>> apply(byteArray3D&);
+        virtual std::optional<ref_ptr<Object>> apply(ubyteArray3D&);
+        virtual std::optional<ref_ptr<Object>> apply(shortArray3D&);
+        virtual std::optional<ref_ptr<Object>> apply(ushortArray3D&);
+        virtual std::optional<ref_ptr<Object>> apply(intArray3D&);
+        virtual std::optional<ref_ptr<Object>> apply(uintArray3D&);
+        virtual std::optional<ref_ptr<Object>> apply(floatArray3D&);
+        virtual std::optional<ref_ptr<Object>> apply(doubleArray3D&);
+        virtual std::optional<ref_ptr<Object>> apply(vec2Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(vec3Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(vec4Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec2Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec3Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(dvec4Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec2Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec3Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(ubvec4Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(block64Array3D&);
+        virtual std::optional<ref_ptr<Object>> apply(block128Array3D&);
+
+        // Nodes
+        virtual std::optional<ref_ptr<Object>> apply(Node&);
+        virtual std::optional<ref_ptr<Object>> apply(Compilable&);
+        virtual std::optional<ref_ptr<Object>> apply(Commands&);
+        virtual std::optional<ref_ptr<Object>> apply(Group&);
+        virtual std::optional<ref_ptr<Object>> apply(QuadGroup&);
+        virtual std::optional<ref_ptr<Object>> apply(LOD&);
+        virtual std::optional<ref_ptr<Object>> apply(PagedLOD&);
+        virtual std::optional<ref_ptr<Object>> apply(StateGroup&);
+        virtual std::optional<ref_ptr<Object>> apply(CullGroup&);
+        virtual std::optional<ref_ptr<Object>> apply(CullNode&);
+        virtual std::optional<ref_ptr<Object>> apply(Transform&);
+        virtual std::optional<ref_ptr<Object>> apply(MatrixTransform&);
+        virtual std::optional<ref_ptr<Object>> apply(CoordinateFrame&);
+        virtual std::optional<ref_ptr<Object>> apply(Geometry&);
+        virtual std::optional<ref_ptr<Object>> apply(VertexDraw&);
+        virtual std::optional<ref_ptr<Object>> apply(VertexIndexDraw&);
+        virtual std::optional<ref_ptr<Object>> apply(DepthSorted&);
+        virtual std::optional<ref_ptr<Object>> apply(Layer&);
+        virtual std::optional<ref_ptr<Object>> apply(Bin&);
+        virtual std::optional<ref_ptr<Object>> apply(Switch&);
+        virtual std::optional<ref_ptr<Object>> apply(Light&);
+        virtual std::optional<ref_ptr<Object>> apply(AmbientLight&);
+        virtual std::optional<ref_ptr<Object>> apply(DirectionalLight&);
+        virtual std::optional<ref_ptr<Object>> apply(PointLight&);
+        virtual std::optional<ref_ptr<Object>> apply(SpotLight&);
+        virtual std::optional<ref_ptr<Object>> apply(InstrumentationNode&);
+        virtual std::optional<ref_ptr<Object>> apply(RegionOfInterest&);
+        virtual std::optional<ref_ptr<Object>> apply(InstanceNode&);
+        virtual std::optional<ref_ptr<Object>> apply(InstanceDraw&);
+        virtual std::optional<ref_ptr<Object>> apply(InstanceDrawIndexed&);
+
+        // text
+        virtual std::optional<ref_ptr<Object>> apply(Text&);
+        virtual std::optional<ref_ptr<Object>> apply(TextGroup&);
+        virtual std::optional<ref_ptr<Object>> apply(TextTechnique&);
+        virtual std::optional<ref_ptr<Object>> apply(TextLayout&);
+
+        // animation
+        virtual std::optional<ref_ptr<Object>> apply(Animation&);
+        virtual std::optional<ref_ptr<Object>> apply(AnimationGroup&);
+        virtual std::optional<ref_ptr<Object>> apply(AnimationSampler&);
+        virtual std::optional<ref_ptr<Object>> apply(JointSampler&);
+        virtual std::optional<ref_ptr<Object>> apply(MorphSampler&);
+        virtual std::optional<ref_ptr<Object>> apply(TransformSampler&);
+        virtual std::optional<ref_ptr<Object>> apply(CameraSampler&);
+        virtual std::optional<ref_ptr<Object>> apply(Joint&);
+
+        // Vulkan nodes
+        virtual std::optional<ref_ptr<Object>> apply(BufferInfo&);
+        virtual std::optional<ref_ptr<Object>> apply(ImageInfo&);
+        virtual std::optional<ref_ptr<Object>> apply(ImageView&);
+        virtual std::optional<ref_ptr<Object>> apply(Image&);
+        virtual std::optional<ref_ptr<Object>> apply(Command&);
+        virtual std::optional<ref_ptr<Object>> apply(StateCommand&);
+        virtual std::optional<ref_ptr<Object>> apply(StateSwitch&);
+        virtual std::optional<ref_ptr<Object>> apply(CommandBuffer&);
+        virtual std::optional<ref_ptr<Object>> apply(RenderPass&);
+        virtual std::optional<ref_ptr<Object>> apply(BindDescriptorSet&);
+        virtual std::optional<ref_ptr<Object>> apply(BindDescriptorSets&);
+        virtual std::optional<ref_ptr<Object>> apply(BindViewDescriptorSets&);
+        virtual std::optional<ref_ptr<Object>> apply(Descriptor&);
+        virtual std::optional<ref_ptr<Object>> apply(DescriptorBuffer&);
+        virtual std::optional<ref_ptr<Object>> apply(DescriptorImage&);
+        virtual std::optional<ref_ptr<Object>> apply(DescriptorSet&);
+        virtual std::optional<ref_ptr<Object>> apply(BindVertexBuffers&);
+        virtual std::optional<ref_ptr<Object>> apply(BindIndexBuffer&);
+        virtual std::optional<ref_ptr<Object>> apply(BindComputePipeline&);
+        virtual std::optional<ref_ptr<Object>> apply(BindGraphicsPipeline&);
+        virtual std::optional<ref_ptr<Object>> apply(BindRayTracingPipeline&);
+        virtual std::optional<ref_ptr<Object>> apply(GraphicsPipeline&);
+        virtual std::optional<ref_ptr<Object>> apply(ComputePipeline&);
+        virtual std::optional<ref_ptr<Object>> apply(RayTracingPipeline&);
+        virtual std::optional<ref_ptr<Object>> apply(GraphicsPipelineState&);
+        virtual std::optional<ref_ptr<Object>> apply(ShaderStage&);
+        virtual std::optional<ref_ptr<Object>> apply(VertexInputState&);
+        virtual std::optional<ref_ptr<Object>> apply(InputAssemblyState&);
+        virtual std::optional<ref_ptr<Object>> apply(TessellationState&);
+        virtual std::optional<ref_ptr<Object>> apply(ViewportState&);
+        virtual std::optional<ref_ptr<Object>> apply(RasterizationState&);
+        virtual std::optional<ref_ptr<Object>> apply(MultisampleState&);
+        virtual std::optional<ref_ptr<Object>> apply(DepthStencilState&);
+        virtual std::optional<ref_ptr<Object>> apply(ColorBlendState&);
+        virtual std::optional<ref_ptr<Object>> apply(DynamicState&);
+        virtual std::optional<ref_ptr<Object>> apply(ResourceHints&);
+        virtual std::optional<ref_ptr<Object>> apply(Draw&);
+        virtual std::optional<ref_ptr<Object>> apply(DrawIndexed&);
+        virtual std::optional<ref_ptr<Object>> apply(ClearAttachments&);
+        virtual std::optional<ref_ptr<Object>> apply(ClearColorImage&);
+        virtual std::optional<ref_ptr<Object>> apply(ClearDepthStencilImage&);
+        virtual std::optional<ref_ptr<Object>> apply(QueryPool&);
+        virtual std::optional<ref_ptr<Object>> apply(ResetQueryPool&);
+        virtual std::optional<ref_ptr<Object>> apply(BeginQuery&);
+        virtual std::optional<ref_ptr<Object>> apply(EndQuery&);
+        virtual std::optional<ref_ptr<Object>> apply(WriteTimestamp&);
+        virtual std::optional<ref_ptr<Object>> apply(CopyQueryPoolResults&);
+
+        // mesh shading classes
+        virtual std::optional<ref_ptr<Object>> apply(DrawMeshTasks&);
+        virtual std::optional<ref_ptr<Object>> apply(DrawMeshTasksIndirect&);
+        virtual std::optional<ref_ptr<Object>> apply(DrawMeshTasksIndirectCount&);
+
+        // ui events
+        virtual std::optional<ref_ptr<Object>> apply(UIEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(WindowEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(ExposeWindowEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(ConfigureWindowEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(CloseWindowEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(FocusInEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(FocusOutEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(KeyEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(KeyPressEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(KeyReleaseEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(PointerEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(ButtonPressEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(ButtonReleaseEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(MoveEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(TouchEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(TouchDownEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(TouchUpEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(TouchMoveEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(ScrollWheelEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(TerminateEvent&);
+        virtual std::optional<ref_ptr<Object>> apply(FrameEvent&);
+
+        // utils
+        virtual std::optional<ref_ptr<Object>> apply(ShaderCompileSettings&);
+
+        // app
+        virtual std::optional<ref_ptr<Object>> apply(Camera&);
+        virtual std::optional<ref_ptr<Object>> apply(CommandGraph&);
+        virtual std::optional<ref_ptr<Object>> apply(SecondaryCommandGraph&);
+        virtual std::optional<ref_ptr<Object>> apply(RenderGraph&);
+        virtual std::optional<ref_ptr<Object>> apply(View&);
+        virtual std::optional<ref_ptr<Object>> apply(Viewer&);
+        virtual std::optional<ref_ptr<Object>> apply(ViewMatrix&);
+        virtual std::optional<ref_ptr<Object>> apply(LookAt&);
+        virtual std::optional<ref_ptr<Object>> apply(LookDirection&);
+        virtual std::optional<ref_ptr<Object>> apply(RelativeViewMatrix&);
+        virtual std::optional<ref_ptr<Object>> apply(TrackingViewMatrix&);
+        virtual std::optional<ref_ptr<Object>> apply(ProjectionMatrix&);
+        virtual std::optional<ref_ptr<Object>> apply(Perspective&);
+        virtual std::optional<ref_ptr<Object>> apply(Orthographic&);
+        virtual std::optional<ref_ptr<Object>> apply(RelativeProjection&);
+        virtual std::optional<ref_ptr<Object>> apply(EllipsoidPerspective&);
+
+        // general classes
+        virtual std::optional<ref_ptr<Object>> apply(FrameStamp&);
+
+        bool is_compatible(const std::type_info& type) const noexcept override { return typeid(ReplacementVisitor) == type || Object::is_compatible(type); }
+    };
+
+    // provide Value<>::accept() implementation
+    template<typename T>
+    std::optional<ref_ptr<Object>> Value<T>::accept(ReplacementVisitor& visitor) { return visitor.apply(*this); }
+
+    // provide Array<>::accept() implementation
+    template<typename T>
+    std::optional<ref_ptr<Object>> Array<T>::accept(ReplacementVisitor& visitor) { return visitor.apply(*this); }
+
+    // provide Array2D<>::accept() implementation
+    template<typename T>
+    std::optional<ref_ptr<Object>> Array2D<T>::accept(ReplacementVisitor& visitor) { return visitor.apply(*this); }
+
+    // provide Array3D<>::accept() implementation
+    template<typename T>
+    std::optional<ref_ptr<Object>> Array3D<T>::accept(ReplacementVisitor& visitor) { return visitor.apply(*this); }
+
+} // namespace vsg

--- a/include/vsg/core/Value.h
+++ b/include/vsg/core/Value.h
@@ -80,6 +80,7 @@ namespace vsg
         // implementation provided by Visitor.h
         void accept(Visitor& visitor) override;
         void accept(ConstVisitor& visitor) const override;
+        std::optional<ref_ptr<Object>> accept(ReplacementVisitor& visitor) override;
 
         void read(Input& input) override
         {

--- a/include/vsg/nodes/CullNode.h
+++ b/include/vsg/nodes/CullNode.h
@@ -38,6 +38,7 @@ namespace vsg
         void traverse(Visitor& visitor) override { child->accept(visitor); }
         void traverse(ConstVisitor& visitor) const override { child->accept(visitor); }
         void traverse(RecordTraversal& visitor) const override { child->accept(visitor); }
+        void traverse(ReplacementVisitor& visitor) override { visitor.tryReplacePointer(child); }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/DepthSorted.h
+++ b/include/vsg/nodes/DepthSorted.h
@@ -41,6 +41,7 @@ namespace vsg
         void traverse(Visitor& visitor) override { child->accept(visitor); }
         void traverse(ConstVisitor& visitor) const override { child->accept(visitor); }
         void traverse(RecordTraversal& visitor) const override { child->accept(visitor); }
+        void traverse(ReplacementVisitor& visitor) override { visitor.tryReplacePointer(child); }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/Group.h
+++ b/include/vsg/nodes/Group.h
@@ -54,6 +54,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& child : children) visitor.tryReplacePointer(child);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/InstanceNode.h
+++ b/include/vsg/nodes/InstanceNode.h
@@ -69,6 +69,7 @@ namespace vsg
         void traverse(Visitor& visitor) override { child->accept(visitor); }
         void traverse(ConstVisitor& visitor) const override { child->accept(visitor); }
         void traverse(RecordTraversal& visitor) const override { child->accept(visitor); }
+        void traverse(ReplacementVisitor& visitor) override { visitor.tryReplacePointer(child); }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/InstrumentationNode.h
+++ b/include/vsg/nodes/InstrumentationNode.h
@@ -45,6 +45,7 @@ namespace vsg
         void traverse(Visitor& visitor) override;
         void traverse(ConstVisitor& visitor) const override;
         void traverse(RecordTraversal& visitor) const override;
+        void traverse(ReplacementVisitor& visitor) override;
 
         void read(Input& input) override;
         void write(Output& output) const override;
@@ -60,6 +61,7 @@ namespace vsg
         SourceLocation _sl_Visitor;
         SourceLocation _sl_ConstVisitor;
         SourceLocation _sl_RecordTraversal;
+        SourceLocation _sl_ReplacementVisitor;
     };
     VSG_type_name(vsg::InstrumentationNode);
 

--- a/include/vsg/nodes/LOD.h
+++ b/include/vsg/nodes/LOD.h
@@ -61,6 +61,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& [ratio, node] : children) { visitor.tryReplacePointer(node); }
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/Layer.h
+++ b/include/vsg/nodes/Layer.h
@@ -47,6 +47,10 @@ namespace vsg
         {
             if ((visitor.traversalMask & (visitor.overrideMask | mask)) != MASK_OFF) child->accept(visitor);
         }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            if ((visitor.traversalMask & (visitor.overrideMask | mask)) != MASK_OFF) { visitor.tryReplacePointer(child); }
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/PagedLOD.h
+++ b/include/vsg/nodes/PagedLOD.h
@@ -73,6 +73,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& [ratio, node] : children) { visitor.tryReplacePointer(node); }
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/QuadGroup.h
+++ b/include/vsg/nodes/QuadGroup.h
@@ -47,6 +47,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& child : children) visitor.tryReplacePointer(child);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/StateGroup.h
+++ b/include/vsg/nodes/StateGroup.h
@@ -76,6 +76,11 @@ namespace vsg
         {
             for (auto& child : children) child->accept(visitor);
         }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& sc : stateCommands) visitor.tryReplacePointer(sc);
+            for (auto& child : children) visitor.tryReplacePointer(child);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/Switch.h
+++ b/include/vsg/nodes/Switch.h
@@ -64,6 +64,13 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& [mask, node] : children)
+            {
+                if ((visitor.traversalMask & (visitor.overrideMask | mask)) != MASK_OFF) { visitor.tryReplacePointer(node); }
+            }
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/nodes/TileDatabase.h
+++ b/include/vsg/nodes/TileDatabase.h
@@ -98,6 +98,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            if (child) visitor.tryReplacePointer(child);
+        }
 
         // read/write of TileReader settings
         void read(Input& input) override;

--- a/include/vsg/state/BindDescriptorSet.h
+++ b/include/vsg/state/BindDescriptorSet.h
@@ -64,6 +64,19 @@ namespace vsg
 
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            bool dirty = false;
+            dirty |= visitor.tryReplacePointer(layout);
+            for (auto& ds : descriptorSets)
+            {
+                dirty |= visitor.tryReplacePointer(ds);
+            }
+            if (dirty)
+            {
+                _vulkanData.clear();
+            }
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;
@@ -141,6 +154,15 @@ namespace vsg
 
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            bool dirty = visitor.tryReplacePointer(layout);
+            dirty |= visitor.tryReplacePointer(descriptorSet);
+            if (dirty)
+            {
+                _vulkanData.clear();
+            }
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/state/DescriptorSet.h
+++ b/include/vsg/state/DescriptorSet.h
@@ -56,6 +56,11 @@ namespace vsg
 
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            if (setLayout) visitor.tryReplacePointer(setLayout);
+            for (auto& descriptor : descriptors) visitor.tryReplacePointer(descriptor);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/state/StateSwitch.h
+++ b/include/vsg/state/StateSwitch.h
@@ -49,6 +49,13 @@ namespace vsg
 
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            for (auto& [mask, stateCommand] : children)
+            {
+                if ((visitor.traversalMask & (visitor.overrideMask | mask)) != MASK_OFF) visitor.tryReplacePointer(stateCommand);
+            }
+        }
 
         ref_ptr<Object> clone(const CopyOp& copyop = {}) const override { return StateSwitch::create(*this, copyop); }
         int compare(const Object& rhs_object) const override;

--- a/include/vsg/state/ViewDependentState.h
+++ b/include/vsg/state/ViewDependentState.h
@@ -78,6 +78,10 @@ namespace vsg
 
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            if (layout) visitor.tryReplacePointer(layout);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;
@@ -117,6 +121,11 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& rt) const override;
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            visitor.tryReplacePointer(descriptorSet);
+            if (preRenderCommandGraph) visitor.tryReplacePointer(preRenderCommandGraph);
+        }
 
         // containers filled in by RecordTraversal
         std::vector<std::pair<dmat4, const AmbientLight*>> ambientLights;

--- a/include/vsg/text/CpuLayoutTechnique.h
+++ b/include/vsg/text/CpuLayoutTechnique.h
@@ -35,6 +35,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            if (scenegraph) visitor.tryReplacePointer(scenegraph);
+        }
 
         void setup(Text* text, uint32_t minimumAllocation = 0, ref_ptr<const Options> options = {}) override;
         void setup(TextGroup* textGroup, uint32_t minimumAllocation = 0, ref_ptr<const Options> options = {}) override;

--- a/include/vsg/text/GpuLayoutTechnique.h
+++ b/include/vsg/text/GpuLayoutTechnique.h
@@ -47,6 +47,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            if (scenegraph) visitor.tryReplacePointer(scenegraph);
+        }
 
         void setup(Text* text, uint32_t minimumAllocation = 0, ref_ptr<const Options> options = {}) override;
         void setup(TextGroup* textGroup, uint32_t minimumAllocation = 0, ref_ptr<const Options> options = {}) override;

--- a/include/vsg/text/Text.h
+++ b/include/vsg/text/Text.h
@@ -38,6 +38,10 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            if (technique) visitor.tryReplacePointer(technique);
+        }
 
         void read(Input& input) override;
         void write(Output& output) const override;

--- a/include/vsg/text/TextGroup.h
+++ b/include/vsg/text/TextGroup.h
@@ -39,6 +39,11 @@ namespace vsg
         {
             if (technique) technique->accept(visitor);
         }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            if (technique) visitor.tryReplacePointer(technique);
+            for (auto& child : children) visitor.tryReplacePointer(child);
+        }
 
         int compare(const Object& rhs) const override;
 

--- a/include/vsg/utils/GraphicsPipelineConfigurator.h
+++ b/include/vsg/utils/GraphicsPipelineConfigurator.h
@@ -101,6 +101,7 @@ namespace vsg
 
         void traverse(Visitor& visitor) override;
         void traverse(ConstVisitor& visitor) const override;
+        void traverse(ReplacementVisitor& visitor) override;
 
         // inputs to setup of GraphicsPipeline, the default sets are taken from any provided by ShaderSet::defaultGraphicsPipelineStates
         GraphicsPipelineStates pipelineStates;

--- a/include/vsg/utils/SharedObjects.h
+++ b/include/vsg/utils/SharedObjects.h
@@ -94,6 +94,7 @@ namespace vsg
 
         void traverse(Visitor& visitor) override;
         void traverse(ConstVisitor& visitor) const override;
+        void traverse(ReplacementVisitor& visitor) override;
 
         int compare(const Object& rhs_object) const override;
     };

--- a/src/vsg/CMakeLists.txt
+++ b/src/vsg/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     core/MemorySlots.cpp
     core/Object.cpp
     core/Objects.cpp
+    core/ReplacementVisitor.cpp
     core/Visitor.cpp
     core/Version.cpp
 

--- a/src/vsg/core/Object.cpp
+++ b/src/vsg/core/Object.cpp
@@ -14,6 +14,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <vsg/core/Auxiliary.h>
 #include <vsg/core/ConstVisitor.h>
 #include <vsg/core/Object.h>
+#include <vsg/core/ReplacementVisitor.h>
 #include <vsg/core/Visitor.h>
 
 #include <vsg/io/Input.h>
@@ -129,6 +130,11 @@ void Object::accept(Visitor& visitor)
 void Object::accept(ConstVisitor& visitor) const
 {
     visitor.apply(*this);
+}
+
+std::optional<ref_ptr<Object>> Object::accept(ReplacementVisitor& visitor)
+{
+    return visitor.apply(*this);
 }
 
 void Object::accept(RecordTraversal& visitor) const

--- a/src/vsg/core/ReplacementVisitor.cpp
+++ b/src/vsg/core/ReplacementVisitor.cpp
@@ -1,0 +1,1141 @@
+/* <editor-fold desc="MIT License">
+
+Copyright(c) 2018-2026 Robert Osfield, Chris Djali
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+</editor-fold> */
+
+#include <vsg/all.h>
+
+using namespace vsg;
+
+ReplacementVisitor::ReplacementVisitor()
+{
+}
+
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Object&)
+{
+    return std::nullopt;
+}
+
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Objects& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(External& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Data& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(MipmapLayout& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Values
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(stringValue& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(wstringValue& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(boolValue& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(intValue& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uintValue& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(floatValue& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(doubleValue& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(bvec2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(bvec3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(bvec4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(svec2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(svec3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(svec4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(usvec2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(usvec3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(usvec4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ivec2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ivec3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ivec4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uivec2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uivec3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uivec4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(mat2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dmat2Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(mat3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dmat3Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(mat4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dmat4Value& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Arrays
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(stringArray& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(byteArray& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubyteArray& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(shortArray& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ushortArray& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(intArray& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uintArray& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(floatArray& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(doubleArray& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec2Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec3Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec2Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec3Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(bvec2Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(bvec3Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(bvec4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(svec2Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(svec3Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(svec4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ivec2Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ivec3Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ivec4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec2Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec3Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(usvec2Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(usvec3Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(usvec4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uivec2Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uivec3Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uivec4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(mat4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dmat4Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(block64Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(block128Array& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Array2Ds
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(byteArray2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubyteArray2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(shortArray2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ushortArray2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(intArray2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uintArray2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(floatArray2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(doubleArray2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec2Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec3Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec4Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec2Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec3Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec4Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(bvec2Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(bvec3Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(bvec4Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(svec2Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(svec3Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(svec4Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ivec2Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ivec3Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ivec4Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec2Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec3Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec4Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(usvec2Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(usvec3Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(usvec4Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uivec2Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uivec3Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uivec4Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(block64Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(block128Array2D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Array3Ds
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(byteArray3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubyteArray3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(shortArray3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ushortArray3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(intArray3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(uintArray3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(floatArray3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(doubleArray3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec2Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec3Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(vec4Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec2Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec3Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(dvec4Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec2Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec3Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ubvec4Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(block64Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(block128Array3D& value)
+{
+    return apply(static_cast<Data&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Nodes
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Node& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Compilable& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Commands& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Group& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(QuadGroup& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(LOD& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(PagedLOD& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(StateGroup& value)
+{
+    return apply(static_cast<Group&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(CullGroup& value)
+{
+    return apply(static_cast<Group&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(CullNode& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Transform& value)
+{
+    return apply(static_cast<Group&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(MatrixTransform& value)
+{
+    return apply(static_cast<Transform&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(CoordinateFrame& value)
+{
+    return apply(static_cast<Transform&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Geometry& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(VertexDraw& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(VertexIndexDraw& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DepthSorted& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Layer& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Bin& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Switch& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Light& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(AmbientLight& value)
+{
+    return apply(static_cast<Light&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DirectionalLight& value)
+{
+    return apply(static_cast<Light&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(PointLight& value)
+{
+    return apply(static_cast<Light&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(SpotLight& value)
+{
+    return apply(static_cast<Light&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(InstrumentationNode& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(RegionOfInterest& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(InstanceNode& value)
+{
+    return apply(static_cast<Compilable&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(InstanceDraw& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(InstanceDrawIndexed& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Text Objects
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Text& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TextGroup& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TextTechnique& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TextLayout& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Animation Objects/Nodes
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Animation& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(AnimationGroup& value)
+{
+    return apply(static_cast<Group&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(AnimationSampler& sampler)
+{
+    return apply(static_cast<Object&>(sampler));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(JointSampler& sampler)
+{
+    return apply(static_cast<AnimationSampler&>(sampler));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(MorphSampler& sampler)
+{
+    return apply(static_cast<AnimationSampler&>(sampler));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TransformSampler& sampler)
+{
+    return apply(static_cast<AnimationSampler&>(sampler));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(CameraSampler& sampler)
+{
+    return apply(static_cast<AnimationSampler&>(sampler));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Joint& value)
+{
+    return apply(static_cast<Node&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Vulkan Objects
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BufferInfo& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ImageInfo& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ImageView& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Image& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Command& value)
+{
+    return apply(static_cast<Compilable&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(StateCommand& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(StateSwitch& value)
+{
+    return apply(static_cast<StateCommand&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(CommandBuffer& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(RenderPass& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BindDescriptorSet& value)
+{
+    return apply(static_cast<StateCommand&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BindDescriptorSets& value)
+{
+    return apply(static_cast<StateCommand&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BindViewDescriptorSets& value)
+{
+    return apply(static_cast<StateCommand&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Descriptor& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DescriptorBuffer& value)
+{
+    return apply(static_cast<Descriptor&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DescriptorImage& value)
+{
+    return apply(static_cast<Descriptor&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DescriptorSet& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BindVertexBuffers& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BindIndexBuffer& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BindComputePipeline& value)
+{
+    return apply(static_cast<StateCommand&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BindGraphicsPipeline& value)
+{
+    return apply(static_cast<StateCommand&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BindRayTracingPipeline& value)
+{
+    return apply(static_cast<StateCommand&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(GraphicsPipeline& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ComputePipeline& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(RayTracingPipeline& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(GraphicsPipelineState& value)
+{
+    return apply(static_cast<StateCommand&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ShaderStage& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(VertexInputState& value)
+{
+    return apply(static_cast<GraphicsPipelineState&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(InputAssemblyState& value)
+{
+    return apply(static_cast<GraphicsPipelineState&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TessellationState& value)
+{
+    return apply(static_cast<GraphicsPipelineState&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ViewportState& value)
+{
+    return apply(static_cast<GraphicsPipelineState&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(RasterizationState& value)
+{
+    return apply(static_cast<GraphicsPipelineState&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(MultisampleState& value)
+{
+    return apply(static_cast<GraphicsPipelineState&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DepthStencilState& value)
+{
+    return apply(static_cast<GraphicsPipelineState&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ColorBlendState& value)
+{
+    return apply(static_cast<GraphicsPipelineState&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DynamicState& value)
+{
+    return apply(static_cast<GraphicsPipelineState&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ResourceHints& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Draw& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DrawIndexed& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ClearAttachments& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ClearColorImage& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ClearDepthStencilImage& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(QueryPool& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ResetQueryPool& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(BeginQuery& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(EndQuery& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(WriteTimestamp& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(CopyQueryPoolResults& value)
+{
+    return apply(static_cast<Command&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Mesh shading
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DrawMeshTasks& dmt)
+{
+    return apply(static_cast<Command&>(dmt));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DrawMeshTasksIndirect& dmti)
+{
+    return apply(static_cast<Command&>(dmti));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(DrawMeshTasksIndirectCount& dmtic)
+{
+    return apply(static_cast<Command&>(dmtic));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// UI Events
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(UIEvent& event)
+{
+    return apply(static_cast<Object&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(WindowEvent& event)
+{
+    return apply(static_cast<UIEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ExposeWindowEvent& event)
+{
+    return apply(static_cast<WindowEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ConfigureWindowEvent& event)
+{
+    return apply(static_cast<WindowEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(CloseWindowEvent& event)
+{
+    return apply(static_cast<WindowEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(FocusInEvent& event)
+{
+    return apply(static_cast<WindowEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(FocusOutEvent& event)
+{
+    return apply(static_cast<WindowEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(KeyEvent& event)
+{
+    return apply(static_cast<WindowEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(KeyPressEvent& event)
+{
+    return apply(static_cast<KeyEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(KeyReleaseEvent& event)
+{
+    return apply(static_cast<KeyEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(PointerEvent& event)
+{
+    return apply(static_cast<WindowEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ButtonPressEvent& event)
+{
+    return apply(static_cast<PointerEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ButtonReleaseEvent& event)
+{
+    return apply(static_cast<PointerEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(MoveEvent& event)
+{
+    return apply(static_cast<PointerEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TouchEvent& event)
+{
+    return apply(static_cast<WindowEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TouchDownEvent& event)
+{
+    return apply(static_cast<TouchEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TouchUpEvent& event)
+{
+    return apply(static_cast<TouchEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TouchMoveEvent& event)
+{
+    return apply(static_cast<TouchEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ScrollWheelEvent& event)
+{
+    return apply(static_cast<WindowEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TerminateEvent& event)
+{
+    return apply(static_cast<UIEvent&>(event));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(FrameEvent& event)
+{
+    return apply(static_cast<UIEvent&>(event));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// util classes
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ShaderCompileSettings& shaderCompileSettings)
+{
+    return apply(static_cast<Object&>(shaderCompileSettings));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Viewer classes
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Camera& camera)
+{
+    return apply(static_cast<Object&>(camera));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(CommandGraph& cg)
+{
+    return apply(static_cast<Group&>(cg));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(SecondaryCommandGraph& cg)
+{
+    return apply(static_cast<CommandGraph&>(cg));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(RenderGraph& rg)
+{
+    return apply(static_cast<Group&>(rg));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(View& view)
+{
+    return apply(static_cast<Group&>(view));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Viewer& viewer)
+{
+    return apply(static_cast<Object&>(viewer));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ViewMatrix& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(LookAt& value)
+{
+    return apply(static_cast<ViewMatrix&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(LookDirection& value)
+{
+    return apply(static_cast<ViewMatrix&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(RelativeViewMatrix& value)
+{
+    return apply(static_cast<ViewMatrix&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(TrackingViewMatrix& value)
+{
+    return apply(static_cast<ViewMatrix&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(ProjectionMatrix& value)
+{
+    return apply(static_cast<Object&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Perspective& value)
+{
+    return apply(static_cast<ProjectionMatrix&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(Orthographic& value)
+{
+    return apply(static_cast<ProjectionMatrix&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(RelativeProjection& value)
+{
+    return apply(static_cast<ProjectionMatrix&>(value));
+}
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(EllipsoidPerspective& value)
+{
+    return apply(static_cast<ProjectionMatrix&>(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// General classes
+//
+std::optional<ref_ptr<Object>> ReplacementVisitor::apply(FrameStamp& fs)
+{
+    return apply(static_cast<Object&>(fs));
+}

--- a/src/vsg/nodes/InstrumentationNode.cpp
+++ b/src/vsg/nodes/InstrumentationNode.cpp
@@ -20,9 +20,10 @@ InstrumentationNode::InstrumentationNode() :
     _level(1),
     _color(255, 255, 255, 255),
     _name("InstrumentationNode"),
-    _sl_Visitor{_name.c_str(), "InstrumentationNode::traverse(Visitor& rt)", __FILE__, 42, _color, _level},
-    _sl_ConstVisitor{_name.c_str(), "InstrumentationNode::traverse(Visitor& rt)", __FILE__, 48, _color, _level},
-    _sl_RecordTraversal{_name.c_str(), "InstrumentationNode::traverse(Visitor& rt)", __FILE__, 54, _color, _level}
+    _sl_Visitor{_name.c_str(), "InstrumentationNode::traverse(Visitor& rt)", __FILE__, 67, _color, _level},
+    _sl_ConstVisitor{_name.c_str(), "InstrumentationNode::traverse(Visitor& rt)", __FILE__, 73, _color, _level},
+    _sl_RecordTraversal{_name.c_str(), "InstrumentationNode::traverse(Visitor& rt)", __FILE__, 79, _color, _level},
+    _sl_ReplacementVisitor{_name.c_str(), "InstrumentationNode::traverse(Visitor& rt)", __FILE__, 86, _color, _level}
 {
 }
 
@@ -33,7 +34,8 @@ InstrumentationNode::InstrumentationNode(const InstrumentationNode& rhs, const C
     _name(rhs._name),
     _sl_Visitor{rhs._sl_Visitor},
     _sl_ConstVisitor{rhs._sl_ConstVisitor},
-    _sl_RecordTraversal{rhs._sl_RecordTraversal}
+    _sl_RecordTraversal{rhs._sl_RecordTraversal},
+    _sl_ReplacementVisitor{rhs._sl_ReplacementVisitor}
 {
     _sl_Visitor.name = _name.c_str();
     _sl_ConstVisitor.name = _name.c_str();
@@ -77,6 +79,13 @@ void InstrumentationNode::traverse(RecordTraversal& rt) const
 {
     GpuInstrumentation cpuInst(rt.instrumentation, &_sl_RecordTraversal, *rt.getCommandBuffer(), child.get());
     child->accept(rt);
+}
+
+
+void InstrumentationNode::traverse(ReplacementVisitor& visitor)
+{
+    CpuInstrumentation cpuInst(visitor.getInstrumentation(), &_sl_ReplacementVisitor, child.get());
+    visitor.tryReplacePointer(child);
 }
 
 void InstrumentationNode::setColor(uint_color color)

--- a/src/vsg/state/ViewDependentState.cpp
+++ b/src/vsg/state/ViewDependentState.cpp
@@ -54,6 +54,21 @@ namespace vsg
         void traverse(Visitor& visitor) override { t_traverse(*this, visitor); }
         void traverse(ConstVisitor& visitor) const override { t_traverse(*this, visitor); }
         void traverse(RecordTraversal& visitor) const override { t_traverse(*this, visitor); }
+        void traverse(ReplacementVisitor& visitor) override
+        {
+            if (auto ref_node = node.ref_ptr())
+            {
+                std::optional<ref_ptr<Node>> newPtr = visitor.acceptChecked(*ref_node);
+                if (newPtr.has_value())
+                {
+                    node = newPtr.value();
+                }
+                // newPtr will go out of scope here, so if visitor doesn't keep the replacement alive by other means,
+                // e.g. a map from replaced objects to their replacements so the same replacement is returned when an
+                // object is visited via multiple paths in the scenegraph, then node will become stale and no longer
+                // be lockable.
+            }
+        }
     };
     VSG_type_name(TraverseChildrenOfNode);
 

--- a/src/vsg/utils/GraphicsPipelineConfigurator.cpp
+++ b/src/vsg/utils/GraphicsPipelineConfigurator.cpp
@@ -421,6 +421,14 @@ void GraphicsPipelineConfigurator::traverse(ConstVisitor& visitor) const
     if (descriptorConfigurator) descriptorConfigurator->accept(visitor);
 }
 
+void GraphicsPipelineConfigurator::traverse(ReplacementVisitor& visitor)
+{
+    for (auto& ps : pipelineStates) visitor.tryReplacePointer(ps);
+    if (shaderSet) visitor.tryReplacePointer(shaderSet);
+    if (shaderHints) visitor.tryReplacePointer(shaderHints);
+    if (descriptorConfigurator) visitor.tryReplacePointer(descriptorConfigurator);
+}
+
 void GraphicsPipelineConfigurator::reset()
 {
     pipelineStates.clear();

--- a/src/vsg/utils/SharedObjects.cpp
+++ b/src/vsg/utils/SharedObjects.cpp
@@ -214,6 +214,10 @@ void LoadedObject::traverse(ConstVisitor& visitor) const
 {
     if (object) object->accept(visitor);
 }
+void LoadedObject::traverse(ReplacementVisitor& visitor)
+{
+    if (object) visitor.tryReplacePointer(object);
+}
 
 int LoadedObject::compare(const Object& rhs_object) const
 {


### PR DESCRIPTION
# Pull Request Template

## Description

As discussed on a call last year, and alluded to in some PR/issue/discussion comments since, a `vsg::Visitor` can't replace objects in the scenegraph it operates on except by handling it at the level of their parent. If you know the structure of the data being operated on and either the object only makes sense in the context of its parent (e.g. swapping the vertex buffer of a `VertexIndexDraw`) or can limit the number of parent types to a feasible number (e.g. you know the node you want to swap out will always have a `StateGroup` as its parent), that's fine, but that's not always the case with real-world data.

An example use-case is the `IntersectionOptimizeVisitor` on my intersection optimisation branch that swaps out nodes for an optimised class which handles intersections faster (and passes other kinds of traversal onto the original node). At the moment, it explicitly handles `StateGroup` because that's the parent of the target nodes in the sample data I've got, but to work in the general case, it would need to explicitly handle every VSG node type that can have one or more children. With this PR applied, it can just handle the specific node types it targets and avoid needing to handle every possible parent. It would also make it easier to move the generated intersection proxy nodes higher in the scenegraph when only one node in a subgraph is intersectable.

I've implemented a slightly contrived but more obvious and straightforward example for the vsgExamples repo that illustrates how the new visitor type can be used and points out a gotcha I expect users of the class might run into. The PR for that is here: https://github.com/vsg-dev/vsgExamples/pull/392

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

So far, basically just the new vsgExample I made to demo the feature. I've not yet adapted the intersection optimisation branch to use it, as I thought it was a good idea to get more eyes on the implementation before marrying anything to it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
