### PR TITLE
Fix Descriptor count comparison when VkDescriptorSetLayoutBinding.descriptorCount is not 1

### DIFF
--- a/src/vsg/state/DescriptorSet.cpp
+++ b/src/vsg/state/DescriptorSet.cpp
@@ -76,9 +76,14 @@ void DescriptorSet::compile(Context& context)
             throw Exception{"Error: invalid DescriptorSet as no setLayout assigned.", VK_INCOMPLETE};
         }
 
-        if (setLayout->bindings.size() != descriptors.size())
+        size_t numDescriptors = 0;
+        for(auto& binding : setLayout->bindings)
         {
-            throw Exception{make_string("Error: invalid DescriptorSet as setLayout bindings size (", setLayout->bindings.size(), ") and descriptors size ", descriptors.size(), ") not equal."), VK_INCOMPLETE};
+            numDescriptors += binding.descriptorCount;
+        }
+        if (numDescriptors != descriptors.size())
+        {
+            throw Exception{make_string("Error: invalid DescriptorSet as setLayout bindings size (", numDescriptors, ") and descriptors size ", descriptors.size(), ") not equal."), VK_INCOMPLETE};
         }
 
         // make sure all the contributing objects are compiled


### PR DESCRIPTION
A VkDescriptorSetLayoutBinding can have multiple descriptors, so the descriptorCount needs to be taken account of when comparing to the size of vsg::Descriptors. Without this, valid texture arrays get rejected. 

The current code assumes that VkDescriptorSetLayoutBinding.descriptorCount is always 1.

This fix has been tested on Kubuntu and Windows 11 with AMD 9070XT.
