### PR TITLE
fix layer offset calculation when uploading cubemaps with MipmapLayout

### DIFF
--- a/src/vsg/app/TransferTask.cpp
+++ b/src/vsg/app/TransferTask.cpp
@@ -681,15 +681,25 @@ void vsg::transferImageData(ref_ptr<ImageView> imageView, VkImageLayout targetIm
         {
             regions.resize(mipLevels * arrayLayers);
 
+            // mipmap.x/y/z are texel sizes. Compressed formats store whole blocks,
+            // so convert texel dimensions to block counts using integer ceil division.
+            auto ceilDiv = [](uint32_t value, uint32_t divisor) { return (value + divisor - 1) / divisor; };
+
             auto mipmapItr = mipmapData->begin();
             for (uint32_t mipLevel = 0; mipLevel < mipLevels; ++mipLevel)
             {
                 const auto& mipmap = (*mipmapItr++);
 
+                // faceSize = bytes per layer at this mip.
+                const size_t faceSize = static_cast<size_t>(valueSize) *
+                    ceilDiv(mipmap.x, properties.blockWidth) *
+                    ceilDiv(mipmap.y, properties.blockHeight) *
+                    ceilDiv(mipmap.z, properties.blockDepth);
+
                 for (uint32_t face = 0; face < arrayLayers; ++face)
                 {
                     auto& region = regions[mipLevel * arrayLayers + face];
-                    region.bufferOffset = stagingBufferOffset + mipmap.w;
+                    region.bufferOffset = stagingBufferOffset + mipmap.w + face * faceSize;
                     region.bufferRowLength = 0;
                     region.bufferImageHeight = 0;
                     region.imageSubresource.aspectMask = aspectMask;


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed per-layer buffer offsets when uploading images with MipmapLayout.

This fixes issue #1721

vsgExamples/[vsgskybox.cpp](https://github.com/vsg-dev/vsgExamples/blob/master/examples/app/vsgskybox/vsgskybox.cpp) renders skybox with incorrect faces.
<img width="1272" height="1044" alt="skybox bug" src="https://github.com/user-attachments/assets/141114f9-77b7-4caf-97cc-6152056473ec" />

So I used RenderDoc to capture frames and inspect the SkyBox textures. I found that when switching between the ±X/Y/Z faces, the displayed image content remained unchanged — in other words, all six faces were using the same texture. I traced the issue to an incorrect offset calculation in TransferTask.cpp.
<img width="772" height="400" alt="vsg skybox bug" src="https://github.com/user-attachments/assets/c0a3f938-5fec-4d74-b06d-1e16f68fe235" />

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test vsgExamples/vsgskybox.cpp

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
