### PR TITLE
Remove perspective divide for orthographic frustum

### DIFF
--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -223,6 +223,18 @@ namespace vsg
             value_type f = -proj[1][1];
             value_type sc = f * std::sqrt(square(mv[0][0]) + square(mv[1][0]) + square(mv[2][0]) + square(mv[0][1]) + square(mv[1][1]) + square(mv[2][1])) * 0.5;
             value_type inv_scale = value_type(1.0) / sc;
+
+            // For an orthographic projection the projected size of a bounding sphere is independent of
+            // its distance from the eye (proj[2][3] == 0: there is no perspective divide). Using the
+            // eye-space depth as done below for perspective would make LOD selection and small-feature
+            // culling vary with distance, which is wrong for ortho, so use a constant lod distance
+            // derived purely from the projection scale.
+            if (proj[2][3] == value_type(0.0))
+            {
+                lodScale.set(value_type(0.0), value_type(0.0), value_type(0.0), inv_scale);
+                return;
+            }
+
             lodScale.set(mv[0][2] * inv_scale,
                          mv[1][2] * inv_scale,
                          mv[2][2] * inv_scale,

--- a/include/vsg/vk/State.h
+++ b/include/vsg/vk/State.h
@@ -224,21 +224,19 @@ namespace vsg
             value_type sc = f * std::sqrt(square(mv[0][0]) + square(mv[1][0]) + square(mv[2][0]) + square(mv[0][1]) + square(mv[1][1]) + square(mv[2][1])) * 0.5;
             value_type inv_scale = value_type(1.0) / sc;
 
-            // For an orthographic projection the projected size of a bounding sphere is independent of
-            // its distance from the eye (proj[2][3] == 0: there is no perspective divide). Using the
-            // eye-space depth as done below for perspective would make LOD selection and small-feature
-            // culling vary with distance, which is wrong for ortho, so use a constant lod distance
-            // derived purely from the projection scale.
             if (proj[2][3] == value_type(0.0))
             {
+                // For an orthographic projection the projected size of a bounding sphere is independent of
+                // its distance from the eye (proj[2][3] == 0: there is no perspective divide). 
                 lodScale.set(value_type(0.0), value_type(0.0), value_type(0.0), inv_scale);
-                return;
             }
-
-            lodScale.set(mv[0][2] * inv_scale,
-                         mv[1][2] * inv_scale,
-                         mv[2][2] * inv_scale,
-                         mv[3][2] * inv_scale);
+            else
+            {
+                lodScale.set(mv[0][2] * inv_scale,
+                             mv[1][2] * inv_scale,
+                             mv[2][2] * inv_scale,
+                             mv[3][2] * inv_scale);
+            }
         }
 
         template<typename T>


### PR DESCRIPTION
Hi Robert,

I recently provided a feature in my application so the user can switch from perspective to orthographic projection. This used the vsg::Orthographic function as per the example vsgOrtho. I found the frustum clipping didn't work properly and neither did my SmallFeatureCullNode, which uses the same logic as RecordTraversal::apply(const LOD& lod).

Running 
./vsgortho ../../data/models/teapot.vsgt
looks OK if you just rotate it, but once you zoom in and out it doesn't clip properly anymore.

This PR applies a fix to Frustum::computeLodScale() that fixes my application and makes the vsgOrtho teapot clip as expected as well. The only changes are in the orthographic code path.

This is beyond my maths abilities and was suggested by Claude. The AI generated explanation is below:

> This PR fixes orthographic frustum/LOD behavior by removing perspective-depth dependence from LOD scaling when the projection is orthographic.  
> The previous LOD scale path always used eye-space Z terms, which is correct for perspective but incorrect for orthographic views.  
> In orthographic mode, projected size is depth-invariant, so LOD distance must not vary with object depth.  
> The change detects orthographic projection and uses a constant LOD scale term instead.  
> Perspective behavior is unchanged.
> 
> Detailed technical comment for discussion:
> 
> Problem statement:
> Orthographic camera setups could show incorrect culling/LOD transitions because LOD distance was computed with a depth-dependent scale model intended for perspective projection.
> 
> Why it happened:
> The LOD metric uses a 4-term dot product with a scale vector derived from model-view column-2 components. That makes distance vary with eye-space depth, which matches perspective projection semantics but conflicts with orthographic semantics.
> 
> Projection difference:
> Perspective projection uses a depth-coupled homogeneous transform and divide, so apparent size changes with depth.
> Orthographic projection is a parallel projection with no depth-driven perspective divide, so apparent size does not change with depth.
> 
> What this PR changes:
> When projection is orthographic, the LOD scale vector is set to a depth-invariant form with zero XYZ coefficients and a constant W term.
> This removes depth dependence from orthographic LOD distance while preserving the same normalization factor used by the existing code.
> The perspective path is left untouched.
> 
> Result:
> Orthographic clipping/LOD behavior is stable and no longer shifts with camera depth.
> Perspective behavior remains exactly as before.
> 
> 