### PR TITLE
Fix pool DeviceMemory allocations and rek

### DIFF
--- a/include/vsg/vk/MemoryBufferPools.h
+++ b/include/vsg/vk/MemoryBufferPools.h
@@ -58,6 +58,11 @@ namespace vsg
         VkResult reserve(const BufferInfoList& bufferInfoList, VkDeviceSize alignment, VkBufferUsageFlags bufferUsageFlags, VkSharingMode sharingMode, VkMemoryPropertyFlags memoryProperties);
         VkResult reserve(ResourceRequirements& requirements);
 
+        /// Release wholly unused Buffer and DeviceMemory pool entries, returning their memory to the driver.
+        /// Pools normally retain freed capacity for reuse, so call this on application memory pressure rather than routinely.
+        /// Returns the number of bytes of device memory released.
+        VkDeviceSize releaseUnusedPools();
+
         void report(LogOutput& out) const;
 
     protected:

--- a/src/vsg/state/Buffer.cpp
+++ b/src/vsg/state/Buffer.cpp
@@ -166,6 +166,11 @@ ref_ptr<Buffer> vsg::createBufferAndMemory(Device* device, VkDeviceSize size, Vk
         if (deviceMemoryBufferPools)
         {
             auto [memory, offset] = deviceMemoryBufferPools->reserveMemory(memRequirements, memoryProperties);
+            if (!memory)
+            {
+                warn("vsg::createBufferAndMemory(.., size = ", size, ", ..) failed to reserve DeviceMemory.");
+                return {};
+            }
 
             buffer->bind(memory, offset);
             return buffer;

--- a/src/vsg/vk/MemoryBufferPools.cpp
+++ b/src/vsg/vk/MemoryBufferPools.cpp
@@ -205,7 +205,12 @@ MemoryBufferPools::DeviceMemoryOffset MemoryBufferPools::reserveMemory(VkMemoryR
             if (deviceMemory)
             {
                 reservedSlot = deviceMemory->reserve(totalSize, alignment);
-                // if (!deviceMemory->full())
+
+                // Only blocks inflated beyond the request have spare capacity worth sharing. An
+                // exact fit block is wholly consumed by its one resource, so pooling it would just
+                // keep the memory alive after the resource is destroyed; leaving it out means the
+                // resource's own reference returns it to the driver.
+                if (poolRequirements.size > totalSize)
                 {
                     //debug("  inserting DeviceMemory into memoryPool ", deviceMemory.get());
                     memoryPools.push_back(deviceMemory);

--- a/src/vsg/vk/MemoryBufferPools.cpp
+++ b/src/vsg/vk/MemoryBufferPools.cpp
@@ -82,7 +82,7 @@ ref_ptr<BufferInfo> MemoryBufferPools::reserveBuffer(VkDeviceSize totalSize, VkD
         std::scoped_lock<std::mutex> lock(_mutex);
         for (auto& bufferFromPool : bufferPools)
         {
-            if (bufferFromPool->usage == bufferUsageFlags && bufferFromPool->size >= totalSize)
+            if (bufferFromPool->usage == bufferUsageFlags && bufferFromPool->size >= totalSize && bufferFromPool->maximumAvailableSpace() >= totalSize)
             {
                 MemorySlots::OptionalOffset reservedBufferSlot = bufferFromPool->reserve(totalSize, alignment);
                 if (reservedBufferSlot.first)
@@ -151,12 +151,20 @@ MemoryBufferPools::DeviceMemoryOffset MemoryBufferPools::reserveMemory(VkMemoryR
     ref_ptr<DeviceMemory> deviceMemory;
     MemorySlots::OptionalOffset reservedSlot(false, 0);
 
+    // Pools can hold linear buffers and optimal tiling images side by side, so every slot is aligned
+    // to bufferImageGranularity to satisfy the Vulkan granularity rule for adjacent resources.
+    const VkDeviceSize granularity = device->getPhysicalDevice()->getProperties().limits.bufferImageGranularity;
+    const VkDeviceSize alignment = std::max(memRequirements.alignment, granularity);
+
     for (auto& memoryPool : memoryPools)
     {
-        if (((memoryPool->getMemoryRequirements().memoryTypeBits & memRequirements.memoryTypeBits) == memRequirements.memoryTypeBits) &&
+        // memoryTypeBits and property flags equality guarantees the pool's chosen memory type index
+        // is also valid for the new resource.
+        if (memoryPool->getMemoryRequirements().memoryTypeBits == memRequirements.memoryTypeBits &&
+            memoryPool->getMemoryPropertyFlags() == memoryPropertiesFlags &&
             memoryPool->maximumAvailableSpace() >= totalSize)
         {
-            reservedSlot = memoryPool->reserve(totalSize, memRequirements.alignment);
+            reservedSlot = memoryPool->reserve(totalSize, alignment);
             if (reservedSlot.first)
             {
                 deviceMemory = memoryPool;
@@ -179,10 +187,15 @@ MemoryBufferPools::DeviceMemoryOffset MemoryBufferPools::reserveMemory(VkMemoryR
 
         if (deviceSize <= availableMemory)
         {
+            // Allocate a pool sized block so subsequent resources suballocate from it rather than
+            // each getting a dedicated vkAllocateMemory. Explicit dedicated allocations
+            // (pNextAllocInfo) must keep their exact size.
+            VkMemoryRequirements poolRequirements = memRequirements;
+            if (!pNextAllocInfo) poolRequirements.size = deviceSize;
 
             try
             {
-                deviceMemory = vsg::DeviceMemory::create(device, memRequirements, memoryPropertiesFlags, pNextAllocInfo);
+                deviceMemory = vsg::DeviceMemory::create(device, poolRequirements, memoryPropertiesFlags, pNextAllocInfo);
             }
             catch (...)
             {
@@ -191,7 +204,7 @@ MemoryBufferPools::DeviceMemoryOffset MemoryBufferPools::reserveMemory(VkMemoryR
 
             if (deviceMemory)
             {
-                reservedSlot = deviceMemory->reserve(totalSize);
+                reservedSlot = deviceMemory->reserve(totalSize, alignment);
                 // if (!deviceMemory->full())
                 {
                     //debug("  inserting DeviceMemory into memoryPool ", deviceMemory.get());

--- a/src/vsg/vk/MemoryBufferPools.cpp
+++ b/src/vsg/vk/MemoryBufferPools.cpp
@@ -349,6 +349,42 @@ VkResult MemoryBufferPools::reserve(ResourceRequirements& requirements)
     }
 }
 
+VkDeviceSize MemoryBufferPools::releaseUnusedPools()
+{
+    std::scoped_lock<std::mutex> lock(_mutex);
+
+    // release empty Buffers first so their DeviceMemory slots are returned before the memory pools are checked
+    for (auto itr = bufferPools.begin(); itr != bufferPools.end();)
+    {
+        auto& buffer = *itr;
+        if (buffer->totalReservedSize() == 0 && buffer->referenceCount() == 1)
+        {
+            itr = bufferPools.erase(itr);
+        }
+        else
+        {
+            ++itr;
+        }
+    }
+
+    VkDeviceSize totalReleased = 0;
+    for (auto itr = memoryPools.begin(); itr != memoryPools.end();)
+    {
+        auto& memoryPool = *itr;
+        if (memoryPool->totalReservedSize() == 0 && memoryPool->referenceCount() == 1)
+        {
+            totalReleased += memoryPool->totalMemorySize();
+            itr = memoryPools.erase(itr);
+        }
+        else
+        {
+            ++itr;
+        }
+    }
+
+    return totalReleased;
+}
+
 void MemoryBufferPools::report(LogOutput& out) const
 {
     out.enter("MemoryBufferPools::report(..)");


### PR DESCRIPTION
## Pool DeviceMemory allocations in MemoryBufferPools

### Problem

`MemoryBufferPools::reserveMemory()` computes a pool-sized `deviceSize` (floored at
`minimumDeviceMemorySize`, 16 MB) but never uses it — `DeviceMemory::create()` receives the
original `memRequirements`, so every image gets an exact-fit dedicated `vkAllocateMemory`.
In applications that page resources continuously (paged terrain databases), `memoryPools`
accumulates one entry per image and is never pruned. In our application (Spatial Integration)
a scene reached **23,000+ `DeviceMemory` entries** averaging ~57 KB:

- The linear `memoryPools` scan under the per-device mutex became the dominant cost of resource
  compilation: per-tile compile time grew from 156 ms at ~400 resident tiles to 2.5 s at ~1600,
  while data preparation stayed flat.
- The allocation count far exceeds `maxMemoryAllocationCount` (spec minimum 4096).
- Freed memory was never returned to the driver — footprint pinned at high-water mark.

### Changes

**Commit 1 — use `deviceSize` as intended** (`src/vsg/vk/MemoryBufferPools.cpp`):

- New `DeviceMemory` blocks are allocated at `deviceSize`, so subsequent resources suballocate
  from shared pools. Explicit dedicated allocations (`pNextAllocInfo`) keep their exact size.
- Since buffers and optimal-tiling images can now share a pool, every slot is aligned to
  `bufferImageGranularity`.
- Pool matching uses *equality* of `memoryTypeBits` and property flags — the previous superset
  test could select a pool whose chosen memory type index is invalid for the new resource.
- `reserveBuffer()` skips pool buffers whose `maximumAvailableSpace()` cannot fit the request,
  avoiding a futile walk of each fragmented buffer's slot map.

**Commit 2 — `MemoryBufferPools::releaseUnusedPools()`**: releases pool entries with no
reserved slots back to the driver and returns the bytes freed. Opt-in for applications to call
under memory pressure; no behavioral change otherwise.

### Results

Same scripted camera path, same resident tile count (~500), 6 DatabasePager threads:

|                                      | before          | after              |
| ------------------------------------ | --------------- | ------------------ |
| `DeviceMemory` allocations           | 23,285          | 96                 |
| per-tile compile median / p90 / max  | 27 / 49 / 205 ms | 2.7 / 5.4 / 6.0 ms |
| tiles compiled in same test time     | 12,966          | 17,996 (+39%)      |

Compile cost is now flat in residency instead of growing linearly.

targetMaxNumPagedLODWithHighResSubgraphs can now be set much higher without degradation (I'm defaulting to 4000).
 
Tested on Kubuntu 26.04 and Windows 11.
